### PR TITLE
Quick fix for issue #66

### DIFF
--- a/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
@@ -274,6 +274,7 @@ public class S3FileSystemProvider extends FileSystemProvider {
                     .contents()
                     .stream()
                     .map(s3Object -> truncateByPrefix(fs, prefix, s3Object))
+                    .distinct()
                     .filter(path -> {
                         try {
                             return filter.accept(path);


### PR DESCRIPTION
Issue #66 

*Description of changes:*

Added .distinct() to avoid duplicates in the returned list. This is a quickfix just to move on with the development but there is a corner case I believe it is not covered when there are two keys one representing a file and one a directory. However please see the note below (that I will report to the issue as well).

If I well understood, the current implementation retrieves all keys (!) in the bucket and then filters the one matching the provided prefix. This is highly undesirable as it would break for buckets of a noticeable size. See Isse #66 for more.