### PR TITLE
Adding AssertJ (issue #59)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,14 @@
 # Ignore Gradle project-specific cache directory
 .gradle
 .idea
+.vscode
 gradle
 gradle.properties
 
 # Ignore Gradle build output directory
 build
+bin
+target
 
 #MacOS
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,18 @@
 # Ignore Gradle project-specific cache directory
 .gradle
 .idea
-.vscode
 gradle
 gradle.properties
 
 # Ignore Gradle build output directory
 build
 bin
+
+# Ignore maven build output
 target
 
-#MacOS
+# Ignore other IDEs files
+.vscode
+
+# MacOS
 .DS_Store

--- a/THIRD-PARTY
+++ b/THIRD-PARTY
@@ -1,6 +1,7 @@
 The Amazon AWS Java NIO SPI for S3 Product includes the following third-party software/licensing:
 
 ** Junit 4.x -- https://junit.org/junit4/
+** AssertJ 3.x -- https://assertj.github.io/
 ** Logback Classic 1.2.x -- https://logback.qos.ch/ -- Copyright © 2021 QOS.ch
 ** Logback Core 1.2.x -- https://logback.qos.ch/ -- Copyright © 2021 QOS.ch
 

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ java {
 
 compileJava {
     // see https://docs.gradle.org/6.6/userguide/building_java_projects.html#sec:java_cross_compilation
-    options.release = 16
+    options.release = 11
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ java {
 
 compileJava {
     // see https://docs.gradle.org/6.6/userguide/building_java_projects.html#sec:java_cross_compilation
-    options.release = 11
+    options.release = 1.8
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -25,8 +25,8 @@ archivesBaseName = 'nio-spi-for-s3'
 version = '1.2.3'
 
 apply plugin: 'java'
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 16
+targetCompatibility = 16
 
 
 java {
@@ -36,7 +36,7 @@ java {
 
 compileJava {
     // see https://docs.gradle.org/6.6/userguide/building_java_projects.html#sec:java_cross_compilation
-    options.release = 8
+    options.release = 16
 }
 
 dependencies {
@@ -46,6 +46,7 @@ dependencies {
     // Use JUnit test framework.
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:5.4.0'
+    testImplementation 'org.assertj:assertj-core:3.24.2'
 
     implementation platform('software.amazon.awssdk:bom:2.20.99')
 

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ java {
 
 compileJava {
     // see https://docs.gradle.org/6.6/userguide/building_java_projects.html#sec:java_cross_compilation
-    options.release = 1.8
+    options.release = 8
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -25,8 +25,8 @@ archivesBaseName = 'nio-spi-for-s3'
 version = '1.2.3'
 
 apply plugin: 'java'
-sourceCompatibility = 16
-targetCompatibility = 16
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 
 java {
@@ -46,7 +46,6 @@ dependencies {
     // Use JUnit test framework.
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:5.4.0'
-    testImplementation 'org.assertj:assertj-core:3.24.2'
 
     implementation platform('software.amazon.awssdk:bom:2.20.99')
 

--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,7 @@ dependencies {
     // Use JUnit test framework.
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:5.4.0'
+    testImplementation 'org.assertj:assertj-core:3.24.2'
 
     implementation platform('software.amazon.awssdk:bom:2.20.99')
 

--- a/src/test/java/software/amazon/nio/spi/s3/config/S3NioSpiConfigurationTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/config/S3NioSpiConfigurationTest.java
@@ -11,6 +11,9 @@ import org.junit.Test;
 import java.util.Properties;
 
 import static org.junit.Assert.*;
+import static org.assertj.core.api.BDDAssertions.then;
+
+import static software.amazon.nio.spi.s3.config.S3NioSpiConfiguration.*;
 
 public class S3NioSpiConfigurationTest {
 
@@ -22,29 +25,35 @@ public class S3NioSpiConfigurationTest {
 
     @Before
     public void setup(){
-        overrides.setProperty(S3NioSpiConfiguration.S3_SPI_READ_MAX_FRAGMENT_SIZE_PROPERTY, "1111");
-        overrides.setProperty(S3NioSpiConfiguration.S3_SPI_READ_MAX_FRAGMENT_NUMBER_PROPERTY, "2");
+        overrides.setProperty(S3_SPI_READ_MAX_FRAGMENT_SIZE_PROPERTY, "1111");
+        overrides.setProperty(S3_SPI_READ_MAX_FRAGMENT_NUMBER_PROPERTY, "2");
         overriddenConfig = new S3NioSpiConfiguration(overrides);
 
-        badOverrides.setProperty(S3NioSpiConfiguration.S3_SPI_READ_MAX_FRAGMENT_NUMBER_PROPERTY, "abcd");
-        badOverrides.setProperty(S3NioSpiConfiguration.S3_SPI_READ_MAX_FRAGMENT_SIZE_PROPERTY, "abcd");
+        badOverrides.setProperty(S3_SPI_READ_MAX_FRAGMENT_NUMBER_PROPERTY, "abcd");
+        badOverrides.setProperty(S3_SPI_READ_MAX_FRAGMENT_SIZE_PROPERTY, "abcd");
         badOverriddenConfig = new S3NioSpiConfiguration(badOverrides);
     }
 
     @Test
+    public void constructors() {
+        then(String.valueOf(config.getMaxFragmentNumber())).isEqualTo(S3_SPI_READ_MAX_FRAGMENT_NUMBER_DEFAULT);
+        then(String.valueOf(config.getMaxFragmentSize())).isEqualTo(S3_SPI_READ_MAX_FRAGMENT_SIZE_DEFAULT);
+    }
+
+    @Test
     public void getS3SpiReadMaxFragmentSize() {
-        assertEquals(Integer.parseInt(S3NioSpiConfiguration.S3_SPI_READ_MAX_FRAGMENT_SIZE_DEFAULT), config.getMaxFragmentSize());
+        assertEquals(Integer.parseInt(S3_SPI_READ_MAX_FRAGMENT_SIZE_DEFAULT), config.getMaxFragmentSize());
 
         assertEquals(1111, overriddenConfig.getMaxFragmentSize());
-        assertEquals(Integer.parseInt(S3NioSpiConfiguration.S3_SPI_READ_MAX_FRAGMENT_SIZE_DEFAULT), badOverriddenConfig.getMaxFragmentSize());
+        assertEquals(Integer.parseInt(S3_SPI_READ_MAX_FRAGMENT_SIZE_DEFAULT), badOverriddenConfig.getMaxFragmentSize());
     }
 
     @Test
     public void getS3SpiReadMaxFragmentNumber() {
-        assertEquals(Integer.parseInt(S3NioSpiConfiguration.S3_SPI_READ_MAX_FRAGMENT_NUMBER_DEFAULT), config.getMaxFragmentNumber());
+        assertEquals(Integer.parseInt(S3_SPI_READ_MAX_FRAGMENT_NUMBER_DEFAULT), config.getMaxFragmentNumber());
 
         assertEquals(2, overriddenConfig.getMaxFragmentNumber());
-        assertEquals(Integer.parseInt(S3NioSpiConfiguration.S3_SPI_READ_MAX_FRAGMENT_NUMBER_DEFAULT), badOverriddenConfig.getMaxFragmentNumber());
+        assertEquals(Integer.parseInt(S3_SPI_READ_MAX_FRAGMENT_NUMBER_DEFAULT), badOverriddenConfig.getMaxFragmentNumber());
     }
 
     @Test


### PR DESCRIPTION
*Issue #59 *

*Description of changes:*
- Adding AssertJ
- Bumping java to 16 otherwise I had an error with logback
- added some more builder/IDE files to ignore

As an example of using assertj, I changed S3SpiConfigurationTest

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
