### PR TITLE
Fixes for newDirectoryStream issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -116,6 +116,7 @@ javadoc {
 }
 
 test {
+    useJUnitPlatform()
     finalizedBy jacocoTestReport
 }
 

--- a/src/main/java/examples/ListPrefix.java
+++ b/src/main/java/examples/ListPrefix.java
@@ -17,7 +17,9 @@ public class ListPrefix {
         String prefix = args[0];
         try (final FileSystem fileSystem = FileSystems.getFileSystem(URI.create(prefix))) {
             Path s3Path = fileSystem.getPath(prefix);
-            fileSystem.provider().newDirectoryStream(s3Path, item -> true).forEach(System.out::println);
+            fileSystem.provider()
+                    .newDirectoryStream(s3Path, item -> true)
+                    .forEach(path -> System.out.println(path.getFileName()));
         }
     }
 }

--- a/src/main/java/examples/WalkFromRoot.java
+++ b/src/main/java/examples/WalkFromRoot.java
@@ -1,0 +1,28 @@
+package examples;
+
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class WalkFromRoot {
+
+    /**
+     * Walks a bucket from the root listing all directories and files. Internally uses the {@code S3FileSystemProvider}'s
+     * {@code newDirectoryStream()} method which uses asynchronous paginated calls to S3.
+     *
+     * @param args provide a bucket name to walk
+     * @throws IOException if a communication problem happens with the S3 service.
+     */
+    public static void main(String[] args) throws IOException {
+        final String bucketName = args[0];
+        final FileSystem s3 = FileSystems.getFileSystem(URI.create("s3://"+bucketName));
+
+        for (Path rootDir : s3.getRootDirectories()) {
+            Files.walk(rootDir).forEach(System.out::println);
+        }
+    }
+}

--- a/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
@@ -286,7 +286,35 @@ public class S3FileSystemProvider extends FileSystemProvider {
                 .prefix(finalDirName)
                 .delimiter(S3Path.PATH_SEPARATOR));
 
