### PR TITLE
Implementing fluent initialization/setting of S3NioSpiConfiguration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:5.4.0'
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'org.mockito:mockito-junit-jupiter:5.4.0'
-
+    testImplementation 'com.github.stefanbirkner:system-lambda:1.2.1'
 
     implementation platform('software.amazon.awssdk:bom:2.20.102')
 

--- a/src/main/java/software/amazon/nio/spi/s3/config/S3NioSpiConfiguration.java
+++ b/src/main/java/software/amazon/nio/spi/s3/config/S3NioSpiConfiguration.java
@@ -240,15 +240,6 @@ public class S3NioSpiConfiguration extends HashMap<String, Object> {
      * @return this instance
      */
     public S3NioSpiConfiguration withCredentials(AwsCredentials credentials) {
-        //
-        // We do not store the credentials object directly for consistency with
-        // the other settings and to kee 1:1 relationship between the defined
-        // properties and the content of this map
-        //
-        if (credentials == null) {
-            return withCredentials(null, null);
-        }
-
         return withCredentials(credentials.accessKeyId(), credentials.secretAccessKey());
     }
 

--- a/src/main/java/software/amazon/nio/spi/s3/config/S3NioSpiConfiguration.java
+++ b/src/main/java/software/amazon/nio/spi/s3/config/S3NioSpiConfiguration.java
@@ -25,7 +25,7 @@ import software.amazon.nio.spi.s3.util.StringUtils;
 /**
  * Object to hold configuration of the S3 NIO SPI
  */
-public class S3NioSpiConfiguration extends HashMap<String, String> {
+public class S3NioSpiConfiguration extends HashMap<String, Object> {
 
     public static final String AWS_REGION_PROPERTY = "aws.region";
     public static final String AWS_ACCESS_KEY_PROPERTY = "aws.accessKey";
@@ -63,6 +63,11 @@ public class S3NioSpiConfiguration extends HashMap<String, String> {
      * The default value of the endpoint protocol property
      */
     public static final String S3_SPI_ENDPOINT_PROTOCOL_DEFAULT = "https";
+
+    /**
+     * The default value of the endpoint protocol property
+     */
+    public static final String S3_SPI_CREDENTIALS_PROPERTY = "s3.spi.credentials";
 
     private final Pattern ENDPOINT_REGEXP = Pattern.compile("(\\w[\\w\\-\\.]*)(?::(\\d+))");
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
@@ -275,7 +280,7 @@ public class S3NioSpiConfiguration extends HashMap<String, String> {
      * @return the configured value or the default ("") if not overridden
      */
     public String getEndpoint() {
-        return getOrDefault(S3_SPI_ENDPOINT_PROPERTY, S3_SPI_ENDPOINT_DEFAULT);
+        return (String)getOrDefault(S3_SPI_ENDPOINT_PROPERTY, S3_SPI_ENDPOINT_DEFAULT);
     }
 
     /**
@@ -283,7 +288,7 @@ public class S3NioSpiConfiguration extends HashMap<String, String> {
      * @return the configured value or the default if not overridden
      */
     public String getEndpointProtocol() {
-        String protocol = getOrDefault(S3_SPI_ENDPOINT_PROTOCOL_PROPERTY, S3_SPI_ENDPOINT_PROTOCOL_DEFAULT);
+        String protocol = (String)getOrDefault(S3_SPI_ENDPOINT_PROTOCOL_PROPERTY, S3_SPI_ENDPOINT_PROTOCOL_DEFAULT);
         if ("http".equalsIgnoreCase(protocol) || "https".equalsIgnoreCase(protocol)) {
             return protocol;
         }
@@ -299,8 +304,8 @@ public class S3NioSpiConfiguration extends HashMap<String, String> {
     public AwsCredentials getCredentials() {
         if (containsKey(AWS_ACCESS_KEY_PROPERTY)) {
             return AwsBasicCredentials.create(
-                get(AWS_ACCESS_KEY_PROPERTY),
-                get(AWS_SECRET_ACCESS_KEY_PROPERTY)
+                (String)get(AWS_ACCESS_KEY_PROPERTY),
+                (String)get(AWS_SECRET_ACCESS_KEY_PROPERTY)
            );
         }
 
@@ -313,10 +318,8 @@ public class S3NioSpiConfiguration extends HashMap<String, String> {
      * @return the configured value or null if not provided
      */
     public String getRegion() {
-        return get(AWS_REGION_PROPERTY);
+        return (String)get(AWS_REGION_PROPERTY);
     }
-
-    // ------------------------------------------------------- protected methods
 
     /**
      * Generates an environment variable name from a property name. E.g 'some.property' becomes 'SOME_PROPERTY'
@@ -332,10 +335,8 @@ public class S3NioSpiConfiguration extends HashMap<String, String> {
                 .toUpperCase(Locale.ROOT);
     }
 
-    // --------------------------------------------------------- private methods
-
     private int parseIntProperty(String propName, int defaultVal){
-        String propertyVal = get(propName);
+        String propertyVal = (String)get(propName);
         try{
             return Integer.parseInt(propertyVal);
         } catch (NumberFormatException e){

--- a/src/main/java/software/amazon/nio/spi/s3/config/S3NioSpiConfiguration.java
+++ b/src/main/java/software/amazon/nio/spi/s3/config/S3NioSpiConfiguration.java
@@ -292,10 +292,9 @@ public class S3NioSpiConfiguration extends HashMap<String, Object> {
     /**
      * Get the configured credentials. Note that credentials can be provided in
      * two ways:
-     * <nl>
-     * <li>{@code withCredentials(String accessKey, String secretAcccessKey)}
-     * <li>{@code withCredentials(AwsCredentials credentials)}
-     * </nl>
+     * 
+     * 1. {@code withCredentials(String accessKey, String secretAcccessKey)}
+     * 2. {@code withCredentials(AwsCredentials credentials)}
      *
      * The latter takes the priority, so if both are used, {@code getCredentials()}
      * returns the most complete object, which is the value of the property

--- a/src/main/java/software/amazon/nio/spi/s3/config/S3NioSpiConfiguration.java
+++ b/src/main/java/software/amazon/nio/spi/s3/config/S3NioSpiConfiguration.java
@@ -6,19 +6,30 @@
 package software.amazon.nio.spi.s3.config;
 
 
+import java.util.HashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import software.amazon.awssdk.utils.Pair;
 
 import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.regex.Pattern;
+import software.amazon.awssdk.utils.Pair;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+
+import software.amazon.nio.spi.s3.util.StringUtils;
 
 /**
  * Object to hold configuration of the S3 NIO SPI
  */
-public class S3NioSpiConfiguration {
+public class S3NioSpiConfiguration extends HashMap<String, String> {
+
+    public static final String AWS_REGION_PROPERTY = "aws.region";
+    public static final String AWS_ACCESS_KEY_PROPERTY = "aws.accessKey";
+    public static final String AWS_SECRET_ACCESS_KEY_PROPERTY = "aws.secretAccessKey";
 
     /**
      * The name of the maximum fragment size property
@@ -27,7 +38,7 @@ public class S3NioSpiConfiguration {
     /**
      * The default value of the maximum fragment size property
      */
-    public static final String S3_SPI_READ_MAX_FRAGMENT_SIZE_DEFAULT = "5242880";
+    public static final int S3_SPI_READ_MAX_FRAGMENT_SIZE_DEFAULT = 5242880;
     /**
      * The name of the maximum fragment number property
      */
@@ -35,47 +46,189 @@ public class S3NioSpiConfiguration {
     /**
      * The default value of the maximum fragment size property
      */
-    public static final String S3_SPI_READ_MAX_FRAGMENT_NUMBER_DEFAULT = "50";
+    public static final int S3_SPI_READ_MAX_FRAGMENT_NUMBER_DEFAULT = 50;
+    /**
+     * The name of the endpoint property
+     */
+    public static final String S3_SPI_ENDPOINT_PROPERTY = "s3.spi.endpoint";
+    /**
+     * The default value of the endpoint property
+     */
+    public static final String S3_SPI_ENDPOINT_DEFAULT = "";
+    /**
+     * The name of the endpoint protocol property
+     */
+    public static final String S3_SPI_ENDPOINT_PROTOCOL_PROPERTY = "s3.spi.endpoint-protocol";
+    /**
+     * The default value of the endpoint protocol property
+     */
+    public static final String S3_SPI_ENDPOINT_PROTOCOL_DEFAULT = "https";
 
-    private final Properties properties;
+    private final Pattern ENDPOINT_REGEXP = Pattern.compile("(\\w[\\w\\-\\.]*)(?::(\\d+))");
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
-
-    {
-        final Properties defaults = new Properties();
-        defaults.put(S3_SPI_READ_MAX_FRAGMENT_NUMBER_PROPERTY, S3_SPI_READ_MAX_FRAGMENT_NUMBER_DEFAULT);
-        defaults.put(S3_SPI_READ_MAX_FRAGMENT_SIZE_PROPERTY, S3_SPI_READ_MAX_FRAGMENT_SIZE_DEFAULT);
-
-        //setup defaults
-        properties = new Properties(defaults);
-
-        //add env var overrides if present
-        properties.stringPropertyNames().stream()
-                .map(key -> Pair.of(key,
-                        Optional.ofNullable(System.getenv().get(this.convertPropertyNameToEnvVar(key)))))
-                .forEach(pair -> pair.right().ifPresent(val -> properties.setProperty(pair.left(), val)));
-
-        //add System props as overrides if present
-        properties.stringPropertyNames()
-                .forEach(key -> Optional.ofNullable(System.getProperty(key))
-                        .ifPresent(val -> properties.put(key, val)));
-
-    }
 
     /**
      * Create a new, empty configuration
      */
     public S3NioSpiConfiguration(){
-        this(new Properties());
+        this(new HashMap<>());
+    }
+
+    /**
+     * Create a new, empty configuration
+     */
+    public S3NioSpiConfiguration(Map<String, ?> overrides) {
+        Objects.requireNonNull(overrides);
+
+        //
+        // setup defaults
+        //
+        put(S3_SPI_READ_MAX_FRAGMENT_NUMBER_PROPERTY, String .valueOf(S3_SPI_READ_MAX_FRAGMENT_NUMBER_DEFAULT));
+        put(S3_SPI_READ_MAX_FRAGMENT_SIZE_PROPERTY, String .valueOf(S3_SPI_READ_MAX_FRAGMENT_SIZE_DEFAULT));
+
+        //
+        // With the below we pick existing environment variables and system
+        // properties as overrides of the default aws-nio specific properties.
+        // We do not pick aws generic properties like aws.region or
+        // aws.accessKey, leaving the framework and the underlying AWS client
+        // the possibility to use the standard behaviour.
+        //
+        // TOTO: shall we return an Optional instead returning null?
+        // TOTO: shall we return an Optional instead returning null?
+        //
+
+        //add env var overrides if present
+        keySet().stream()
+                .map(key -> Pair.of(key,
+                        Optional.ofNullable(System.getenv().get(this.convertPropertyNameToEnvVar(key)))))
+                .forEach(pair -> pair.right().ifPresent(val -> put(pair.left(), val)));
+
+        //add System props as overrides if present
+        keySet().forEach(
+            key -> Optional.ofNullable(System.getProperty(key)).ifPresent(val -> put(key, val))
+        );
+
+        overrides.keySet().forEach(key -> put(key, String.valueOf(overrides.get(key))));
     }
 
     /**
      * Create a new configuration with overrides
      * @param overrides the overrides
      */
+    //
+    // TODO: to be removed if not used
+    //
     protected S3NioSpiConfiguration(Properties overrides) {
         Objects.requireNonNull(overrides);
         overrides.stringPropertyNames()
-                .forEach(key -> properties.setProperty(key, overrides.getProperty(key)));
+            .forEach(key -> put(key, overrides.getProperty(key)));
+    }
+
+    /**
+     * Fluently sets the value of maximum fragment number
+     *
+     * @param maxFragmentNumber the maximum fragment number
+     *
+     * @return this instance
+     */
+    public S3NioSpiConfiguration withMaxFragmentNumber(int maxFragmentNumber) {
+        if (maxFragmentNumber < 1) {
+            throw new IllegalArgumentException("maxFragmentNumber must be positive");
+        }
+        put(S3_SPI_READ_MAX_FRAGMENT_NUMBER_PROPERTY, String.valueOf(maxFragmentNumber));
+        return this;
+    }
+
+    /**
+     * Fluently sets the value of maximum fragment size
+     *
+     * @param maxFragmentSize the maximum fragment size
+     *
+     * @return this instance
+     */
+    public S3NioSpiConfiguration withMaxFragmentSize(int maxFragmentSize) {
+        if (maxFragmentSize < 1) {
+            throw new IllegalArgumentException("maxFragmentSize must be positive");
+        }
+        put(S3_SPI_READ_MAX_FRAGMENT_SIZE_PROPERTY, String.valueOf(maxFragmentSize));
+        return this;
+    }
+
+    /**
+     * Fluently sets the value of the endpoint
+     *
+     * @param endpoint the endpoint
+     *
+     * @return this instance
+     */
+    public S3NioSpiConfiguration withEndpoint(String endpoint) {
+
+        if (endpoint == null) {
+            endpoint = "";
+        }
+        endpoint = endpoint.trim();
+
+        if ((endpoint.length() > 0) && !ENDPOINT_REGEXP.matcher(endpoint).find()) {
+            throw new IllegalArgumentException(
+                String.format("endpoint '%s' does not match format host:port", endpoint)
+            );
+        }
+
+        put(S3_SPI_ENDPOINT_PROPERTY, endpoint); return this;
+    }
+
+    /**
+     * Fluently sets the value of the endpoint's protocol
+     *
+     * @param protocol the endpoint's protcol
+     *
+     * @return this instance
+     */
+    public S3NioSpiConfiguration withEndpointProtocol(String protocol) {
+        if (protocol != null) {
+            protocol = protocol.trim();
+        }
+        if (!"http".equals(protocol) && !"https".equals(protocol)) {
+            throw new IllegalArgumentException("endpoint prococol must be one of ('http', 'https')");
+        }
+        put(S3_SPI_ENDPOINT_PROTOCOL_PROPERTY, protocol); return this;
+    }
+
+    /**
+     * Fluently sets the value of the region
+     *
+     * @param region the region; if null or blank the property is removed
+     *
+     * @return this instance
+     */
+    public S3NioSpiConfiguration withRegion(String region) {
+        if ((region == null) || StringUtils.isBlank(region)) {
+            remove(AWS_REGION_PROPERTY);
+        } else {
+            put(AWS_REGION_PROPERTY, region.trim());
+        }
+
+        return this;
+    }
+
+    /**
+     * Fluently sets the value of accessKey and secretAccessKey
+     *
+     * @param accessKey the accesskey; if null, credentials are removed
+     * @param secretAccessKey the secretAccesskey; if accessKey is not null, it can not be null
+     *
+     * @return this instance
+     */
+    public S3NioSpiConfiguration withCredentials(String accessKey, String secretAccessKey) {
+        if (accessKey == null) {
+            remove(AWS_ACCESS_KEY_PROPERTY); remove(AWS_SECRET_ACCESS_KEY_PROPERTY);
+        } else {
+            if (secretAccessKey == null) {
+                throw new IllegalArgumentException("secretAccessKey can not be null");
+            }
+            put(AWS_ACCESS_KEY_PROPERTY, accessKey); put(AWS_SECRET_ACCESS_KEY_PROPERTY, secretAccessKey);
+        }
+        return this;
     }
 
     /**
@@ -83,8 +236,10 @@ public class S3NioSpiConfiguration {
      * @return the configured value or the default if not overridden
      */
     public int getMaxFragmentSize(){
-        return parseIntProperty(S3_SPI_READ_MAX_FRAGMENT_SIZE_PROPERTY,
-                Integer.parseInt(S3_SPI_READ_MAX_FRAGMENT_SIZE_DEFAULT));
+        return parseIntProperty(
+            S3_SPI_READ_MAX_FRAGMENT_SIZE_PROPERTY,
+            S3_SPI_READ_MAX_FRAGMENT_SIZE_DEFAULT
+        );
     }
 
     /**
@@ -92,20 +247,61 @@ public class S3NioSpiConfiguration {
      * @return the configured value or the default if not overridden
      */
     public int getMaxFragmentNumber(){
-        return parseIntProperty(S3_SPI_READ_MAX_FRAGMENT_NUMBER_PROPERTY,
-                Integer.parseInt(S3_SPI_READ_MAX_FRAGMENT_NUMBER_DEFAULT));
+        return parseIntProperty(
+            S3_SPI_READ_MAX_FRAGMENT_NUMBER_PROPERTY,
+            S3_SPI_READ_MAX_FRAGMENT_NUMBER_DEFAULT
+        );
     }
 
-    private int parseIntProperty(String propName, int defaultVal){
-        String propertyVal = properties.getProperty(propName);
-        try{
-            return Integer.parseInt(propertyVal);
-        } catch (NumberFormatException e){
-            logger.warn("the value of '{}' for '{}' is not an integer, using default value of '{}'",
-                    propertyVal, propName, defaultVal);
-            return defaultVal;
-        }
+    /**
+     * Get the value of the endpoint. Not that no endvar/sysprop is taken as
+     * default.
+     *
+     * @return the configured value or the default ("") if not overridden
+     */
+    public String getEndpoint() {
+        return getOrDefault(S3_SPI_ENDPOINT_PROPERTY, S3_SPI_ENDPOINT_DEFAULT);
     }
+
+    /**
+     * Get the value of the endpoint protocol
+     * @return the configured value or the default if not overridden
+     */
+    public String getEndpointProtocol() {
+        String protocol = getOrDefault(S3_SPI_ENDPOINT_PROTOCOL_PROPERTY, S3_SPI_ENDPOINT_PROTOCOL_DEFAULT);
+        if ("http".equalsIgnoreCase(protocol) || "https".equalsIgnoreCase(protocol)) {
+            return protocol;
+        }
+        logger.warn("the value of '{}' for '{}' is not 'http'|'https', using default value of '{}'",
+                    protocol, S3_SPI_ENDPOINT_PROTOCOL_PROPERTY, S3_SPI_ENDPOINT_PROTOCOL_DEFAULT);
+        return S3_SPI_ENDPOINT_PROTOCOL_DEFAULT;
+    }
+
+    /**
+     * Get the configured credentials
+     * @return the configured value or null if not provided
+     */
+    public AwsCredentials getCredentials() {
+        if (containsKey(AWS_ACCESS_KEY_PROPERTY)) {
+            return AwsBasicCredentials.create(
+                get(AWS_ACCESS_KEY_PROPERTY),
+                get(AWS_SECRET_ACCESS_KEY_PROPERTY)
+           );
+        }
+
+        return null;
+    }
+
+    /**
+     * Get the configured region if any
+     *
+     * @return the configured value or null if not provided
+     */
+    public String getRegion() {
+        return get(AWS_REGION_PROPERTY);
+    }
+
+    // ------------------------------------------------------- protected methods
 
     /**
      * Generates an environment variable name from a property name. E.g 'some.property' becomes 'SOME_PROPERTY'
@@ -119,5 +315,18 @@ public class S3NioSpiConfiguration {
                 .trim()
                 .replace('.', '_').replace('-', '_')
                 .toUpperCase(Locale.ROOT);
+    }
+
+    // --------------------------------------------------------- private methods
+
+    private int parseIntProperty(String propName, int defaultVal){
+        String propertyVal = get(propName);
+        try{
+            return Integer.parseInt(propertyVal);
+        } catch (NumberFormatException e){
+            logger.warn("the value of '{}' for '{}' is not an integer, using default value of '{}'",
+                    propertyVal, propName, defaultVal);
+            return defaultVal;
+        }
     }
 }

--- a/src/main/java/software/amazon/nio/spi/s3/config/S3NioSpiConfiguration.java
+++ b/src/main/java/software/amazon/nio/spi/s3/config/S3NioSpiConfiguration.java
@@ -220,6 +220,7 @@ public class S3NioSpiConfiguration extends HashMap<String, Object> {
      * @return this instance
      */
     public S3NioSpiConfiguration withCredentials(String accessKey, String secretAccessKey) {
+        AwsCredentials credentials = null;
         if (accessKey == null) {
             remove(AWS_ACCESS_KEY_PROPERTY); remove(AWS_SECRET_ACCESS_KEY_PROPERTY);
         } else {
@@ -227,7 +228,10 @@ public class S3NioSpiConfiguration extends HashMap<String, Object> {
                 throw new IllegalArgumentException("secretAccessKey can not be null");
             }
             put(AWS_ACCESS_KEY_PROPERTY, accessKey); put(AWS_SECRET_ACCESS_KEY_PROPERTY, secretAccessKey);
+            credentials = AwsBasicCredentials.create(accessKey, secretAccessKey);
         }
+        withCredentials(credentials);
+
         return this;
     }
 
@@ -240,7 +244,12 @@ public class S3NioSpiConfiguration extends HashMap<String, Object> {
      * @return this instance
      */
     public S3NioSpiConfiguration withCredentials(AwsCredentials credentials) {
-        return withCredentials(credentials.accessKeyId(), credentials.secretAccessKey());
+        if (credentials == null) {
+            remove(S3_SPI_CREDENTIALS_PROPERTY);
+        } else {
+            put(S3_SPI_CREDENTIALS_PROPERTY, credentials);
+        }
+        return this;
     }
 
     /**
@@ -292,7 +301,7 @@ public class S3NioSpiConfiguration extends HashMap<String, Object> {
     /**
      * Get the configured credentials. Note that credentials can be provided in
      * two ways:
-     * 
+     *
      * 1. {@code withCredentials(String accessKey, String secretAcccessKey)}
      * 2. {@code withCredentials(AwsCredentials credentials)}
      *

--- a/src/main/java/software/amazon/nio/spi/s3/config/S3NioSpiConfiguration.java
+++ b/src/main/java/software/amazon/nio/spi/s3/config/S3NioSpiConfiguration.java
@@ -93,9 +93,6 @@ public class S3NioSpiConfiguration extends HashMap<String, String> {
         // aws.accessKey, leaving the framework and the underlying AWS client
         // the possibility to use the standard behaviour.
         //
-        // TOTO: shall we return an Optional instead returning null?
-        // TOTO: shall we return an Optional instead returning null?
-        //
 
         //add env var overrides if present
         keySet().stream()
@@ -115,9 +112,6 @@ public class S3NioSpiConfiguration extends HashMap<String, String> {
      * Create a new configuration with overrides
      * @param overrides the overrides
      */
-    //
-    // TODO: to be removed if not used
-    //
     protected S3NioSpiConfiguration(Properties overrides) {
         Objects.requireNonNull(overrides);
         overrides.stringPropertyNames()
@@ -229,6 +223,27 @@ public class S3NioSpiConfiguration extends HashMap<String, String> {
             put(AWS_ACCESS_KEY_PROPERTY, accessKey); put(AWS_SECRET_ACCESS_KEY_PROPERTY, secretAccessKey);
         }
         return this;
+    }
+
+    /**
+     * Fluently sets the value of accessKey and secretAccessKey given a
+     * {@code AwsCredentials} object.
+     *
+     * @param credentials the credentials; if null, credentials are removed
+     *
+     * @return this instance
+     */
+    public S3NioSpiConfiguration withCredentials(AwsCredentials credentials) {
+        //
+        // We do not store the credentials object directly for consistency with
+        // the other settings and to kee 1:1 relationship between the defined
+        // properties and the content of this map
+        //
+        if (credentials == null) {
+            return withCredentials(null, null);
+        }
+
+        return withCredentials(credentials.accessKeyId(), credentials.secretAccessKey());
     }
 
     /**

--- a/src/main/java/software/amazon/nio/spi/s3/util/StringUtils.java
+++ b/src/main/java/software/amazon/nio/spi/s3/util/StringUtils.java
@@ -4,33 +4,52 @@
  */
 package software.amazon.nio.spi.s3.util;
 
-import software.amazon.nio.spi.s3.S3Path;
+import java.util.StringJoiner;
 
 /**
  *
  */
 public class StringUtils {
-    public static String join(String separator, String[] elements, int startAt) {
-        StringBuilder sb = new StringBuilder();
+    /**
+     * Join method to join multiple elements starting from the element with
+     * index {@code startAt}. Elements are joined with the provided
+     * {@code delimiter} in between them. Elements with index less then
+     * {@code startAt} are ignored and will are not added to the returned
+     * string.
+     *
+     * @param separator the delimiter that separates each element
+     * @param elements the substrings to join
+     * @param startAt the index of the element in {@code elements} to start joining
+     *
+     * @return a new {@code String} that is composed of the {@code elements}
+     *         separated by the {@code delimiter}
+     */
+    public static String joinFrom(String separator, String[] elements, int startAt) {
+        StringJoiner sj = new StringJoiner(separator);
 
         for(; startAt < elements.length; ++startAt) {
-            sb.append(S3Path.PATH_SEPARATOR).append(elements[startAt]);
+            sj.add(elements[startAt]);
         }
 
-        return sb.toString();
+        return sj.toString();
     }
 
     /**
-     * Like Java 11's String.isBlank(): it returns true if the string is empty or 
+     * Like Java 11's String.isBlank(): it returns true if the string is empty or
      * contains only white space codepoints, otherwise false.
-     * 
+     *
      * @param s the string to check
-     * 
+     *
      * @return true if the string is empty or contains only white space codepoints, otherwise false
-     * 
+     *
      * TODO: to replace with Java11's isBlank when moving away from Java8
      */
     public static boolean isBlank(final String s) {
-        return s.replace(" ", "").replace("\n", "").replace("\r", "").replace("\t", "").isEmpty();
+        for (int i=0; i<s.length(); ++i) {
+            if (!Character.isWhitespace(s.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/src/main/java/software/amazon/nio/spi/s3/util/StringUtils.java
+++ b/src/main/java/software/amazon/nio/spi/s3/util/StringUtils.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.nio.spi.s3.util;
+
+import software.amazon.nio.spi.s3.S3Path;
+
+/**
+ *
+ */
+public class StringUtils {
+    public static String join(String separator, String[] elements, int startAt) {
+        StringBuilder sb = new StringBuilder();
+
+        for(; startAt < elements.length; ++startAt) {
+            sb.append(S3Path.PATH_SEPARATOR).append(elements[startAt]);
+        }
+
+        return sb.toString();
+    }
+
+    /**
+     * Like Java 11's String.isBlank(): it returns true if the string is empty or 
+     * contains only white space codepoints, otherwise false.
+     * 
+     * @param s the string to check
+     * 
+     * @return true if the string is empty or contains only white space codepoints, otherwise false
+     * 
+     * TODO: to replace with Java11's isBlank when moving away from Java8
+     */
+    public static boolean isBlank(final String s) {
+        return s.replace(" ", "").replace("\n", "").replace("\r", "").replace("\t", "").isEmpty();
+    }
+}

--- a/src/test/java/software/amazon/nio/spi/s3/config/S3NioSpiConfigurationTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/config/S3NioSpiConfigurationTest.java
@@ -8,7 +8,6 @@ package software.amazon.nio.spi.s3.config;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
-import static org.assertj.core.api.BDDAssertions.entry;
 
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -184,23 +183,23 @@ public class S3NioSpiConfigurationTest {
 
     @Test
     public void withAndGetCredentials() {
-        final AwsCredentials C1 = AwsBasicCredentials.create("key", "secret");
-        final AwsCredentials C2 = AwsBasicCredentials.create("key", "secret");
+        final AwsCredentials C1 = AwsBasicCredentials.create("key1", "secret1");
+        final AwsCredentials C2 = AwsBasicCredentials.create("key2", "secret2");
 
         then(config.withCredentials(C1)).isSameAs(config);
-        AwsCredentials c = config.getCredentials();
-        then(c.accessKeyId()).isEqualTo(C1.accessKeyId());
-        then(c.secretAccessKey()).isEqualTo(C1.secretAccessKey());
-
+        then(config.getCredentials()).isSameAs(C1);
         then(config.withCredentials(C2)).isSameAs(config);
-        c = config.getCredentials();
-        then(c.accessKeyId()).isEqualTo(C2.accessKeyId());
-        then(c.secretAccessKey()).isEqualTo(C2.secretAccessKey());
-
-        then(config.withCredentials(null)).doesNotContainKeys(
-            AWS_ACCESS_KEY_PROPERTY, AWS_SECRET_ACCESS_KEY_PROPERTY
-        );
+        then(config.getCredentials()).isSameAs(C2);
         then(config.getCredentials()).isNull();
+
+        //
+        // withCredentials(AwsCredentials) takes priority over withCredentialas(String, String)
+        //
+        then(
+            config.withCredentials(C1.accessKeyId(), C2.secretAccessKey())
+            .withCredentials(C2)
+            .getCredentials()
+        ).isSameAs(C2);
     }
 
     @Test

--- a/src/test/java/software/amazon/nio/spi/s3/config/S3NioSpiConfigurationTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/config/S3NioSpiConfigurationTest.java
@@ -8,6 +8,7 @@ package software.amazon.nio.spi.s3.config;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import static org.assertj.core.api.BDDAssertions.entry;
 
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -15,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 
 import static software.amazon.nio.spi.s3.config.S3NioSpiConfiguration.*;
@@ -158,7 +160,7 @@ public class S3NioSpiConfigurationTest {
     }
 
     @Test
-    public void withAndGetCredentials() {
+    public void withAndGetPlainCredentials() {
         then(config.withCredentials("akey", "asecret")).isSameAs(config);
 
         AwsCredentials credentials = config.getCredentials();
@@ -178,6 +180,27 @@ public class S3NioSpiConfigurationTest {
             then(x).hasMessage("secretAccessKey can not be null");
         }
 
+    }
+
+    @Test
+    public void withAndGetCredentials() {
+        final AwsCredentials C1 = AwsBasicCredentials.create("key", "secret");
+        final AwsCredentials C2 = AwsBasicCredentials.create("key", "secret");
+
+        then(config.withCredentials(C1)).isSameAs(config);
+        AwsCredentials c = config.getCredentials();
+        then(c.accessKeyId()).isEqualTo(C1.accessKeyId());
+        then(c.secretAccessKey()).isEqualTo(C1.secretAccessKey());
+
+        then(config.withCredentials(C2)).isSameAs(config);
+        c = config.getCredentials();
+        then(c.accessKeyId()).isEqualTo(C2.accessKeyId());
+        then(c.secretAccessKey()).isEqualTo(C2.secretAccessKey());
+
+        then(config.withCredentials(null)).doesNotContainKeys(
+            AWS_ACCESS_KEY_PROPERTY, AWS_SECRET_ACCESS_KEY_PROPERTY
+        );
+        then(config.getCredentials()).isNull();
     }
 
     @Test

--- a/src/test/java/software/amazon/nio/spi/s3/config/S3NioSpiConfigurationTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/config/S3NioSpiConfigurationTest.java
@@ -5,15 +5,20 @@
 
 package software.amazon.nio.spi.s3.config;
 
-
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 
 import static org.assertj.core.api.BDDAssertions.then;
-
-import static software.amazon.nio.spi.s3.config.S3NioSpiConfiguration.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+
+import static software.amazon.nio.spi.s3.config.S3NioSpiConfiguration.*;
+
 
 public class S3NioSpiConfigurationTest {
 
@@ -36,24 +41,143 @@ public class S3NioSpiConfigurationTest {
 
     @Test
     public void constructors() {
-        then(String.valueOf(config.getMaxFragmentNumber())).isEqualTo(S3_SPI_READ_MAX_FRAGMENT_NUMBER_DEFAULT);
-        then(String.valueOf(config.getMaxFragmentSize())).isEqualTo(S3_SPI_READ_MAX_FRAGMENT_SIZE_DEFAULT);
+        then(config).isInstanceOf(Map.class);
+        then(config.getMaxFragmentNumber()).isEqualTo(S3_SPI_READ_MAX_FRAGMENT_NUMBER_DEFAULT);
+        then(config.getMaxFragmentSize()).isEqualTo(S3_SPI_READ_MAX_FRAGMENT_SIZE_DEFAULT);
+        then(config.getEndpointProtocol()).isEqualTo("https");
+        then(config.getEndpoint()).isEmpty();
+        then(config.getRegion()).isNull();
+        then(config.getCredentials()).isNull();
+    }
+
+    @Test
+    public void overridesAsMap() {
+        assertThrows(NullPointerException.class, () -> new S3NioSpiConfiguration((Map)null));
+
+        Map<String, String> map = new HashMap<>();
+        map.put(S3_SPI_READ_MAX_FRAGMENT_SIZE_PROPERTY, "1212");
+        S3NioSpiConfiguration c = new S3NioSpiConfiguration(map);
+
+        assertEquals(1212, c.getMaxFragmentSize());
     }
 
     @Test
     public void getS3SpiReadMaxFragmentSize() {
-        assertEquals(Integer.parseInt(S3_SPI_READ_MAX_FRAGMENT_SIZE_DEFAULT), config.getMaxFragmentSize());
+        assertEquals(S3_SPI_READ_MAX_FRAGMENT_SIZE_DEFAULT, config.getMaxFragmentSize());
 
         assertEquals(1111, overriddenConfig.getMaxFragmentSize());
-        assertEquals(Integer.parseInt(S3_SPI_READ_MAX_FRAGMENT_SIZE_DEFAULT), badOverriddenConfig.getMaxFragmentSize());
+        assertEquals(S3_SPI_READ_MAX_FRAGMENT_SIZE_DEFAULT, badOverriddenConfig.getMaxFragmentSize());
     }
 
     @Test
     public void getS3SpiReadMaxFragmentNumber() {
-        assertEquals(Integer.parseInt(S3_SPI_READ_MAX_FRAGMENT_NUMBER_DEFAULT), config.getMaxFragmentNumber());
+        assertEquals(S3_SPI_READ_MAX_FRAGMENT_NUMBER_DEFAULT, config.getMaxFragmentNumber());
 
         assertEquals(2, overriddenConfig.getMaxFragmentNumber());
-        assertEquals(Integer.parseInt(S3_SPI_READ_MAX_FRAGMENT_NUMBER_DEFAULT), badOverriddenConfig.getMaxFragmentNumber());
+        assertEquals(S3_SPI_READ_MAX_FRAGMENT_NUMBER_DEFAULT, badOverriddenConfig.getMaxFragmentNumber());
+    }
+
+    @Test
+    public void withAndGetRegion() {
+        then(new S3NioSpiConfiguration().getRegion()).isNull();
+
+        Properties env = new Properties();
+        env.setProperty(AWS_REGION_PROPERTY, "region1");
+
+        final S3NioSpiConfiguration C = new S3NioSpiConfiguration(env);
+        then(C.getRegion()).isEqualTo("region1");
+        then(C.withRegion("\tregion2 ")).isSameAs(C); then(C.getRegion()).isEqualTo("region2");
+        then(C.withRegion(" \t ").getRegion()).isNull();
+        then(C.withRegion("").getRegion()).isNull();
+        then(C.withRegion(null).getRegion()).isNull();
+    }
+
+    @Test
+    public void withAndGetEndpoint() {
+        then(config.withEndpoint("somewhere.com:8000")).isSameAs(config);
+        then(config.getEndpoint()).isEqualTo("somewhere.com:8000");
+        then(config.withEndpoint(" somewhere.com:8080\t").getEndpoint()).isEqualTo("somewhere.com:8080");
+        then(config.withEndpoint("   ").getEndpoint()).isEqualTo("");
+        then(config.withEndpoint(null).getEndpoint()).isEqualTo("");
+
+        try {
+           config.withEndpoint("noport.somewhere.com");
+           fail("missing sanity check");
+        } catch (IllegalArgumentException x) {
+            then(x).hasMessage("endpoint 'noport.somewhere.com' does not match format host:port");
+        }
+
+        try {
+            config.withEndpoint("wrongport.somewhere.com:aabbcc");
+            fail("missing sanity check");
+        } catch (IllegalArgumentException x) {
+            then(x).hasMessage("endpoint 'wrongport.somewhere.com:aabbcc' does not match format host:port");
+        }
+    }
+
+    @Test
+    public void withAndGetEndpointProtocol() {
+        then(config.withEndpointProtocol("http")).isSameAs(config);
+        then(config.getEndpointProtocol()).isEqualTo("http");
+        then(config.withEndpointProtocol("  http\n").getEndpointProtocol()).isEqualTo("http");
+        then(overriddenConfig.getEndpointProtocol()).isEqualTo("https");
+        then(badOverriddenConfig.getEndpointProtocol()).isEqualTo(S3_SPI_ENDPOINT_PROTOCOL_DEFAULT);
+
+        try {
+            config.withEndpointProtocol("ftp");
+            fail("missing sanity check");
+        } catch (IllegalArgumentException x) {
+            then(x).hasMessage("endpoint prococol must be one of ('http', 'https')");
+        }
+    }
+
+    @Test
+    public void withAndGetMaxFragmentNumber() {
+        then(config.withMaxFragmentNumber(1000)).isSameAs(config);
+        then(config.getMaxFragmentNumber()).isEqualTo(1000);
+
+        try {
+            config.withMaxFragmentNumber(-1);
+            fail("missing sanity check");
+        } catch (IllegalArgumentException x) {
+            then(x).hasMessage("maxFragmentNumber must be positive");
+        }
+    }
+
+    @Test
+    public void withAndGetMaxFragmentSize() {
+        then(config.withMaxFragmentSize(4000)).isSameAs(config);
+        then(config.getMaxFragmentSize()).isEqualTo(4000);
+
+        try {
+            config.withMaxFragmentSize(-1);
+            fail("missing sanity check");
+        } catch (IllegalArgumentException x) {
+            then(x).hasMessage("maxFragmentSize must be positive");
+        }
+    }
+
+    @Test
+    public void withAndGetCredentials() {
+        then(config.withCredentials("akey", "asecret")).isSameAs(config);
+
+        AwsCredentials credentials = config.getCredentials();
+        then(credentials.accessKeyId()).isEqualTo("akey");
+        then(credentials.secretAccessKey()).isEqualTo("asecret");
+
+        credentials = config.withCredentials("anotherkey", "anothersecret").getCredentials();
+        then(credentials.accessKeyId()).isEqualTo("anotherkey");
+        then(credentials.secretAccessKey()).isEqualTo("anothersecret");
+
+        then(config.withCredentials(null, "something").getCredentials()).isNull();
+
+        try {
+            config.withCredentials("akey", null);
+            fail("missing sanity check");
+        } catch (IllegalArgumentException x) {
+            then(x).hasMessage("secretAccessKey can not be null");
+        }
+
     }
 
     @Test


### PR DESCRIPTION
It also cleans up a bit the code using proper type for properties S3_SPI_READ_MAX_FRAGMENT_SIZE_PROPERTY and S3_SPI_READ_MAX_FRAGMENT_NUMBER_PROPERTY

*Issue #*
#112 

*Description of changes:*
See #112 for a description of the functionality introduced.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
