### PR TITLE
Fix for getRootDirectories()

### DIFF
--- a/src/main/java/software/amazon/nio/spi/s3/S3FileSystem.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3FileSystem.java
@@ -12,7 +12,16 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.channels.Channel;
-import java.nio.file.*;
+import java.nio.file.ClosedFileSystemException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.FileStore;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.nio.file.WatchService;
 import java.nio.file.attribute.UserPrincipalLookupService;
 import java.nio.file.spi.FileSystemProvider;
 import java.util.Collections;
@@ -182,7 +191,7 @@ public class S3FileSystem extends FileSystem {
      */
     @Override
     public Iterable<Path> getRootDirectories() {
-        return S3Path.getPath(this, "/");
+        return Collections.singleton(S3Path.getPath(this, "/"));
     }
 
     /**

--- a/src/test/java/software/amazon/nio/spi/s3/S3FileSystemTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3FileSystemTest.java
@@ -13,8 +13,12 @@ import java.net.URI;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
 import java.util.Collections;
+import java.util.Iterator;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class S3FileSystemTest {
     S3FileSystemProvider provider;
@@ -60,8 +64,12 @@ public class S3FileSystemTest {
     public void getRootDirectories() {
         final Iterable<Path> rootDirectories = s3FileSystem.getRootDirectories();
         assertNotNull(rootDirectories);
-        assertEquals(S3Path.PATH_SEPARATOR, rootDirectories.toString());
-        assertFalse(s3FileSystem.getRootDirectories().iterator().hasNext());
+
+        final Iterator<Path> rootDirectoriesIterator = rootDirectories.iterator();
+
+        assertTrue(rootDirectoriesIterator.hasNext());
+        assertEquals(S3Path.PATH_SEPARATOR, rootDirectoriesIterator.next().toString());
+        assertFalse(rootDirectoriesIterator.hasNext());
     }
 
     @Test


### PR DESCRIPTION
*Issue #, if available:*
#35 

*Description of changes:*
changed `getRootDirectories()` implementation to return a singleton list of the root `/` rather than the path itself (which is also iterable).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