-        final Iterator<Path> iterator = Flowable.fromPublisher(listObjectsV2Publisher)
+        final Iterator<Path> iterator = pathIteratorForPublisher(filter, fs, finalDirName, listObjectsV2Publisher);
+
+        return new DirectoryStream<Path>() {
+            @Override
+            public void close() throws IOException {
+            }
+
+            @Override
+            public Iterator<Path> iterator() {
+                return iterator;
+            }
+        };
+    }
+
+    /**
+     * Get an iterator for a {@ListObjectsV2Publisher}. This method is protected level access only for testing
+     * purposes. It is not intended to be used by any other code outside of this class.
+     * @param filter a filter to apply to returned Paths. Only accepted paths will be included.
+     * @param fs the Filesystem.
+     * @param finalDirName the directory name that will be streamed.
+     * @param listObjectsV2Publisher the publisher that returns objects and common prefixes that are iterated on.
+     * @return an iterator for {@code Path}s constructed from the {@ListObjectsV2Publisher}s responses.
+     */
+    protected Iterator<Path> pathIteratorForPublisher(
+            final DirectoryStream.Filter<? super Path> filter,
+            final FileSystem fs, String finalDirName,
+            final ListObjectsV2Publisher listObjectsV2Publisher) {
+
+        return Flowable.fromPublisher(listObjectsV2Publisher)
                 .flatMapIterable(response -> {
 
                     //add common prefixes from this page
@@ -317,17 +345,6 @@ public class S3FileSystemProvider extends FileSystemProvider {
                 .blockingStream()
                 .map(Path.class::cast) // upcast to Path from S3Path
                 .iterator();
-
-        return new DirectoryStream<Path>() {
-            @Override
-            public void close() throws IOException {
-            }
-
-            @Override
-            public Iterator<Path> iterator() {
-                return iterator;
-            }
-        };
     }
 
     /**

--- a/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
@@ -301,13 +301,13 @@ public class S3FileSystemProvider extends FileSystemProvider {
     }
 
     /**
-     * Get an iterator for a {@ListObjectsV2Publisher}. This method is protected level access only for testing
+     * Get an iterator for a {@code ListObjectsV2Publisher}. This method is protected level access only for testing
      * purposes. It is not intended to be used by any other code outside of this class.
      * @param filter a filter to apply to returned Paths. Only accepted paths will be included.
      * @param fs the Filesystem.
      * @param finalDirName the directory name that will be streamed.
      * @param listObjectsV2Publisher the publisher that returns objects and common prefixes that are iterated on.
-     * @return an iterator for {@code Path}s constructed from the {@ListObjectsV2Publisher}s responses.
+     * @return an iterator for {@code Path}s constructed from the {@code ListObjectsV2Publisher}s responses.
      */
     protected Iterator<Path> pathIteratorForPublisher(
             final DirectoryStream.Filter<? super Path> filter,

--- a/src/main/java/software/amazon/nio/spi/s3/S3Path.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3Path.java
@@ -10,7 +10,14 @@ import software.amazon.awssdk.services.s3.model.S3Object;
 import java.io.File;
 import java.io.IOError;
 import java.net.URI;
-import java.nio.file.*;
+import java.nio.file.FileSystem;
+import java.nio.file.InvalidPathException;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.ProviderMismatchException;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -748,7 +755,7 @@ public class S3Path implements Path {
      */
     @Override
     public int hashCode() {
-        return toRealPath(NOFOLLOW_LINKS).pathRepresentation.hashCode();
+        return this.bucketName().hashCode() + toRealPath(NOFOLLOW_LINKS).pathRepresentation.hashCode();
     }
 
     /**

--- a/src/test/java/software/amazon/nio/spi/s3/S3FileSystemProviderTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3FileSystemProviderTest.java
@@ -5,24 +5,48 @@
 
 package software.amazon.nio.spi.s3;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.http.SdkHttpResponse;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
-import software.amazon.awssdk.services.s3.model.*;
+import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
+import software.amazon.awssdk.services.s3.model.CopyObjectResponse;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsResponse;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.services.s3.model.S3Object;
 import software.amazon.awssdk.services.s3.paginators.ListObjectsV2Publisher;
 
 import java.io.IOException;
 import java.net.URI;
 import java.nio.channels.SeekableByteChannel;
-import java.nio.file.*;
+import java.nio.file.AccessDeniedException;
+import java.nio.file.AccessMode;
+import java.nio.file.DirectoryStream;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.FileSystem;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributeView;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileAttributeView;
 import java.nio.file.attribute.FileTime;
 import java.time.Instant;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -32,15 +56,11 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 @SuppressWarnings("unchecked")
 @ExtendWith(MockitoExtension.class)
@@ -92,23 +112,81 @@ public class S3FileSystemProviderTest {
     @Test
     public void newDirectoryStream() throws ExecutionException, InterruptedException {
 
-        S3Object object1 = S3Object.builder().key("key1").build();
-        S3Object object2 = S3Object.builder().key("key2").build();
-
+        S3Object object1 = S3Object.builder().key(pathUri+"/key1").build();
+        S3Object object2 = S3Object.builder().key(pathUri+"/key2").build();
 
         when(mockClient.listObjectsV2Paginator(any(Consumer.class))).thenReturn(new ListObjectsV2Publisher(mockClient,
                 ListObjectsV2Request.builder()
                         .bucket(fs.bucketName())
-                        .prefix("")
+                        .prefix(pathUri + "/")
                         .build())
         );
 
         when(mockClient.listObjectsV2(any(ListObjectsV2Request.class))).thenReturn(CompletableFuture.supplyAsync(() ->
                 ListObjectsV2Response.builder().contents(object1, object2).build()));
 
-        final DirectoryStream<Path> stream = provider.newDirectoryStream(mockClient, Paths.get(URI.create(pathUri)), entry -> true);
+        final DirectoryStream<Path> stream = provider.newDirectoryStream(mockClient, Paths.get(URI.create(pathUri+"/")), entry -> true);
         assertNotNull(stream);
         assertEquals(2, countDirStreamItems(stream));
+    }
+
+    /**
+     * Tests core functionality of the path iterator used by the directory stream.
+     */
+    @Test
+    public void pathIteratorForPublisher() {
+        final ListObjectsV2Publisher publisher = new ListObjectsV2Publisher(mockClient,
+                ListObjectsV2Request.builder()
+                        .bucket(fs.bucketName())
+                        .prefix(pathUri + "/")
+                        .build());
+        S3Object object1 = S3Object.builder().key(pathUri+"/key1").build();
+        S3Object object2 = S3Object.builder().key(pathUri+"/key2").build();
+        S3Object object3 = S3Object.builder().key(pathUri+"/").build();
+
+        when(mockClient.listObjectsV2(any(ListObjectsV2Request.class))).thenReturn(CompletableFuture.supplyAsync(() ->
+                ListObjectsV2Response.builder().contents(object1, object2, object3).build()));
+
+        final Iterator<Path> pathIterator = provider.pathIteratorForPublisher(
+                path -> true,
+                fs,
+                pathUri+"/",
+                publisher);
+
+        assertNotNull(pathIterator);
+        assertTrue(pathIterator.hasNext());
+        assertEquals(fs.getPath(object1.key()), pathIterator.next());
+        assertTrue(pathIterator.hasNext());
+        assertEquals(fs.getPath(object2.key()), pathIterator.next());
+        // object3 should not be present
+        assertFalse(pathIterator.hasNext());
+    }
+
+    @Test
+    public void pathIteratorForPublisher_appliesFilter() {
+        final ListObjectsV2Publisher publisher = new ListObjectsV2Publisher(mockClient,
+                ListObjectsV2Request.builder()
+                        .bucket(fs.bucketName())
+                        .prefix(pathUri + "/")
+                        .build());
+        S3Object object1 = S3Object.builder().key(pathUri+"/key1").build();
+        S3Object object2 = S3Object.builder().key(pathUri+"/key2").build();
+        S3Object object3 = S3Object.builder().key(pathUri+"/").build();
+
+        when(mockClient.listObjectsV2(any(ListObjectsV2Request.class))).thenReturn(CompletableFuture.supplyAsync(() ->
+                ListObjectsV2Response.builder().contents(object1, object2, object3).build()));
+
+        final Iterator<Path> pathIterator = provider.pathIteratorForPublisher(
+                path -> path.toString().endsWith("key2"),
+                fs,
+                pathUri+"/",
+                publisher);
+
+        assertNotNull(pathIterator);
+        assertTrue(pathIterator.hasNext());
+        assertEquals(fs.getPath(object2.key()), pathIterator.next());
+        // object3 and object1 should not be present
+        assertFalse(pathIterator.hasNext());
     }
 
     private int countDirStreamItems(DirectoryStream<Path> stream) {


### PR DESCRIPTION
*Issue #, if available:*

#96 

*Description of changes:*

Fixed behavior of `S3FileSystemProvider.newDirectoryStream` so that it behaves as expected.

Some example test applications are added with `examples/ListPrefix and `examples/WalkFromRoot`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
