### PR TITLE
Adding a S3ClientProvider who generates the clients... (Issue #30)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     // Use JUnit test framework.
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:5.3.1'
+    testImplementation 'com.github.stefanbirkner:system-rules:1.19.0'
 
     implementation platform('software.amazon.awssdk:bom:2.20.79')
 

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     // Use JUnit test framework.
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:5.3.1'
-    testImplementation 'com.github.stefanbirkner:system-rules:1.19.0'
+    testImplementation 'com.github.stefanbirkner:system-lambda:1.2.1'
 
     implementation platform('software.amazon.awssdk:bom:2.20.79')
 

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,8 @@ dependencies {
     // Use JUnit test framework.
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:5.3.1'
+    // todo: to be removed
+    testImplementation 'com.github.stefanbirkner:system-rules:1.19.0'
     testImplementation 'com.github.stefanbirkner:system-lambda:1.2.1'
 
     implementation platform('software.amazon.awssdk:bom:2.20.79')

--- a/src/main/java/software/amazon/nio/spi/s3/S3BasicFileAttributes.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3BasicFileAttributes.java
@@ -47,7 +47,7 @@ public class S3BasicFileAttributes implements BasicFileAttributes {
      * @param path the path to represent the attributes of
      */
     protected S3BasicFileAttributes(S3Path path){
-        this(path, S3ClientStore.getInstance().getAsyncClientForBucketName(path.bucketName()));
+        this(path, path.getFileSystem().client());
     }
 
     /**

--- a/src/main/java/software/amazon/nio/spi/s3/S3ClientProvider.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3ClientProvider.java
@@ -82,7 +82,7 @@ public class S3ClientProvider {
         );
     }
 
-    Logger logger = LoggerFactory.getLogger("S3ClientStore");
+    Logger logger = LoggerFactory.getLogger("S3ClientStoreProvider");
 
 
     /**

--- a/src/main/java/software/amazon/nio/spi/s3/S3ClientProvider.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3ClientProvider.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.nio.spi.s3;
+
+import java.io.IOException;
+import java.net.URI;
+import java.time.Duration;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.awscore.AwsClient;
+import software.amazon.awssdk.core.exception.ApiCallAttemptTimeoutException;
+import software.amazon.awssdk.core.exception.ApiCallTimeoutException;
+import software.amazon.awssdk.core.exception.RetryableException;
+import software.amazon.awssdk.core.retry.backoff.EqualJitterBackoffStrategy;
+import software.amazon.awssdk.core.retry.conditions.OrRetryCondition;
+import software.amazon.awssdk.core.retry.conditions.RetryCondition;
+import software.amazon.awssdk.core.retry.conditions.RetryOnClockSkewCondition;
+import software.amazon.awssdk.core.retry.conditions.RetryOnExceptionsCondition;
+import software.amazon.awssdk.core.retry.conditions.RetryOnStatusCodeCondition;
+import software.amazon.awssdk.core.retry.conditions.RetryOnThrottlingCondition;
+import software.amazon.awssdk.http.HttpStatusCode;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.HeadBucketResponse;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+/**
+ *
+ */
+public class S3ClientProvider {
+
+    /**
+     * Default client using the "https://s3.us-east-1.amazonaws.com" endpoint
+     */
+    private static final S3Client DEFAULT_CLIENT = S3Client.builder()
+            .endpointOverride(URI.create("https://s3.us-east-1.amazonaws.com"))
+            .region(Region.US_EAST_1)
+            .build();
+
+    /**
+     * Default asynchronous client using the "https://s3.us-east-1.amazonaws.com" endpoint
+     */
+    private static final S3AsyncClient DEFAULT_ASYNC_CLIENT = S3AsyncClient.builder()
+            .endpointOverride(URI.create("https://s3.us-east-1.amazonaws.com"))
+            .region(Region.US_EAST_1)
+            .build();
+
+        private final EqualJitterBackoffStrategy backoffStrategy = EqualJitterBackoffStrategy.builder()
+            .baseDelay(Duration.ofMillis(200L))
+            .maxBackoffTime(Duration.ofSeconds(5L))
+            .build();
+
+    final RetryCondition retryCondition;
+
+    {
+        final Set<Integer> RETRYABLE_STATUS_CODES = Stream.of(
+                HttpStatusCode.INTERNAL_SERVER_ERROR,
+                HttpStatusCode.BAD_GATEWAY,
+                HttpStatusCode.SERVICE_UNAVAILABLE,
+                HttpStatusCode.GATEWAY_TIMEOUT
+        ).collect(Collectors.toSet());
+
+        final Set<Class<? extends Exception>> RETRYABLE_EXCEPTIONS = Stream.of(
+                RetryableException.class,
+                IOException.class,
+                ApiCallAttemptTimeoutException.class,
+                ApiCallTimeoutException.class).collect(Collectors.toSet());
+
+        retryCondition = OrRetryCondition.create(
+                RetryOnStatusCodeCondition.create(RETRYABLE_STATUS_CODES),
+                RetryOnExceptionsCondition.create(RETRYABLE_EXCEPTIONS),
+                RetryOnClockSkewCondition.create(),
+                RetryOnThrottlingCondition.create()
+        );
+    }
+
+    Logger logger = LoggerFactory.getLogger("S3ClientStore");
+
+
+    /**
+     * This method returns a universal client (i.e. not bound to any region)
+     * that can be used by certain S3 operations for discovery.
+     * This is the same as universalClient(false);
+     *
+     * @return a S3Client not bound to a region
+     */
+    public S3Client universalClient() {
+        return universalClient(false);
+    }
+
+    /**
+     * This method returns a universal client (i.e.not bound to any region)
+     * that can be used by certain S3 operations for discovery
+     *
+     * @param async true to return an asynchronous client, false otherwise
+     * @return a S3Client not bound to a region
+     */
+    public <T extends AwsClient> T universalClient(boolean async) {
+        return (T)((async) ? DEFAULT_ASYNC_CLIENT : DEFAULT_CLIENT);
+    }
+
+    /**
+     * Generate a client for the named bucket using a default client to determine the location of the named bucket
+     * @param bucketName the named of the bucket to make the client for
+     * @return an S3 client appropriate for the region of the named bucket
+     */
+    protected S3Client generateClient(String bucketName){
+        return this.generateClient(bucketName, universalClient());
+    }
+
+    /**
+     * Generate an asynchronous client for the named bucket using a default client to determine the location of the named bucket
+     * @param bucketName the named of the bucket to make the client for
+     * @return an asynchronous S3 client appropriate for the region of the named bucket
+     */
+    protected S3AsyncClient generateAsyncClient(String bucketName){
+        return this.generateAsyncClient(bucketName, universalClient());
+    }
+
+    /**
+     * Generate a client for the named bucket using a default client to determine the location of the named client
+     * @param bucketName the named of the bucket to make the client for
+     * @param locationClient the client used to determine the location of the named bucket, recommend using DEFAULT_CLIENT
+     * @return an S3 client appropriate for the region of the named bucket
+     */
+    protected S3Client generateClient (String bucketName, S3Client locationClient) {
+        logger.debug("generating client for bucket: '{}'", bucketName);
+        S3Client bucketSpecificClient;
+        try {
+            logger.debug("determining bucket location with getBucketLocation");
+            String bucketLocation = locationClient.getBucketLocation(builder -> builder.bucket(bucketName)).locationConstraintAsString();
+
+            bucketSpecificClient = this.clientForRegion(bucketLocation);
+
+        } catch (S3Exception e) {
+            if(e.statusCode() == 403) {
+                logger.debug("Cannot determine location of '{}' bucket directly. Attempting to obtain bucket location with headBucket operation", bucketName);
+                try {
+                    final HeadBucketResponse headBucketResponse = locationClient.headBucket(builder -> builder.bucket(bucketName));
+                    bucketSpecificClient = this.clientForRegion(headBucketResponse.
+                            sdkHttpResponse()
+                            .firstMatchingHeader("x-amz-bucket-region")
+                            .orElseThrow(() -> new NoSuchElementException("Head Bucket Response doesn't include the header 'x-amz-bucket-region'")));
+                } catch (S3Exception e2) {
+                    if (e2.statusCode() == 301) {
+                        bucketSpecificClient = this.clientForRegion(e2.awsErrorDetails().
+                                sdkHttpResponse()
+                                .firstMatchingHeader("x-amz-bucket-region")
+                                .orElseThrow(() -> new NoSuchElementException("Head Bucket Response doesn't include the header 'x-amz-bucket-region'")));
+                    } else {
+                        throw e2;
+                    }
+                }
+            } else {
+                throw e;
+            }
+        }
+
+        if (bucketSpecificClient == null) {
+            logger.warn("Unable to determine the region of bucket: '{}'. Generating a client for the profile region.", bucketName);
+            bucketSpecificClient = S3Client.builder()
+                    .overrideConfiguration(conf -> conf.retryPolicy(builder -> builder
+                        .retryCondition(retryCondition)
+                        .backoffStrategy(backoffStrategy)))
+                    .build();
+        }
+
+        return bucketSpecificClient;
+    }
+
+    /**
+     * Generate an asynchronous client for the named bucket using a default client to determine the location of the named client
+     * @param bucketName the named of the bucket to make the client for
+     * @param locationClient the client used to determine the location of the named bucket, recommend using DEFAULT_CLIENT
+     * @return an S3 client appropriate for the region of the named bucket
+     */
+    protected S3AsyncClient generateAsyncClient (String bucketName, S3Client locationClient) {
+        logger.debug("generating asynchronous client for bucket: '{}'", bucketName);
+        S3AsyncClient bucketSpecificClient;
+        try {
+            logger.debug("determining bucket location with getBucketLocation");
+            String bucketLocation = locationClient.getBucketLocation(builder -> builder.bucket(bucketName)).locationConstraintAsString();
+
+            bucketSpecificClient = this.asyncClientForRegion(bucketLocation);
+
+        } catch (S3Exception e) {
+            if(e.statusCode() == 403) {
+                logger.debug("Cannot determine location of '{}' bucket directly. Attempting to obtain bucket location with headBucket operation", bucketName);
+                try {
+                    final HeadBucketResponse headBucketResponse = locationClient.headBucket(builder -> builder.bucket(bucketName));
+                    bucketSpecificClient = this.asyncClientForRegion(headBucketResponse.sdkHttpResponse()
+                            .firstMatchingHeader("x-amz-bucket-region")
+                            .orElseThrow(() -> new NoSuchElementException("Head Bucket Response doesn't include the header 'x-amz-bucket-region'")));
+                } catch (S3Exception e2) {
+                    if (e2.statusCode() == 301) {
+                        bucketSpecificClient = this.asyncClientForRegion(e2
+                                .awsErrorDetails()
+                                .sdkHttpResponse()
+                                .firstMatchingHeader("x-amz-bucket-region")
+                                .orElseThrow(() -> new NoSuchElementException("Head Bucket Response doesn't include the header 'x-amz-bucket-region'")));
+                    } else {
+                        throw e2;
+                    }
+                }
+            } else {
+                throw e;
+            }
+        }
+
+        if (bucketSpecificClient == null) {
+            logger.warn("Unable to determine the region of bucket: '{}'. Generating a client for the profile region.", bucketName);
+            bucketSpecificClient = S3AsyncClient.builder()
+                    .overrideConfiguration(conf -> conf.retryPolicy(builder -> builder
+                            .retryCondition(retryCondition)
+                            .backoffStrategy(backoffStrategy)))
+                    .build();
+        }
+
+        return bucketSpecificClient;
+    }
+
+    private S3Client clientForRegion(String regionString){
+        // It may be useful to further cache clients for regions although at some point clients for buckets may need to be
+        // specialized beyond just region end points.
+        Region region = regionString.equals("") ? Region.US_EAST_1 : Region.of(regionString);
+        logger.debug("bucket region is: '{}'", region.id());
+
+        return S3Client.builder()
+                .region(region)
+                .overrideConfiguration(conf -> conf.retryPolicy(builder -> builder
+                        .retryCondition(retryCondition)
+                        .backoffStrategy(backoffStrategy)))
+                .build();
+    }
+
+    private S3AsyncClient asyncClientForRegion(String regionString){
+        // It may be useful to further cache clients for regions although at some point clients for buckets may need to be
+        // specialized beyond just region end points.
+        Region region = regionString.equals("") ? Region.US_EAST_1 : Region.of(regionString);
+        logger.debug("bucket region is: '{}'", region.id());
+
+        return S3AsyncClient.crtBuilder()
+                .region(region)
+                .build();
+    }
+
+}

--- a/src/main/java/software/amazon/nio/spi/s3/S3ClientProvider.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3ClientProvider.java
@@ -113,6 +113,9 @@ public class S3ClientProvider {
      * @return an S3 client appropriate for the region of the named bucket
      */
     protected S3Client generateClient(String bucketName){
+        //
+        // TODO: use generics like in universalClient()
+        //
         return this.generateClient(bucketName, universalClient());
     }
 
@@ -122,6 +125,9 @@ public class S3ClientProvider {
      * @return an asynchronous S3 client appropriate for the region of the named bucket
      */
     protected S3AsyncClient generateAsyncClient(String bucketName){
+        //
+        // TODO: use generics like in universalClient()
+        //
         return this.generateAsyncClient(bucketName, universalClient());
     }
 

--- a/src/main/java/software/amazon/nio/spi/s3/S3ClientStore.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3ClientStore.java
@@ -24,6 +24,10 @@ public class S3ClientStore {
 
     Logger logger = LoggerFactory.getLogger("S3ClientStore");
 
+    private static final S3ClientProvider DEFAULT_PROVIDER = new S3ClientProvider();
+    public static final S3Client DEFAULT_CLIENT = DEFAULT_PROVIDER.universalClient(false);
+    public static final S3AsyncClient DEFAULT_ASYNC_CLIENT = DEFAULT_PROVIDER.universalClient(true);
+
     private S3ClientStore(){}
 
     /**

--- a/src/main/java/software/amazon/nio/spi/s3/S3ClientStore.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3ClientStore.java
@@ -6,26 +6,11 @@
 package software.amazon.nio.spi.s3;
 
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import software.amazon.awssdk.core.exception.ApiCallAttemptTimeoutException;
-import software.amazon.awssdk.core.exception.ApiCallTimeoutException;
-import software.amazon.awssdk.core.exception.RetryableException;
-import software.amazon.awssdk.core.retry.backoff.EqualJitterBackoffStrategy;
-import software.amazon.awssdk.core.retry.conditions.*;
-import software.amazon.awssdk.http.HttpStatusCode;
-import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.HeadBucketResponse;
-import software.amazon.awssdk.services.s3.model.S3Exception;
-
-import java.io.IOException;
-import java.net.URI;
-import java.time.Duration;
 import java.util.*;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A Singleton cache of clients for buckets configured for the region of those buckets
@@ -34,53 +19,8 @@ public class S3ClientStore {
 
     private static final S3ClientStore instance = new S3ClientStore();
 
-    /**
-     * Default client using the "https://s3.us-east-1.amazonaws.com" endpoint
-     */
-    public static final S3Client DEFAULT_CLIENT = S3Client.builder()
-            .endpointOverride(URI.create("https://s3.us-east-1.amazonaws.com"))
-            .region(Region.US_EAST_1)
-            .build();
-
-    /**
-     * Default asynchronous client using the "https://s3.us-east-1.amazonaws.com" endpoint
-     */
-    public static final S3AsyncClient DEFAULT_ASYNC_CLIENT = S3AsyncClient.builder()
-            .endpointOverride(URI.create("https://s3.us-east-1.amazonaws.com"))
-            .region(Region.US_EAST_1)
-            .build();
-
     private final Map<String, S3Client> bucketToClientMap = Collections.synchronizedMap(new HashMap<>());
     private final Map<String, S3AsyncClient> bucketToAsyncClientMap = Collections.synchronizedMap(new HashMap<>());
-
-    private final EqualJitterBackoffStrategy backoffStrategy = EqualJitterBackoffStrategy.builder()
-            .baseDelay(Duration.ofMillis(200L))
-            .maxBackoffTime(Duration.ofSeconds(5L))
-            .build();
-
-    final RetryCondition retryCondition;
-
-    {
-        final Set<Integer> RETRYABLE_STATUS_CODES = Stream.of(
-                HttpStatusCode.INTERNAL_SERVER_ERROR,
-                HttpStatusCode.BAD_GATEWAY,
-                HttpStatusCode.SERVICE_UNAVAILABLE,
-                HttpStatusCode.GATEWAY_TIMEOUT
-        ).collect(Collectors.toSet());
-
-        final Set<Class<? extends Exception>> RETRYABLE_EXCEPTIONS = Stream.of(
-                RetryableException.class,
-                IOException.class,
-                ApiCallAttemptTimeoutException.class,
-                ApiCallTimeoutException.class).collect(Collectors.toSet());
-
-        retryCondition = OrRetryCondition.create(
-                RetryOnStatusCodeCondition.create(RETRYABLE_STATUS_CODES),
-                RetryOnExceptionsCondition.create(RETRYABLE_EXCEPTIONS),
-                RetryOnClockSkewCondition.create(),
-                RetryOnThrottlingCondition.create()
-        );
-    }
 
     Logger logger = LoggerFactory.getLogger("S3ClientStore");
 
@@ -92,6 +32,8 @@ public class S3ClientStore {
      */
     public static S3ClientStore getInstance() { return instance; }
 
+    protected S3ClientProvider provider = new S3ClientProvider();
+
     /**
      * Get an existing client or generate a new client for the named bucket if one doesn't exist
      * @param bucketName the bucket name. If this value is null or empty a default client is returned
@@ -100,10 +42,10 @@ public class S3ClientStore {
     public S3Client getClientForBucketName( String bucketName ) {
         logger.debug("obtaining client for bucket '{}'", bucketName);
         if (bucketName == null || bucketName.trim().equals("")) {
-            return DEFAULT_CLIENT;
+            return provider.universalClient();
         }
 
-        return bucketToClientMap.computeIfAbsent(bucketName, this::generateClient);
+        return bucketToClientMap.computeIfAbsent(bucketName, provider::generateClient);
     }
 
     /**
@@ -114,155 +56,10 @@ public class S3ClientStore {
     public S3AsyncClient getAsyncClientForBucketName( String bucketName ) {
         logger.debug("obtaining async client for bucket '{}'", bucketName);
         if (bucketName == null || bucketName.trim().equals("")) {
-            return DEFAULT_ASYNC_CLIENT;
+            return provider.universalClient(true);
         }
 
-        return bucketToAsyncClientMap.computeIfAbsent(bucketName, this::generateAsyncClient);
-    }
-
-    /**
-     * Generate a client for the named bucket using a default client to determine the location of the named bucket
-     * @param bucketName the named of the bucket to make the client for
-     * @return an S3 client appropriate for the region of the named bucket
-     */
-    protected S3Client generateClient(String bucketName){
-        return this.generateClient(bucketName, DEFAULT_CLIENT);
-    }
-
-    /**
-     * Generate an asynchronous client for the named bucket using a default client to determine the location of the named bucket
-     * @param bucketName the named of the bucket to make the client for
-     * @return an asynchronous S3 client appropriate for the region of the named bucket
-     */
-    protected S3AsyncClient generateAsyncClient(String bucketName){
-        return this.generateAsyncClient(bucketName, DEFAULT_CLIENT);
-    }
-
-    /**
-     * Generate a client for the named bucket using a default client to determine the location of the named client
-     * @param bucketName the named of the bucket to make the client for
-     * @param locationClient the client used to determine the location of the named bucket, recommend using DEFAULT_CLIENT
-     * @return an S3 client appropriate for the region of the named bucket
-     */
-    protected S3Client generateClient (String bucketName, S3Client locationClient) {
-        logger.debug("generating client for bucket: '{}'", bucketName);
-        S3Client bucketSpecificClient;
-        try {
-            logger.debug("determining bucket location with getBucketLocation");
-            String bucketLocation = locationClient.getBucketLocation(builder -> builder.bucket(bucketName)).locationConstraintAsString();
-
-            bucketSpecificClient = this.clientForRegion(bucketLocation);
-
-        } catch (S3Exception e) {
-            if(e.statusCode() == 403) {
-                logger.debug("Cannot determine location of '{}' bucket directly. Attempting to obtain bucket location with headBucket operation", bucketName);
-                try {
-                    final HeadBucketResponse headBucketResponse = locationClient.headBucket(builder -> builder.bucket(bucketName));
-                    bucketSpecificClient = this.clientForRegion(headBucketResponse.
-                            sdkHttpResponse()
-                            .firstMatchingHeader("x-amz-bucket-region")
-                            .orElseThrow(() -> new NoSuchElementException("Head Bucket Response doesn't include the header 'x-amz-bucket-region'")));
-                } catch (S3Exception e2) {
-                    if (e2.statusCode() == 301) {
-                        bucketSpecificClient = this.clientForRegion(e2.awsErrorDetails().
-                                sdkHttpResponse()
-                                .firstMatchingHeader("x-amz-bucket-region")
-                                .orElseThrow(() -> new NoSuchElementException("Head Bucket Response doesn't include the header 'x-amz-bucket-region'")));
-                    } else {
-                        throw e2;
-                    }
-                }
-            } else {
-                throw e;
-            }
-        }
-
-        if (bucketSpecificClient == null) {
-            logger.warn("Unable to determine the region of bucket: '{}'. Generating a client for the profile region.", bucketName);
-            bucketSpecificClient = S3Client.builder()
-                    .overrideConfiguration(conf -> conf.retryPolicy(builder -> builder
-                        .retryCondition(retryCondition)
-                        .backoffStrategy(backoffStrategy)))
-                    .build();
-        }
-
-        return bucketSpecificClient;
-    }
-
-    /**
-     * Generate an asynchronous client for the named bucket using a default client to determine the location of the named client
-     * @param bucketName the named of the bucket to make the client for
-     * @param locationClient the client used to determine the location of the named bucket, recommend using DEFAULT_CLIENT
-     * @return an S3 client appropriate for the region of the named bucket
-     */
-    protected S3AsyncClient generateAsyncClient (String bucketName, S3Client locationClient) {
-        logger.debug("generating asynchronous client for bucket: '{}'", bucketName);
-        S3AsyncClient bucketSpecificClient;
-        try {
-            logger.debug("determining bucket location with getBucketLocation");
-            String bucketLocation = locationClient.getBucketLocation(builder -> builder.bucket(bucketName)).locationConstraintAsString();
-
-            bucketSpecificClient = this.asyncClientForRegion(bucketLocation);
-
-        } catch (S3Exception e) {
-            if(e.statusCode() == 403) {
-                logger.debug("Cannot determine location of '{}' bucket directly. Attempting to obtain bucket location with headBucket operation", bucketName);
-                try {
-                    final HeadBucketResponse headBucketResponse = locationClient.headBucket(builder -> builder.bucket(bucketName));
-                    bucketSpecificClient = this.asyncClientForRegion(headBucketResponse.sdkHttpResponse()
-                            .firstMatchingHeader("x-amz-bucket-region")
-                            .orElseThrow(() -> new NoSuchElementException("Head Bucket Response doesn't include the header 'x-amz-bucket-region'")));
-                } catch (S3Exception e2) {
-                    if (e2.statusCode() == 301) {
-                        bucketSpecificClient = this.asyncClientForRegion(e2
-                                .awsErrorDetails()
-                                .sdkHttpResponse()
-                                .firstMatchingHeader("x-amz-bucket-region")
-                                .orElseThrow(() -> new NoSuchElementException("Head Bucket Response doesn't include the header 'x-amz-bucket-region'")));
-                    } else {
-                        throw e2;
-                    }
-                }
-            } else {
-                throw e;
-            }
-        }
-
-        if (bucketSpecificClient == null) {
-            logger.warn("Unable to determine the region of bucket: '{}'. Generating a client for the profile region.", bucketName);
-            bucketSpecificClient = S3AsyncClient.builder()
-                    .overrideConfiguration(conf -> conf.retryPolicy(builder -> builder
-                            .retryCondition(retryCondition)
-                            .backoffStrategy(backoffStrategy)))
-                    .build();
-        }
-
-        return bucketSpecificClient;
-    }
-
-    private S3Client clientForRegion(String regionString){
-        // It may be useful to further cache clients for regions although at some point clients for buckets may need to be
-        // specialized beyond just region end points.
-        Region region = regionString.equals("") ? Region.US_EAST_1 : Region.of(regionString);
-        logger.debug("bucket region is: '{}'", region.id());
-
-        return S3Client.builder()
-                .region(region)
-                .overrideConfiguration(conf -> conf.retryPolicy(builder -> builder
-                        .retryCondition(retryCondition)
-                        .backoffStrategy(backoffStrategy)))
-                .build();
-    }
-
-    private S3AsyncClient asyncClientForRegion(String regionString){
-        // It may be useful to further cache clients for regions although at some point clients for buckets may need to be
-        // specialized beyond just region end points.
-        Region region = regionString.equals("") ? Region.US_EAST_1 : Region.of(regionString);
-        logger.debug("bucket region is: '{}'", region.id());
-
-        return S3AsyncClient.crtBuilder()
-                .region(region)
-                .build();
+        return bucketToAsyncClientMap.computeIfAbsent(bucketName, provider::generateAsyncClient);
     }
 
 }

--- a/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
@@ -646,52 +646,44 @@ public class S3FileSystemProvider extends FileSystemProvider {
     @Override
     public void checkAccess(Path path, AccessMode... modes) throws IOException {
         try {
-            this.checkAccess(null, path, modes);
+            assert path instanceof S3Path;
+
+            final S3Path s3Path = (S3Path) path.toRealPath(NOFOLLOW_LINKS);
+            final S3FileSystem fs = s3Path.getFileSystem();
+            final String bucketName = fs.bucketName();
+            final S3AsyncClient s3Client = fs.client();
+
+            final CompletableFuture<? extends S3Response> response;
+            if (s3Path.equals(s3Path.getRoot())) {
+                response = s3Client.headBucket(request -> request.bucket(bucketName));
+            } else {
+                response = s3Client.headObject(req -> req.bucket(bucketName).key(s3Path.getKey()));
+            }
+
+            long timeOut = TimeOutUtils.TIMEOUT_TIME_LENGTH_1;
+            TimeUnit unit = MINUTES;
+
+            try {
+                SdkHttpResponse httpResponse = response.get(timeOut, unit).sdkHttpResponse();
+                if (httpResponse.isSuccessful()) return;
+
+                if (httpResponse.statusCode() == FORBIDDEN)
+                    throw new AccessDeniedException(s3Path.toString());
+
+                if (httpResponse.statusCode() == NOT_FOUND)
+                    throw new NoSuchFileException(s3Path.toString());
+
+                throw new IOException(String.format("exception occurred while checking access, response code was '%d'",
+                        httpResponse.statusCode()));
+
+            } catch (TimeoutException e) {
+                throw logAndGenerateExceptionOnTimeOut(logger, "checkAccess", timeOut, unit);
+            }
         } catch (ExecutionException e) {
             throw new IOException(e);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new RuntimeException(e);
-        }
-    }
-
-    /**
-     * Composable and testable version of {@code checkAccess} that uses the provided client to check access
-     */
-    protected void checkAccess(S3AsyncClient s3Client, Path path, AccessMode... modes) throws IOException, ExecutionException, InterruptedException {
-        assert path instanceof S3Path;
-        S3Path s3Path = (S3Path) path.toRealPath(NOFOLLOW_LINKS);
-        final String bucketName = s3Path.getFileSystem().bucketName();
-
-        if (s3Client == null) {
-            s3Client = S3ClientStore.getInstance().getAsyncClientForBucketName(bucketName);
-        }
-
-        final CompletableFuture<? extends S3Response> response;
-        if (s3Path.equals(s3Path.getRoot())) {
-            response = s3Client.headBucket(request -> request.bucket(bucketName));
-        } else {
-            response = s3Client.headObject(req -> req.bucket(bucketName).key(s3Path.getKey()));
-        }
-
-        long timeOut = TimeOutUtils.TIMEOUT_TIME_LENGTH_1;
-        TimeUnit unit = MINUTES;
-
-        try {
-            SdkHttpResponse httpResponse = response.get(timeOut, unit).sdkHttpResponse();
-            if (httpResponse.isSuccessful()) return;
-
-            if (httpResponse.statusCode() == FORBIDDEN)
-                throw new AccessDeniedException(s3Path.toString());
-
-            if (httpResponse.statusCode() == NOT_FOUND)
-                throw new NoSuchFileException(s3Path.toString());
-
-            throw new IOException(String.format("exception occurred while checking access, response code was '%d'",
-                    httpResponse.statusCode()));
-
-        } catch (TimeoutException e) {
-            throw logAndGenerateExceptionOnTimeOut(logger, "checkAccess", timeOut, unit);
         }
     }
 
@@ -735,25 +727,17 @@ public class S3FileSystemProvider extends FileSystemProvider {
      * @param options options indicating how symbolic links are handled
      * @return the file attributes or {@code null} if {@code path} is inferred to be a directory.
      */
-    @Override
     public <A extends BasicFileAttributes> A readAttributes(Path path, Class<A> type, LinkOption... options) {
-        return this.readAttributes(null, path, type, options);
-    }
-
-    protected <A extends BasicFileAttributes> A readAttributes(S3AsyncClient s3AsyncClient, Path path, Class<A> type, LinkOption... options) {
         Objects.requireNonNull(path);
         Objects.requireNonNull(type);
         if (!(path instanceof S3Path))
             throw new IllegalArgumentException("path must be an S3Path instance");
         S3Path s3Path = (S3Path) path;
-        //if (s3Path.isDirectory()) return null;
+        S3AsyncClient s3Client = s3Path.getFileSystem().client();
 
         if (type.equals(BasicFileAttributes.class) || type.equals(S3BasicFileAttributes.class)) {
-            if (s3AsyncClient == null) {
-                s3AsyncClient = S3ClientStore.getInstance().getAsyncClientForBucketName(s3Path.bucketName());
-            }
             @SuppressWarnings("unchecked")
-            A a = (A) new S3BasicFileAttributes(s3Path, s3AsyncClient);
+            A a = (A) new S3BasicFileAttributes(s3Path, s3Client);
             return a;
         } else {
             throw new UnsupportedOperationException("cannot read attributes of type: " + type);
@@ -781,28 +765,21 @@ public class S3FileSystemProvider extends FileSystemProvider {
      */
     @Override
     public Map<String, Object> readAttributes(Path path, String attributes, LinkOption... options) {
-        return this.readAttributes(null, path, attributes, options);
-    }
-
-    protected Map<String, Object> readAttributes(S3AsyncClient client, Path path, String attributes, LinkOption... options) {
         Objects.requireNonNull(path);
         Objects.requireNonNull(attributes);
         S3Path s3Path = (S3Path) path;
-
-        if (client == null) {
-            client = S3ClientStore.getInstance().getAsyncClientForBucketName(s3Path.bucketName());
-        }
+        S3AsyncClient s3Client = s3Path.getFileSystem().client();
 
         if (s3Path.isDirectory() || attributes.trim().isEmpty())
             return Collections.emptyMap();
 
         if (attributes.equals("*") || attributes.equals("s3"))
-            return new S3BasicFileAttributes(s3Path, client).asMap();
+            return new S3BasicFileAttributes(s3Path, s3Client).asMap();
 
         final Set<String> attrSet = Arrays.stream(attributes.split(","))
                 .map(attr -> attr.replaceAll("^s3:", ""))
                 .collect(Collectors.toSet());
-        return readAttributes(client, path, S3BasicFileAttributes.class, options)
+        return readAttributes(path, S3BasicFileAttributes.class, options)
                 .asMap(attrSet::contains);
     }
 

--- a/src/main/java/software/amazon/nio/spi/s3/S3SeekableByteChannel.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3SeekableByteChannel.java
@@ -55,11 +55,11 @@ public class S3SeekableByteChannel implements SeekableByteChannel {
      */
     @Deprecated
     protected S3SeekableByteChannel(S3Path s3Path, long startAt) throws IOException {
-        this(s3Path, S3ClientStore.getInstance().getAsyncClientForBucketName(s3Path.bucketName()), startAt);
+        this(s3Path, s3Path.getFileSystem().client(), startAt);
     }
 
     protected S3SeekableByteChannel(S3Path s3Path) throws IOException {
-        this(s3Path, S3ClientStore.getInstance().getAsyncClientForBucketName(s3Path.bucketName()), Collections.singleton(StandardOpenOption.READ));
+        this(s3Path, s3Path.getFileSystem().client(), Collections.singleton(StandardOpenOption.READ));
     }
 
     protected S3SeekableByteChannel(S3Path s3Path, S3AsyncClient s3Client, Set<? extends OpenOption> options) throws IOException {

--- a/src/test/java/software/amazon/nio/spi/s3/S3ClientProviderTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3ClientProviderTest.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.nio.spi.s3;
+
+import java.util.NoSuchElementException;
+import java.util.function.Consumer;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import static org.mockito.ArgumentMatchers.any;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.when;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetBucketLocationResponse;
+import software.amazon.awssdk.services.s3.model.HeadBucketResponse;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+@RunWith(MockitoJUnitRunner.class)
+public class S3ClientProviderTest {
+
+    @Mock
+    S3Client mockClient; //client used to determine bucket location
+
+    S3ClientProvider provider;
+
+    @Before
+    public void before() throws Exception {
+        provider = new S3ClientProvider();
+    }
+
+    @Test
+    public void initialization() {
+        final S3ClientProvider P = new S3ClientProvider();
+        assertTrue(P.universalClient() instanceof S3Client);
+        assertNotNull(P.universalClient());
+
+        assertTrue(P.universalClient(true) instanceof S3AsyncClient);
+        assertNotNull(P.universalClient());
+    }
+
+
+    @Test
+    public void testGenerateAsyncClientWithNoErrors() {
+        when(mockClient.getBucketLocation(any(Consumer.class)))
+                .thenReturn(GetBucketLocationResponse.builder().locationConstraint("us-west-2").build());
+        final S3AsyncClient s3Client = provider.generateAsyncClient("test-bucket", mockClient);
+        assertNotNull(s3Client);
+    }
+
+    @Test
+    public void testGenerateClientWith403Response() {
+        // when you get a forbidden response from getBucketLocation
+        when(mockClient.getBucketLocation(any(Consumer.class))).thenThrow(
+                S3Exception.builder().statusCode(403).build()
+        );
+        // you should fall back to a head bucket attempt
+        when(mockClient.headBucket(any(Consumer.class)))
+                .thenReturn((HeadBucketResponse) HeadBucketResponse.builder()
+                        .sdkHttpResponse(SdkHttpResponse.builder()
+                                .putHeader("x-amz-bucket-region", "us-west-2")
+                                .build())
+                        .build());
+
+        // which should get you a client
+        final S3Client s3Client = provider.generateClient("test-bucket", mockClient);
+        assertNotNull(s3Client);
+
+        final InOrder inOrder = inOrder(mockClient);
+        inOrder.verify(mockClient).getBucketLocation(any(Consumer.class));
+        inOrder.verify(mockClient).headBucket(any(Consumer.class));
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void testGenerateAsyncClientWith403Response() {
+        // when you get a forbidden response from getBucketLocation
+        when(mockClient.getBucketLocation(any(Consumer.class))).thenThrow(
+                S3Exception.builder().statusCode(403).build()
+        );
+        // you should fall back to a head bucket attempt
+        when(mockClient.headBucket(any(Consumer.class)))
+                .thenReturn((HeadBucketResponse) HeadBucketResponse.builder()
+                        .sdkHttpResponse(SdkHttpResponse.builder()
+                                .putHeader("x-amz-bucket-region", "us-west-2")
+                                .build())
+                        .build());
+
+        // which should get you a client
+        final S3AsyncClient s3Client = provider.generateAsyncClient("test-bucket", mockClient);
+        assertNotNull(s3Client);
+
+        final InOrder inOrder = inOrder(mockClient);
+        inOrder.verify(mockClient).getBucketLocation(any(Consumer.class));
+        inOrder.verify(mockClient).headBucket(any(Consumer.class));
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void testGenerateAsyncClientWith403Then301Responses(){
+        // when you get a forbidden response from getBucketLocation
+        when(mockClient.getBucketLocation(any(Consumer.class))).thenThrow(
+                S3Exception.builder().statusCode(403).build()
+        );
+        // and you get a 301 response on headBucket
+        when(mockClient.headBucket(any(Consumer.class))).thenThrow(
+                S3Exception.builder()
+                        .statusCode(301)
+                        .awsErrorDetails(AwsErrorDetails.builder()
+                                .sdkHttpResponse(SdkHttpResponse.builder()
+                                        .putHeader("x-amz-bucket-region", "us-west-2")
+                                        .build())
+                                .build())
+                        .build()
+        );
+
+        // then you should be able to get a client as long as the error response header contains the region
+        final S3AsyncClient s3Client = provider.generateAsyncClient("test-bucket", mockClient);
+        assertNotNull(s3Client);
+
+        final InOrder inOrder = inOrder(mockClient);
+        inOrder.verify(mockClient).getBucketLocation(any(Consumer.class));
+        inOrder.verify(mockClient).headBucket(any(Consumer.class));
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void testGenerateClientWith403Then301ResponsesNoHeader(){
+        // when you get a forbidden response from getBucketLocation
+        when(mockClient.getBucketLocation(any(Consumer.class))).thenThrow(
+                S3Exception.builder().statusCode(403).build()
+        );
+        // and you get a 301 response on headBucket but no header for region
+        when(mockClient.headBucket(any(Consumer.class))).thenThrow(
+                S3Exception.builder()
+                        .statusCode(301)
+                        .awsErrorDetails(AwsErrorDetails.builder()
+                                .sdkHttpResponse(SdkHttpResponse.builder()
+                                        .build())
+                                .build())
+                        .build()
+        );
+
+        // then you should get a NoSuchElement exception when you try to get the header
+        try {
+            provider.generateClient("test-bucket", mockClient);
+        } catch (Exception e) {
+            assertEquals(NoSuchElementException.class, e.getClass());
+        }
+
+        final InOrder inOrder = inOrder(mockClient);
+        inOrder.verify(mockClient).getBucketLocation(any(Consumer.class));
+        inOrder.verify(mockClient).headBucket(any(Consumer.class));
+        inOrder.verifyNoMoreInteractions();
+    }
+
+
+    @Test
+    public void testGenerateAsyncClientWith403Then301ResponsesNoHeader(){
+        // when you get a forbidden response from getBucketLocation
+        when(mockClient.getBucketLocation(any(Consumer.class))).thenThrow(
+                S3Exception.builder().statusCode(403).build()
+        );
+        // and you get a 301 response on headBucket but no header for region
+        when(mockClient.headBucket(any(Consumer.class))).thenThrow(
+                S3Exception.builder()
+                        .statusCode(301)
+                        .awsErrorDetails(AwsErrorDetails.builder()
+                                .sdkHttpResponse(SdkHttpResponse.builder()
+                                        .build())
+                                .build())
+                        .build()
+        );
+
+        // then you should get a NoSuchElement exception when you try to get the header
+        try {
+            provider.generateAsyncClient("test-bucket", mockClient);
+        } catch (Exception e) {
+            assertEquals(NoSuchElementException.class, e.getClass());
+        }
+
+        final InOrder inOrder = inOrder(mockClient);
+        inOrder.verify(mockClient).getBucketLocation(any(Consumer.class));
+        inOrder.verify(mockClient).headBucket(any(Consumer.class));
+        inOrder.verifyNoMoreInteractions();
+    }
+
+}

--- a/src/test/java/software/amazon/nio/spi/s3/S3ClientStoreTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3ClientStoreTest.java
@@ -9,22 +9,13 @@ import junit.framework.TestCase;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.InOrder;
 import org.mockito.Mock;
-import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
-import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
-import software.amazon.awssdk.http.SdkHttpResponse;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.GetBucketLocationResponse;
-import software.amazon.awssdk.services.s3.model.HeadBucketResponse;
-import software.amazon.awssdk.services.s3.model.S3Exception;
+import org.junit.Rule;
+import org.junit.contrib.java.lang.system.ProvideSystemProperty;
 
-import java.util.NoSuchElementException;
-import java.util.function.Consumer;
-
-import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 @SuppressWarnings("unchecked")
@@ -32,11 +23,12 @@ public class S3ClientStoreTest extends TestCase {
 
     S3ClientStore instance;
 
+    @Rule
+    public final ProvideSystemProperty AWS_PROPERTIES
+        = new ProvideSystemProperty("aws.region", "aws-east-1");
+
     @Mock
     S3Client mockClient; //client used to determine bucket location
-
-    @Spy
-    final S3ClientStore spyInstance = S3ClientStore.getInstance();
 
     @Before
     public void setUp() throws Exception {
@@ -51,218 +43,53 @@ public class S3ClientStoreTest extends TestCase {
 
     @Test
     public void testGetClientForNullBucketName() {
-        assertEquals(S3ClientStore.DEFAULT_CLIENT, instance.getClientForBucketName(null));
+        assertEquals(instance.provider.universalClient(), instance.getClientForBucketName(null));
     }
 
     @Test
     public void testGetAsyncClientForNullBucketName() {
-        assertEquals(S3ClientStore.DEFAULT_ASYNC_CLIENT, instance.getAsyncClientForBucketName(null));
+        assertEquals(instance.provider.universalClient(true), instance.getAsyncClientForBucketName(null));
     }
 
     @Test
     public void testGetClientForEmptyBucketName() {
-        assertEquals(S3ClientStore.DEFAULT_CLIENT, instance.getClientForBucketName(""));
-        assertEquals(S3ClientStore.DEFAULT_CLIENT, instance.getClientForBucketName(" "));
+        assertEquals(instance.provider.universalClient(), instance.getClientForBucketName(""));
+        assertEquals(instance.provider.universalClient(), instance.getClientForBucketName(" "));
     }
 
     @Test
     public void testGetAsyncClientForEmptyBucketName() {
-        assertEquals(S3ClientStore.DEFAULT_ASYNC_CLIENT, instance.getAsyncClientForBucketName(""));
-        assertEquals(S3ClientStore.DEFAULT_ASYNC_CLIENT, instance.getAsyncClientForBucketName(" "));
-    }
-
-    @Test
-    public void testGenerateClientWithNoErrors() {
-        when(mockClient.getBucketLocation(any(Consumer.class)))
-                .thenReturn(GetBucketLocationResponse.builder().locationConstraint("us-west-2").build());
-        final S3Client s3Client = instance.generateClient("test-bucket", mockClient);
-        assertNotNull(s3Client);
-
-    }
-
-    @Test
-    public void testGenerateAsyncClientWithNoErrors() {
-        when(mockClient.getBucketLocation(any(Consumer.class)))
-                .thenReturn(GetBucketLocationResponse.builder().locationConstraint("us-west-2").build());
-        final S3AsyncClient s3Client = instance.generateAsyncClient("test-bucket", mockClient);
-        assertNotNull(s3Client);
-    }
-
-    @Test
-    public void testGenerateClientWith403Response() {
-        // when you get a forbidden response from getBucketLocation
-        when(mockClient.getBucketLocation(any(Consumer.class))).thenThrow(
-                S3Exception.builder().statusCode(403).build()
-        );
-        // you should fall back to a head bucket attempt
-        when(mockClient.headBucket(any(Consumer.class)))
-                .thenReturn((HeadBucketResponse) HeadBucketResponse.builder()
-                        .sdkHttpResponse(SdkHttpResponse.builder()
-                                .putHeader("x-amz-bucket-region", "us-west-2")
-                                .build())
-                        .build());
-
-        // which should get you a client
-        final S3Client s3Client = instance.generateClient("test-bucket", mockClient);
-        assertNotNull(s3Client);
-
-        final InOrder inOrder = inOrder(mockClient);
-        inOrder.verify(mockClient).getBucketLocation(any(Consumer.class));
-        inOrder.verify(mockClient).headBucket(any(Consumer.class));
-        inOrder.verifyNoMoreInteractions();
-    }
-
-    @Test
-    public void testGenerateAsyncClientWith403Response() {
-        // when you get a forbidden response from getBucketLocation
-        when(mockClient.getBucketLocation(any(Consumer.class))).thenThrow(
-                S3Exception.builder().statusCode(403).build()
-        );
-        // you should fall back to a head bucket attempt
-        when(mockClient.headBucket(any(Consumer.class)))
-                .thenReturn((HeadBucketResponse) HeadBucketResponse.builder()
-                        .sdkHttpResponse(SdkHttpResponse.builder()
-                                .putHeader("x-amz-bucket-region", "us-west-2")
-                                .build())
-                        .build());
-
-        // which should get you a client
-        final S3AsyncClient s3Client = instance.generateAsyncClient("test-bucket", mockClient);
-        assertNotNull(s3Client);
-
-        final InOrder inOrder = inOrder(mockClient);
-        inOrder.verify(mockClient).getBucketLocation(any(Consumer.class));
-        inOrder.verify(mockClient).headBucket(any(Consumer.class));
-        inOrder.verifyNoMoreInteractions();
-    }
-
-    @Test
-    public void testGenerateAsyncClientWith403Then301Responses(){
-        // when you get a forbidden response from getBucketLocation
-        when(mockClient.getBucketLocation(any(Consumer.class))).thenThrow(
-                S3Exception.builder().statusCode(403).build()
-        );
-        // and you get a 301 response on headBucket
-        when(mockClient.headBucket(any(Consumer.class))).thenThrow(
-                S3Exception.builder()
-                        .statusCode(301)
-                        .awsErrorDetails(AwsErrorDetails.builder()
-                                .sdkHttpResponse(SdkHttpResponse.builder()
-                                        .putHeader("x-amz-bucket-region", "us-west-2")
-                                        .build())
-                                .build())
-                        .build()
-        );
-
-        // then you should be able to get a client as long as the error response header contains the region
-        final S3AsyncClient s3Client = instance.generateAsyncClient("test-bucket", mockClient);
-        assertNotNull(s3Client);
-
-        final InOrder inOrder = inOrder(mockClient);
-        inOrder.verify(mockClient).getBucketLocation(any(Consumer.class));
-        inOrder.verify(mockClient).headBucket(any(Consumer.class));
-        inOrder.verifyNoMoreInteractions();
-    }
-
-    @Test
-    public void testGenerateClientWith403Then301ResponsesNoHeader(){
-        // when you get a forbidden response from getBucketLocation
-        when(mockClient.getBucketLocation(any(Consumer.class))).thenThrow(
-                S3Exception.builder().statusCode(403).build()
-        );
-        // and you get a 301 response on headBucket but no header for region
-        when(mockClient.headBucket(any(Consumer.class))).thenThrow(
-                S3Exception.builder()
-                        .statusCode(301)
-                        .awsErrorDetails(AwsErrorDetails.builder()
-                                .sdkHttpResponse(SdkHttpResponse.builder()
-                                        .build())
-                                .build())
-                        .build()
-        );
-
-        // then you should get a NoSuchElement exception when you try to get the header
-        try {
-            instance.generateClient("test-bucket", mockClient);
-        } catch (Exception e) {
-            assertEquals(NoSuchElementException.class, e.getClass());
-        }
-
-        final InOrder inOrder = inOrder(mockClient);
-        inOrder.verify(mockClient).getBucketLocation(any(Consumer.class));
-        inOrder.verify(mockClient).headBucket(any(Consumer.class));
-        inOrder.verifyNoMoreInteractions();
-    }
-
-
-    @Test
-    public void testGenerateAsyncClientWith403Then301ResponsesNoHeader(){
-        // when you get a forbidden response from getBucketLocation
-        when(mockClient.getBucketLocation(any(Consumer.class))).thenThrow(
-                S3Exception.builder().statusCode(403).build()
-        );
-        // and you get a 301 response on headBucket but no header for region
-        when(mockClient.headBucket(any(Consumer.class))).thenThrow(
-                S3Exception.builder()
-                        .statusCode(301)
-                        .awsErrorDetails(AwsErrorDetails.builder()
-                                .sdkHttpResponse(SdkHttpResponse.builder()
-                                        .build())
-                                .build())
-                        .build()
-        );
-
-        // then you should get a NoSuchElement exception when you try to get the header
-        try {
-            instance.generateAsyncClient("test-bucket", mockClient);
-        } catch (Exception e) {
-            assertEquals(NoSuchElementException.class, e.getClass());
-        }
-
-        final InOrder inOrder = inOrder(mockClient);
-        inOrder.verify(mockClient).getBucketLocation(any(Consumer.class));
-        inOrder.verify(mockClient).headBucket(any(Consumer.class));
-        inOrder.verifyNoMoreInteractions();
+        assertEquals(instance.provider.universalClient(true), instance.getAsyncClientForBucketName(""));
+        assertEquals(instance.provider.universalClient(true), instance.getAsyncClientForBucketName(" "));
     }
 
     @Test
     public void testCaching() {
-        S3Client client = S3Client.create();
-        doReturn(client).when(spyInstance).generateClient("test-bucket");
+        instance.provider = new S3ClientProvider() {
+            @Override
+            protected S3Client generateClient(String bucketName) {
+                return S3Client.create();
+            }
+        };
 
-        final S3Client client1 = spyInstance.getClientForBucketName("test-bucket");
-        verify(spyInstance).generateClient("test-bucket");
-        assertSame(client1, client);
-
-        S3Client differentClient = S3Client.create();
-        assertNotSame(client, differentClient);
-
-        lenient().doReturn(differentClient).when(spyInstance).generateClient("test-bucket");
-        final S3Client client2 = spyInstance.getClientForBucketName("test-bucket");
-        // same instance because second is cached.
-        assertSame(client1, client2);
-        assertSame(client2, client);
-        assertNotSame(client2, differentClient);
+        final S3Client client1 = instance.getClientForBucketName("test-bucket1");
+        assertSame(client1, instance.getClientForBucketName("test-bucket1"));
+        assertNotSame(client1, instance.getClientForBucketName("test-bucket2"));
     }
 
     @Test
     public void testAsyncCaching() {
-        S3AsyncClient client = S3AsyncClient.create();
-        doReturn(client).when(spyInstance).generateAsyncClient("test-bucket");
+        instance.provider = new S3ClientProvider() {
+            @Override
+            protected S3AsyncClient generateAsyncClient(String bucketName) {
+                return S3AsyncClient.create();
+            }
+        };
 
-        final S3AsyncClient client1 = spyInstance.getAsyncClientForBucketName("test-bucket");
-        verify(spyInstance).generateAsyncClient("test-bucket");
-        assertSame(client1, client);
-
-        S3AsyncClient differentClient = S3AsyncClient.create();
-        assertNotSame(client, differentClient);
-
-        lenient().doReturn(differentClient).when(spyInstance).generateAsyncClient("test-bucket");
-        final S3AsyncClient client2 = spyInstance.getAsyncClientForBucketName("test-bucket");
-        // same instance because second is cached.
-        assertSame(client1, client2);
-        assertSame(client2, client);
-        assertNotSame(client2, differentClient);
+        final S3AsyncClient client1 = instance.getAsyncClientForBucketName("test-bucket1");
+        assertSame(client1, instance.getAsyncClientForBucketName("test-bucket1"));
+        assertNotSame(client1, instance.getAsyncClientForBucketName("test-bucket2"));
     }
+
 }
 

--- a/src/test/java/software/amazon/nio/spi/s3/S3FileSystemProviderTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3FileSystemProviderTest.java
@@ -459,12 +459,12 @@ public class S3FileSystemProviderTest {
                         .build()));
 
         S3Path foo = fileSystem.getPath("/foo");
-        provider.checkAccess(mockClient, foo, AccessMode.READ);
-        provider.checkAccess(mockClient, foo, AccessMode.EXECUTE);
-        provider.checkAccess(mockClient, foo);
+        provider.checkAccess(foo, AccessMode.READ);
+        provider.checkAccess(foo, AccessMode.EXECUTE);
+        provider.checkAccess(foo);
     }
 
-   @Test(expected = AccessDeniedException.class)
+    @Test(expected = AccessDeniedException.class)
     public void checkAccessWhenAccessDenied() throws Exception {
         when(mockClient.headObject(any(Consumer.class))).thenReturn(CompletableFuture.supplyAsync(() ->
                 HeadObjectResponse.builder()
@@ -472,7 +472,7 @@ public class S3FileSystemProviderTest {
                         .build()));
 
         S3Path foo = fileSystem.getPath("/foo");
-        provider.checkAccess(mockClient, foo);
+        provider.checkAccess(foo);
     }
 
     @Test(expected = NoSuchFileException.class)
@@ -483,7 +483,7 @@ public class S3FileSystemProviderTest {
                         .build()));
 
         S3Path foo = fileSystem.getPath("/foo");
-        provider.checkAccess(mockClient, foo);
+        provider.checkAccess(foo);
     }
 
     @Test
@@ -492,7 +492,7 @@ public class S3FileSystemProviderTest {
                 HeadObjectResponse.builder()
                         .sdkHttpResponse(SdkHttpResponse.builder().statusCode(200).build())
                         .build()));
-        provider.checkAccess(mockClient, fileSystem.getPath("foo"), AccessMode.WRITE);
+        provider.checkAccess(fileSystem.getPath("foo"), AccessMode.WRITE);
     }
 
     @Test
@@ -509,17 +509,17 @@ public class S3FileSystemProviderTest {
     @Test(expected = IllegalArgumentException.class)
     public void getFileAttributeViewIllegalArg() {
         S3Path foo = fileSystem.getPath("/foo");
-        final FileAttributeView fileAttributeView = provider.getFileAttributeView(foo, FileAttributeView.class);
+        provider.getFileAttributeView(foo, FileAttributeView.class);
     }
 
     @Test
     public void readAttributes() {
         S3Path foo = fileSystem.getPath("/foo");
-        final BasicFileAttributes BasicFileAttributes = provider.readAttributes(mockClient, foo, BasicFileAttributes.class);
+        final BasicFileAttributes BasicFileAttributes = provider.readAttributes(foo, BasicFileAttributes.class);
         assertNotNull(BasicFileAttributes);
         assertTrue(BasicFileAttributes instanceof S3BasicFileAttributes);
 
-        final S3BasicFileAttributes s3BasicFileAttributes = provider.readAttributes(mockClient, foo, S3BasicFileAttributes.class);
+        final S3BasicFileAttributes s3BasicFileAttributes = provider.readAttributes(foo, S3BasicFileAttributes.class);
         assertNotNull(s3BasicFileAttributes);
     }
 
@@ -535,15 +535,15 @@ public class S3FileSystemProviderTest {
                         .eTag("abcdef")
                         .build()));
 
-        Map<String, Object> attributes = provider.readAttributes(mockClient, foo, "*");
+        Map<String, Object> attributes = provider.readAttributes(foo, "*");
         assertTrue(attributes.size() >= 9);
 
-        attributes = provider.readAttributes(mockClient, foo, "lastModifiedTime,size,fileKey");
+        attributes = provider.readAttributes(foo, "lastModifiedTime,size,fileKey");
         assertEquals(3, attributes.size());
         assertEquals(FileTime.from(Instant.EPOCH), attributes.get("lastModifiedTime"));
         assertEquals(100L, attributes.get("size"));
 
-        assertEquals(Collections.emptyMap(), provider.readAttributes(mockClient, fooDir, "*"));
+        assertEquals(Collections.emptyMap(), provider.readAttributes(fooDir, "*"));
     }
 
     @Test(expected = UnsupportedOperationException.class)

--- a/src/test/java/software/amazon/nio/spi/s3/S3ReadAheadByteChannelTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3ReadAheadByteChannelTest.java
@@ -16,6 +16,7 @@ import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 
 import java.io.IOException;
+import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
@@ -29,7 +30,10 @@ import static org.mockito.Mockito.when;
 @SuppressWarnings("unchecked")
 public class S3ReadAheadByteChannelTest {
 
-    S3Path path = S3Path.getPath(new S3FileSystem("my-bucket"), "/object");
+    final S3FileSystemProvider provider = new S3FileSystemProvider();
+
+
+    S3Path path;
 
     @Mock
     S3SeekableByteChannel delegator;
@@ -42,6 +46,14 @@ public class S3ReadAheadByteChannelTest {
 
     @Before
     public void setup() throws IOException {
+        provider.clientProvider = new S3ClientProvider() {
+            @Override
+            protected S3AsyncClient generateAsyncClient(String bucketName) {
+                return client;
+            }
+        };
+        path = S3Path.getPath(provider.getFileSystem(URI.create("s3://my-bucket"), true), "/object");
+
 
         // mocking
         when(delegator.size()).thenReturn(52L);


### PR DESCRIPTION
S3ClientStore can implement just the caching/storing logic, while the configuration and creation logic of the clients is delegated to the client provider

*Issue #, if available:*
Issue #30 

*Description of changes:*
S3ClientStore can implement just the caching/storing logic, while the configuration and creation logic of the clients is delegated to the client provider

*Attribution*
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
