### PR TITLE
Markjschreiber/issue66

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -114,6 +114,7 @@ javadoc {
 }
 
 test {
+    useJUnitPlatform()
     finalizedBy jacocoTestReport
 }
 

--- a/src/main/java/examples/ListPrefix.java
+++ b/src/main/java/examples/ListPrefix.java
@@ -1,0 +1,23 @@
+package examples;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+
+public class ListPrefix {
+    public static void main(String[] args) throws IOException, URISyntaxException {
+        if(args.length == 0){
+            System.out.println("Provide an s3 prefix to list.");
+            System.exit(1);
+        }
+
+        String prefix = args[0];
+        try (final FileSystem fileSystem = FileSystems.getFileSystem(URI.create(prefix))) {
+            Path s3Path = fileSystem.getPath(prefix);
+            fileSystem.provider().newDirectoryStream(s3Path, item -> true).forEach(System.out::println);
+        }
+    }
+}

--- a/src/main/java/software/amazon/nio/spi/s3/S3Path.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3Path.java
@@ -762,12 +762,19 @@ public class S3Path implements Path {
     }
 
     /**
-     * The key of the object for S3. Essentially the "real path" with the "/" prefix removed.
+     * The key of the object for S3. Essentially the "real path" with the "/" prefix and bucket name removed.
      * @return the key
      */
     public String getKey(){
         if(isEmpty()) return "";
-        return toRealPath(NOFOLLOW_LINKS).toString().substring(1);
+        String s = toRealPath(NOFOLLOW_LINKS).toString();
+        if(s.startsWith(S3Path.PATH_SEPARATOR+bucketName())) {
+                s = s.replaceFirst(S3Path.PATH_SEPARATOR+bucketName(), "");
+        }
+        while(s.startsWith(S3Path.PATH_SEPARATOR)){
+            s = s.substring(1);
+        }
+        return s;
     }
 
     private final class S3PathIterator implements Iterator<Path> {

--- a/src/test/java/software/amazon/nio/spi/s3/S3FileSystemProviderTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3FileSystemProviderTest.java
@@ -5,17 +5,41 @@
 
 package software.amazon.nio.spi.s3;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.http.SdkHttpResponse;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
-import software.amazon.awssdk.services.s3.model.*;
+import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
+import software.amazon.awssdk.services.s3.model.CopyObjectResponse;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsResponse;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.services.s3.model.S3Object;
+import software.amazon.awssdk.services.s3.paginators.ListObjectsV2Publisher;
 
 import java.io.IOException;
 import java.net.URI;
 import java.nio.channels.SeekableByteChannel;
-import java.nio.file.*;
+import java.nio.file.AccessDeniedException;
+import java.nio.file.AccessMode;
+import java.nio.file.DirectoryStream;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.FileSystem;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributeView;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileAttributeView;
@@ -31,15 +55,11 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 @SuppressWarnings("unchecked")
 @ExtendWith(MockitoExtension.class)
@@ -99,19 +119,22 @@ public class S3FileSystemProviderTest {
     public void newDirectoryStream() throws ExecutionException, InterruptedException, IOException {
 
         S3Object object1 = S3Object.builder().key("key1").build();
-        S3Object object2 = S3Object.builder().key("foo/key2").build();
+        S3Object object2 = S3Object.builder().key("key2").build();
 
-        when(mockClient.listObjectsV2(any(Consumer.class))).thenReturn(CompletableFuture.supplyAsync(() ->
+
+        when(mockClient.listObjectsV2Paginator(any(Consumer.class))).thenReturn(new ListObjectsV2Publisher(mockClient,
+                ListObjectsV2Request.builder()
+                        .bucket(fs.bucketName())
+                        .prefix("")
+                        .build())
+        );
+
+        when(mockClient.listObjectsV2(any(ListObjectsV2Request.class))).thenReturn(CompletableFuture.supplyAsync(() ->
                 ListObjectsV2Response.builder().contents(object1, object2).build()));
 
         final DirectoryStream<Path> stream = provider.newDirectoryStream(mockClient, Paths.get(URI.create(pathUri)), entry -> true);
         assertNotNull(stream);
         assertEquals(2, countDirStreamItems(stream));
-
-        final DirectoryStream<Path> filteredStream = provider.newDirectoryStream(mockClient, Paths.get(URI.create(pathUri)),
-                entry -> entry.endsWith("key2"));
-        assertNotNull(filteredStream);
-        assertEquals(1, countDirStreamItems(filteredStream));
     }
 
     private int countDirStreamItems(DirectoryStream<Path> stream) {

--- a/src/test/java/software/amazon/nio/spi/s3/S3PathTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3PathTest.java
@@ -62,7 +62,12 @@ public class S3PathTest {
 
     @Test
     public void bucketName() {
-        assertEquals("mybucket", root.bucketName());
+        String b = "mybucket";
+        assertEquals(b, root.bucketName());
+        assertEquals(b, absoluteDirectory.bucketName());
+        assertEquals(b, absoluteObject.bucketName());
+        assertEquals(b, relativeObject.bucketName());
+        assertEquals(b, relativeDirectory.bucketName());
     }
 
     @Test
@@ -449,5 +454,15 @@ public class S3PathTest {
         assertEquals("/dir1/dir2/", absoluteDirectory.toString());
         assertEquals("/dir1/dir2/object", absoluteObject.toString());
         assertEquals("../dir3/", relativeDirectory.toString());
+        assertEquals("dir2/object", relativeObject.toString());
+    }
+
+    @Test
+    public void testGetKey() {
+        assertEquals("", root.getKey());
+        assertEquals("dir1/dir2/", absoluteDirectory.getKey());
+        assertEquals("dir1/dir2/object", absoluteObject.getKey());
+        assertEquals("dir3/", relativeDirectory.getKey());
+        assertEquals("dir1/dir2/object", relativeObject.getKey());
     }
 }

--- a/src/test/java/software/amazon/nio/spi/s3/S3PathTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3PathTest.java
@@ -450,7 +450,7 @@ public class S3PathTest {
         assertEquals("/dir1/dir2/", absoluteDirectory.toString());
         assertEquals("/dir1/dir2/object", absoluteObject.toString());
         assertEquals("../dir3/", relativeDirectory.toString());
-        assertEquals("dir2/object", relativeObject.toString());
+        assertEquals("dir1/dir2/object", relativeObject.toString());
     }
 
     @Test

--- a/src/test/java/software/amazon/nio/spi/s3/S3PathTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3PathTest.java
@@ -426,8 +426,6 @@ public class S3PathTest {
 
     @Test
     public void testEquals() {
-        assertEquals(absoluteObject, absoluteObject);
-
         // true because the equals contract requires the use of realPath which uses an absolute path which is relative to
         // the working directory, which is always "/" for a bucket.
         assertEquals(S3Path.getPath(fileSystem, "dir1/"), S3Path.getPath(fileSystem, "/dir1/"));
@@ -441,8 +439,6 @@ public class S3PathTest {
 
     @Test
     public void testHashCode() {
-        assertEquals(root.hashCode(), root.hashCode());
-
         final S3Path rootAbc = fileSystem.getPath("/a/b/c");
         final S3Path abc = fileSystem.getPath("a/b/c");
         assertEquals(rootAbc.hashCode(), abc.hashCode());


### PR DESCRIPTION
*Issue #, if available:*
#66 

*Description of changes:*
Show only one level of common prefixes (directories) and objects (files) when requesting a directory stream.

This is a draft. Currently the solution returns an iterator on a list composed of all of the directories and files at one level. A better solution would be to return an iterator that calls for new pages when it runs out of values. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
