### PR TITLE
Add NIO write operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ supply the option `StandardOpenOption.READ`. All write operations on the channel
 which will be uploaded to S3 upon closing the channel.
 
 Be aware, that the current implementation only supports channels to be used either for read or write due to potential
-consistency issues we may face in some cases.
+consistency issues we may face in some cases. Attempting to open a channel for both read and write will result in an error.
 
 ### Configuration
 

--- a/README.md
+++ b/README.md
@@ -115,15 +115,31 @@ reduce the number of requests to the S3 service.
 
 Ensure sufficient memory is available to your JVM if you increase the fragment size or fragment number.
 
+## Writing Files
+
+The mode of the channel is controlled with the `StandardOpenOptions`. To open a channel for write access you need to 
+supply the option `StandardOpenOption.READ`. All write operations on the channel will be gathered in a temporary file,
+which will be uploaded to S3 upon closing the channel.
+
+Be aware, that the current implementation only supports channels to be used either for read or write due to potential
+consistency issues we may face in some cases.
+
+### Configuration
+
+The handling of large files could take potentially very long, therefore there are currently no timeouts configured per 
+default. However, you may configure timeouts via the `S3SeekableByteChannel`.
+
+#### Timeouts
+To configure timeouts for writing files or opening files for write access, you may use the `Long timeout` and 
+`TimeUnit timeUnit` parameters of the `S3SeekableByteChannel` constructor.
+```java
+new S3SeekableByteChannel(s3Path, s3Client, channelOpenOptions, timeout, timeUnit);
+```
+
 ## Design Decisions
 
 As an object store, S3 is not completely analogous to a traditional file system. Therefore, several opinionated decisions
 were made to map filesystem concepts to S3 concepts.
-
-### Read Only
-
-The current implementation only supports read operations. It would be possible to add write operations, however special consideration
-would be needed due to the lack of support for random writes in S3 and the read-after-write consistency of S3 objects.
 
 ### A Bucket is a `FileSystem`
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ consistency issues we may face in some cases. Attempting to open a channel for b
 
 ### Configuration
 
-The handling of large files could take potentially very long, therefore there are currently no timeouts configured per 
+Because we cannot predict the time it would take to write files, there are currently no timeouts configured per 
 default. However, you may configure timeouts via the `S3SeekableByteChannel`.
 
 #### Timeouts

--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ dependencies {
 
     implementation 'software.amazon.awssdk:s3'
     implementation 'software.amazon.awssdk:s3-transfer-manager:2.19.26'
+    implementation 'software.amazon.awssdk.crt:aws-crt:0.21.7'
     implementation 'org.slf4j:slf4j-api:1.7.36'
     implementation 'ch.qos.logback:logback-classic:1.2.10'
     implementation 'ch.qos.logback:logback-core:1.2.10'

--- a/build.gradle
+++ b/build.gradle
@@ -44,9 +44,10 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:4.3.1'
 
-    implementation platform('software.amazon.awssdk:bom:2.17.285')
+    implementation platform('software.amazon.awssdk:bom:2.19.26')
 
     implementation 'software.amazon.awssdk:s3'
+    implementation 'software.amazon.awssdk:s3-transfer-manager:2.19.26'
     implementation 'org.slf4j:slf4j-api:1.7.36'
     implementation 'ch.qos.logback:logback-classic:1.2.10'
     implementation 'ch.qos.logback:logback-core:1.2.10'
@@ -65,7 +66,7 @@ publishing {
                         'access to S3 objects for Java applications using Java NIO.2 for file access.'
                 url = 'https://github.com/awslabs/aws-java-nio-spi-for-s3'
                 inceptionYear = '2022'
-                scm{
+                scm {
                     url = 'https://github.com/awslabs/aws-java-nio-spi-for-s3/tree/main'
                     connection = 'scm:git:ssh://git@github.com/awslabs/aws-java-nio-spi-for-s3.git'
                     developerConnection = 'scm:git:ssh://git@github.com/awslabs/aws-java-nio-spi-for-s3.git'
@@ -90,7 +91,7 @@ publishing {
         }
     }
     repositories {
-        maven{
+        maven {
             def releasesRepoUrl = 'https://aws.oss.sonatype.org/service/local/staging/deploy/maven2/'
             def snapshotsRepoUrl = 'https://aws.oss.sonatype.org/content/repositories/snapshots'
             url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
@@ -104,7 +105,7 @@ signing {
 }
 
 javadoc {
-    if(JavaVersion.current().isJava9Compatible()) {
+    if (JavaVersion.current().isJava9Compatible()) {
         options.addBooleanOption('html5', true)
     }
 }

--- a/src/main/java/software/amazon/nio/spi/s3/S3ClientStore.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3ClientStore.java
@@ -260,11 +260,8 @@ public class S3ClientStore {
         Region region = regionString.equals("") ? Region.US_EAST_1 : Region.of(regionString);
         logger.debug("bucket region is: '{}'", region.id());
 
-        return S3AsyncClient.builder()
+        return S3AsyncClient.crtBuilder()
                 .region(region)
-                .overrideConfiguration(conf -> conf.retryPolicy(builder -> builder
-                        .retryCondition(retryCondition)
-                        .backoffStrategy(backoffStrategy)))
                 .build();
     }
 

--- a/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
@@ -53,8 +53,6 @@ public class S3FileSystemProvider extends FileSystemProvider {
      */
     public static final String SCHEME = "s3";
 
-    private static final Long MULTIPART_UPLOAD_THRESHOLD = 1024L * 500; // 500 MB
-
     private final Logger logger = LoggerFactory.getLogger(this.getClass().getName());
 
 

--- a/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
@@ -665,10 +665,6 @@ public class S3FileSystemProvider extends FileSystemProvider {
      * Composable and testable version of {@code checkAccess} that uses the provided client to check access
      */
     protected void checkAccess(S3AsyncClient s3Client, Path path, AccessMode... modes) throws IOException, ExecutionException, InterruptedException {
-        if (Arrays.asList(modes).contains(AccessMode.WRITE)) {
-            throw new UnsupportedOperationException("WRITE is not currently supported. Please raise a feature request if you want this.");
-        }
-
         assert path instanceof S3Path;
         S3Path s3Path = (S3Path) path.toRealPath(NOFOLLOW_LINKS);
         final String bucketName = s3Path.getFileSystem().bucketName();

--- a/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
@@ -477,11 +477,11 @@ public class S3FileSystemProvider extends FileSystemProvider {
 
             for (List<ObjectIdentifier> keyList : keys) {
                 for (ObjectIdentifier objectIdentifier : keyList) {
-                    if (!copyOptions.contains(StandardCopyOption.REPLACE_EXISTING) && exists(s3Client, s3TargetPath)) {
+                    S3Path resolvedS3TargetPath = s3TargetPath.resolve(objectIdentifier.key().replaceFirst(prefix + S3Path.PATH_SEPARATOR, ""));
+
+                    if (!copyOptions.contains(StandardCopyOption.REPLACE_EXISTING) && exists(s3Client, resolvedS3TargetPath)) {
                         throw new FileAlreadyExistsException("File already exists at the target key");
                     }
-
-                    S3Path resolvedS3TargetPath = s3TargetPath.resolve(objectIdentifier.key().replaceFirst(prefix + S3Path.PATH_SEPARATOR, ""));
 
                     try (S3TransferManager s3TransferManager = S3TransferManager.builder().s3Client(s3Client).build()) {
                         s3TransferManager.copy(CopyRequest.builder()
@@ -508,8 +508,8 @@ public class S3FileSystemProvider extends FileSystemProvider {
             return true;
         } catch (ExecutionException e) {
             logger.debug("Could not retrieve object head information", e);
+            return false;
         }
-        return false;
     }
 
     /**

--- a/src/main/java/software/amazon/nio/spi/s3/S3WritableByteChannel.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3WritableByteChannel.java
@@ -36,7 +36,7 @@ public class S3WritableByteChannel implements WritableByteChannel {
                 throw new FileAlreadyExistsException("File at path:" + path + " already exists");
             }
             if (!exists && !options.contains(StandardOpenOption.CREATE_NEW) && !options.contains(StandardOpenOption.CREATE)) {
-                throw new NoSuchFileException("File at path:" + path + " does exist yet");
+                throw new NoSuchFileException("File at path:" + path + " does not exist yet");
             }
 
             tempFile = Files.createTempFile("aws-s3-nio-", ".tmp");

--- a/src/main/java/software/amazon/nio/spi/s3/S3WritableByteChannel.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3WritableByteChannel.java
@@ -1,0 +1,98 @@
+package software.amazon.nio.spi.s3;
+
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.transfer.s3.S3TransferManager;
+import software.amazon.awssdk.transfer.s3.model.DownloadFileRequest;
+import software.amazon.awssdk.transfer.s3.model.UploadFileRequest;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.channels.WritableByteChannel;
+import java.nio.file.*;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.TimeoutException;
+
+public class S3WritableByteChannel implements WritableByteChannel {
+    private final S3AsyncClient client;
+    private final S3Path path;
+    private final Path tempFile;
+    private final SeekableByteChannel channel;
+
+    private boolean open;
+
+    public S3WritableByteChannel(S3Path path, S3AsyncClient client, Set<? extends OpenOption> options) throws IOException {
+        Objects.requireNonNull(path);
+        Objects.requireNonNull(client);
+
+        try {
+            S3FileSystemProvider fileSystemProvider = (S3FileSystemProvider) path.getFileSystem().provider();
+            boolean exists = fileSystemProvider.exists(client, path);
+
+            if (exists && options.contains(StandardOpenOption.CREATE_NEW)) {
+                throw new FileAlreadyExistsException("File at path:" + path + " already exists");
+            }
+            if (!exists && !options.contains(StandardOpenOption.CREATE_NEW) && !options.contains(StandardOpenOption.CREATE)) {
+                throw new NoSuchFileException("File at path:" + path + " does exist yet");
+            }
+
+            tempFile = Files.createTempFile("aws-s3-nio-", ".tmp");
+            if (exists) {
+                try (S3TransferManager s3TransferManager = S3TransferManager.builder().s3Client(client).build()) {
+                    s3TransferManager.downloadFile(
+                            DownloadFileRequest.builder()
+                                    .getObjectRequest(GetObjectRequest.builder()
+                                            .bucket(path.bucketName())
+                                            .key(path.getKey())
+                                            .build())
+                                    .destination(tempFile)
+                                    .build()
+                    ).completionFuture().join();
+                }
+            }
+
+            options.remove(StandardOpenOption.CREATE_NEW);
+            channel = Files.newByteChannel(this.tempFile, options);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Could not open the path:" + path, e);
+        } catch (TimeoutException e) {
+            throw new IOException("Could not open the path:" + path, e);
+        }
+
+        this.client = client;
+        this.path = path;
+        this.open = true;
+    }
+
+    @Override
+    public int write(ByteBuffer src) throws IOException {
+        return channel.write(src);
+    }
+
+    @Override
+    public boolean isOpen() {
+        return open;
+    }
+
+    @Override
+    public void close() throws IOException {
+        channel.close();
+
+        try (S3TransferManager s3TransferManager = S3TransferManager.builder().s3Client(client).build()) {
+            s3TransferManager.uploadFile(
+                    UploadFileRequest.builder()
+                            .putObjectRequest(PutObjectRequest.builder()
+                                    .bucket(path.bucketName())
+                                    .key(path.getKey())
+                                    .build())
+                            .source(tempFile)
+                            .build()
+            ).completionFuture().join();
+        }
+        open = false;
+    }
+}

--- a/src/main/java/software/amazon/nio/spi/s3/S3WritableByteChannel.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3WritableByteChannel.java
@@ -4,6 +4,8 @@ import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.transfer.s3.S3TransferManager;
+import software.amazon.awssdk.transfer.s3.model.CompletedFileDownload;
+import software.amazon.awssdk.transfer.s3.model.CompletedFileUpload;
 import software.amazon.awssdk.transfer.s3.model.DownloadFileRequest;
 import software.amazon.awssdk.transfer.s3.model.UploadFileRequest;
 
@@ -14,6 +16,9 @@ import java.nio.channels.WritableByteChannel;
 import java.nio.file.*;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 public class S3WritableByteChannel implements WritableByteChannel {
@@ -21,12 +26,21 @@ public class S3WritableByteChannel implements WritableByteChannel {
     private final S3Path path;
     private final Path tempFile;
     private final SeekableByteChannel channel;
+    private final Long timeout;
+    private final TimeUnit timeUnit;
 
     private boolean open;
 
+
     public S3WritableByteChannel(S3Path path, S3AsyncClient client, Set<? extends OpenOption> options) throws IOException {
+        this(path, client, options, null, null);
+    }
+
+    public S3WritableByteChannel(S3Path path, S3AsyncClient client, Set<? extends OpenOption> options, Long timeout, TimeUnit timeUnit) throws IOException {
         Objects.requireNonNull(path);
         Objects.requireNonNull(client);
+        this.timeout = timeout;
+        this.timeUnit = timeUnit;
 
         try {
             S3FileSystemProvider fileSystemProvider = (S3FileSystemProvider) path.getFileSystem().provider();
@@ -42,7 +56,7 @@ public class S3WritableByteChannel implements WritableByteChannel {
             tempFile = Files.createTempFile("aws-s3-nio-", ".tmp");
             if (exists) {
                 try (S3TransferManager s3TransferManager = S3TransferManager.builder().s3Client(client).build()) {
-                    s3TransferManager.downloadFile(
+                    CompletableFuture<CompletedFileDownload> downloadCompletableFuture = s3TransferManager.downloadFile(
                             DownloadFileRequest.builder()
                                     .getObjectRequest(GetObjectRequest.builder()
                                             .bucket(path.bucketName())
@@ -50,7 +64,13 @@ public class S3WritableByteChannel implements WritableByteChannel {
                                             .build())
                                     .destination(tempFile)
                                     .build()
-                    ).completionFuture().join();
+                    ).completionFuture();
+
+                    if (timeout != null && timeUnit != null) {
+                        downloadCompletableFuture.get(timeout, timeUnit);
+                    } else {
+                        downloadCompletableFuture.join();
+                    }
                 }
             }
 
@@ -59,7 +79,7 @@ public class S3WritableByteChannel implements WritableByteChannel {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new IOException("Could not open the path:" + path, e);
-        } catch (TimeoutException e) {
+        } catch (TimeoutException | ExecutionException e) {
             throw new IOException("Could not open the path:" + path, e);
         }
 
@@ -83,7 +103,7 @@ public class S3WritableByteChannel implements WritableByteChannel {
         channel.close();
 
         try (S3TransferManager s3TransferManager = S3TransferManager.builder().s3Client(client).build()) {
-            s3TransferManager.uploadFile(
+            CompletableFuture<CompletedFileUpload> uploadCompletableFuture = s3TransferManager.uploadFile(
                     UploadFileRequest.builder()
                             .putObjectRequest(PutObjectRequest.builder()
                                     .bucket(path.bucketName())
@@ -91,7 +111,18 @@ public class S3WritableByteChannel implements WritableByteChannel {
                                     .build())
                             .source(tempFile)
                             .build()
-            ).completionFuture().join();
+            ).completionFuture();
+
+            if (timeout != null && timeUnit != null) {
+                uploadCompletableFuture.get(timeout, timeUnit);
+            } else {
+                uploadCompletableFuture.join();
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Could not write to path:" + path, e);
+        } catch (TimeoutException | ExecutionException e) {
+            throw new IOException("Could not write to path:" + path, e);
         }
         open = false;
     }

--- a/src/test/java/software/amazon/nio/spi/s3/S3FileSystemProviderTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3FileSystemProviderTest.java
@@ -81,7 +81,7 @@ public class S3FileSystemProviderTest {
 
     @Test
     public void newByteChannel() throws IOException {
-        final SeekableByteChannel channel = provider.newByteChannel(mockClient, Paths.get(URI.create(pathUri)), Collections.emptySet());
+        final SeekableByteChannel channel = provider.newByteChannel(mockClient, Paths.get(URI.create(pathUri)), Collections.singleton(StandardOpenOption.READ));
         assertNotNull(channel);
         assertTrue(channel instanceof S3SeekableByteChannel);
     }

--- a/src/test/java/software/amazon/nio/spi/s3/S3FileSystemProviderTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3FileSystemProviderTest.java
@@ -281,9 +281,13 @@ public class S3FileSystemProviderTest {
         provider.checkAccess(mockClient, foo);
     }
 
-    @Test(expected = UnsupportedOperationException.class) // TODO
-    public void checkWriteAccess() throws IOException {
-        provider.checkAccess(fs.getPath("foo"), AccessMode.WRITE);
+    @Test
+    public void checkWriteAccess() throws IOException, ExecutionException, InterruptedException {
+        when(mockClient.headObject(any(Consumer.class))).thenReturn(CompletableFuture.supplyAsync(() ->
+                HeadObjectResponse.builder()
+                        .sdkHttpResponse(SdkHttpResponse.builder().statusCode(200).build())
+                        .build()));
+        provider.checkAccess(mockClient, fs.getPath("foo"), AccessMode.WRITE);
     }
 
     @Test

--- a/src/test/java/software/amazon/nio/spi/s3/S3FileSystemTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3FileSystemTest.java
@@ -11,9 +11,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.FileSystems;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Collections;
 
 import static org.junit.Assert.*;
@@ -37,7 +35,7 @@ public class S3FileSystemTest {
 
 
     @Test
-    public void close() throws IOException{
+    public void close() throws IOException {
         assertEquals(0, s3FileSystem.getOpenChannels().size());
         s3FileSystem.close();
         assertFalse("File system should return false from isOpen when closed has been called", s3FileSystem.isOpen());
@@ -89,8 +87,9 @@ public class S3FileSystemTest {
     }
 
 
-    @Test(expected = UnsupportedOperationException.class) //thrown because cannot be modified
-    public void testGetOpenChannelsIsNotModifiable() throws IOException {
-        s3FileSystem.getOpenChannels().add(Files.newByteChannel(Paths.get(".")));
+    @Test(expected = UnsupportedOperationException.class)
+    //thrown because cannot be modified
+    public void testGetOpenChannelsIsNotModifiable() {
+        s3FileSystem.getOpenChannels().add(null);
     }
 }

--- a/src/test/java/software/amazon/nio/spi/s3/S3ReadAheadByteChannelTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3ReadAheadByteChannelTest.java
@@ -51,7 +51,7 @@ public class S3ReadAheadByteChannelTest {
         final ResponseBytes<GetObjectResponse> bytes2 = ResponseBytes.fromByteArray(response, "ABCDEFGHIJKLMNOPQRSTUVWXYZ".getBytes(StandardCharsets.UTF_8));
         when(client.getObject(any(Consumer.class), any(ByteArrayAsyncResponseTransformer.class))).thenReturn(CompletableFuture.supplyAsync(() -> bytes1), CompletableFuture.supplyAsync(() -> bytes2));
 
-        readAheadByteChannel = new S3ReadAheadByteChannel(path, 26, 2, client, delegator);
+        readAheadByteChannel = new S3ReadAheadByteChannel(path, 26, 2, client, delegator, null, null);
     }
 
     @Test
@@ -123,7 +123,7 @@ public class S3ReadAheadByteChannelTest {
     }
 
     @Test
-    public void shouldSignalFinished() throws IOException{
+    public void shouldSignalFinished() throws IOException {
         when(delegator.position()).thenReturn(52L);
         ByteBuffer dst = ByteBuffer.allocate(6);
 
@@ -147,7 +147,7 @@ public class S3ReadAheadByteChannelTest {
     }
 
     @Test
-    public void fragmentIndexForByteNumber(){
+    public void fragmentIndexForByteNumber() {
         assertEquals(Integer.valueOf(0), readAheadByteChannel.fragmentIndexForByteNumber(0L));
         assertEquals(Integer.valueOf(1), readAheadByteChannel.fragmentIndexForByteNumber(26L));
     }

--- a/src/test/java/software/amazon/nio/spi/s3/S3SeekableByteChannelTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3SeekableByteChannelTest.java
@@ -24,6 +24,7 @@ import java.nio.file.StandardOpenOption;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.any;
@@ -42,8 +43,11 @@ public class S3SeekableByteChannelTest {
 
     @Before
     public void init() {
+        // forward to the method that uses the HeadObjectRequest parameter
+        when(mockClient.headObject(any(Consumer.class))).thenCallRealMethod();
         when(mockClient.headObject(any(HeadObjectRequest.class))).thenReturn(
                 CompletableFuture.supplyAsync(() -> HeadObjectResponse.builder().contentLength(100L).build()));
+        when(mockClient.getObject(any(Consumer.class), any(AsyncResponseTransformer.class))).thenCallRealMethod();
         when(mockClient.getObject(any(GetObjectRequest.class), any(AsyncResponseTransformer.class))).thenReturn(
                 CompletableFuture.supplyAsync(() -> ResponseBytes.fromByteArray(
                         GetObjectResponse.builder().contentLength(6L).build(),

--- a/src/test/java/software/amazon/nio/spi/s3/S3SeekableByteChannelTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3SeekableByteChannelTest.java
@@ -11,16 +11,19 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
-import software.amazon.awssdk.services.s3.model.GetObjectResponse;
-import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.*;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.OpenOption;
+import java.nio.file.StandardOpenOption;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Consumer;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.any;
@@ -31,7 +34,6 @@ import static org.mockito.Mockito.when;
 public class S3SeekableByteChannelTest {
 
     S3FileSystem fs;
-    S3SeekableByteChannel channel;
     S3Path path;
     byte[] bytes = "abcdef".getBytes(StandardCharsets.UTF_8);
 
@@ -39,61 +41,74 @@ public class S3SeekableByteChannelTest {
     S3AsyncClient mockClient;
 
     @Before
-    public void init() throws IOException {
-
-        when(mockClient.headObject(any(Consumer.class))).thenReturn(
+    public void init() {
+        when(mockClient.headObject(any(HeadObjectRequest.class))).thenReturn(
                 CompletableFuture.supplyAsync(() -> HeadObjectResponse.builder().contentLength(100L).build()));
-        when(mockClient.getObject(any(Consumer.class), any(AsyncResponseTransformer.class))).thenReturn(
+        when(mockClient.getObject(any(GetObjectRequest.class), any(AsyncResponseTransformer.class))).thenReturn(
                 CompletableFuture.supplyAsync(() -> ResponseBytes.fromByteArray(
                         GetObjectResponse.builder().contentLength(6L).build(),
                         bytes)));
 
         fs = new S3FileSystem("test-bucket");
         path = fs.getPath("/object");
-        channel = new S3SeekableByteChannel(path, mockClient, 0L);
     }
 
     @Test
-    public void read() throws IOException{
+    public void read() throws IOException {
+        S3SeekableByteChannel channel = new S3SeekableByteChannel(path, mockClient);
         ByteBuffer dst = ByteBuffer.allocate(6);
         channel.read(dst);
         assertArrayEquals(bytes, dst.array());
         assertEquals(6L, channel.position());
     }
 
-    @Test(expected = UnsupportedOperationException.class)
-    public void write() {
+    @Test
+    public void write() throws IOException {
+        when(mockClient.headObject(any(HeadObjectRequest.class))).thenThrow(NoSuchKeyException.class);
+        when(mockClient.putObject(any(PutObjectRequest.class), any(AsyncRequestBody.class))).thenReturn(CompletableFuture.supplyAsync(() ->
+                PutObjectResponse.builder().build()));
+        Set<OpenOption> options = new HashSet<>();
+        options.add(StandardOpenOption.CREATE);
+        options.add(StandardOpenOption.WRITE);
+        S3SeekableByteChannel channel = new S3SeekableByteChannel(path, mockClient, options);
         channel.write(ByteBuffer.allocate(1));
+        channel.close();
     }
 
     @Test
-    public void position() {
+    public void position() throws IOException {
+        S3SeekableByteChannel channel = new S3SeekableByteChannel(path, mockClient);
         assertEquals(0L, channel.position());
     }
 
     @Test
     public void testPosition() throws IOException {
+        S3SeekableByteChannel channel = new S3SeekableByteChannel(path, mockClient);
         channel.position(1L);
         assertEquals(1L, channel.position());
     }
 
     @Test
     public void size() throws IOException {
+        S3SeekableByteChannel channel = new S3SeekableByteChannel(path, mockClient);
         assertEquals(100L, channel.size());
     }
 
     @Test(expected = UnsupportedOperationException.class)
-    public void truncate() {
+    public void truncate() throws IOException {
+        S3SeekableByteChannel channel = new S3SeekableByteChannel(path, mockClient);
         channel.truncate(0L);
     }
 
     @Test
-    public void isOpen() {
+    public void isOpen() throws IOException {
+        S3SeekableByteChannel channel = new S3SeekableByteChannel(path, mockClient);
         assertTrue(channel.isOpen());
     }
 
     @Test
-    public void close() throws IOException{
+    public void close() throws IOException {
+        S3SeekableByteChannel channel = new S3SeekableByteChannel(path, mockClient);
         channel.close();
         assertFalse(channel.isOpen());
     }


### PR DESCRIPTION
**Ticket:** https://github.com/awslabs/aws-java-nio-spi-for-s3/issues/4

*Description of changes:*
* This adds the NIO FileSystemProvider methods as well as a implementation of a writable channel
* With this pr the async s3 client is using now the s3 transfer manager and therefore the crt builder


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
