### PR TITLE
Addressing issue #30 about NIO FileSystem lifecycle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     testImplementation 'org.mockito:mockito-junit-jupiter:5.4.0'
     testImplementation 'com.github.stefanbirkner:system-lambda:1.2.1'
 
-    implementation platform('software.amazon.awssdk:bom:2.20.105')
+    implementation platform('software.amazon.awssdk:bom:2.20.110')
 
     implementation 'software.amazon.awssdk:s3'
     implementation 'software.amazon.awssdk:s3-transfer-manager'

--- a/build.gradle
+++ b/build.gradle
@@ -48,14 +48,14 @@ dependencies {
     testImplementation 'org.mockito:mockito-junit-jupiter:5.4.0'
     testImplementation 'com.github.stefanbirkner:system-lambda:1.2.1'
 
-    implementation platform('software.amazon.awssdk:bom:2.20.113')
+    implementation platform('software.amazon.awssdk:bom:2.20.130')
 
     implementation 'software.amazon.awssdk:s3'
     implementation 'software.amazon.awssdk:s3-transfer-manager'
-    implementation 'software.amazon.awssdk.crt:aws-crt:0.23.2'
+    implementation 'software.amazon.awssdk.crt:aws-crt:0.25.0'
     implementation 'org.slf4j:slf4j-api:2.0.7'
     implementation 'ch.qos.logback:logback-classic:1.4.8'
-    implementation 'ch.qos.logback:logback-core:1.4.8'
+    implementation 'ch.qos.logback:logback-core:1.4.11'
     // cannot use caffeine v3 because that requires java 11
     implementation('com.github.ben-manes.caffeine:caffeine:2.9.3')
 }

--- a/src/main/java/examples/ListPrefix.java
+++ b/src/main/java/examples/ListPrefix.java
@@ -5,6 +5,7 @@ import java.net.URI;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
+import java.util.Collections;
 
 public class ListPrefix {
     public static void main(String[] args) throws IOException {
@@ -14,7 +15,7 @@ public class ListPrefix {
         }
 
         String prefix = args[0];
-        try (final FileSystem fileSystem = FileSystems.getFileSystem(URI.create(prefix))) {
+        try (final FileSystem fileSystem = FileSystems.newFileSystem(URI.create(prefix), Collections.EMPTY_MAP)) {
             Path s3Path = fileSystem.getPath(prefix);
             fileSystem.provider()
                     .newDirectoryStream(s3Path, item -> true)

--- a/src/main/java/examples/WalkFromRoot.java
+++ b/src/main/java/examples/WalkFromRoot.java
@@ -7,6 +7,7 @@ import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collections;
 
 public class WalkFromRoot {
 
@@ -19,7 +20,7 @@ public class WalkFromRoot {
      */
     public static void main(String[] args) throws IOException {
         final String bucketName = args[0];
-        final FileSystem s3 = FileSystems.getFileSystem(URI.create("s3://"+bucketName));
+        final FileSystem s3 = FileSystems.newFileSystem(URI.create("s3://"+bucketName), Collections.EMPTY_MAP);
 
         for (Path rootDir : s3.getRootDirectories()) {
             Files.walk(rootDir).forEach(System.out::println);

--- a/src/main/java/software/amazon/nio/spi/s3/FixedS3ClientProvider.java
+++ b/src/main/java/software/amazon/nio/spi/s3/FixedS3ClientProvider.java
@@ -8,10 +8,11 @@ package software.amazon.nio.spi.s3;
 import software.amazon.awssdk.awscore.AwsClient;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.nio.spi.s3.S3ClientProvider;
 
 /**
- *
+ * Utility class that extends {@code S3ClientProvider} with a given
+ * implementation of S3AsyncClient. This may be helpful in tests or in use cases
+ * where a single instance of a S3 client should be used.
  */
 public class FixedS3ClientProvider extends S3ClientProvider {
 

--- a/src/main/java/software/amazon/nio/spi/s3/FixedS3ClientProvider.java
+++ b/src/main/java/software/amazon/nio/spi/s3/FixedS3ClientProvider.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.nio.spi.s3;
+
+import software.amazon.awssdk.awscore.AwsClient;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.nio.spi.s3.S3ClientProvider;
+
+/**
+ *
+ */
+public class FixedS3ClientProvider extends S3ClientProvider {
+
+    final public AwsClient client;
+
+    public FixedS3ClientProvider(S3AsyncClient client) {
+        this.client = client;
+    }
+
+    @Override
+    public S3Client universalClient() {
+        return (S3Client)client;
+    }
+
+    @Override
+    protected S3AsyncClient generateAsyncClient(String bucketName) {
+        return (S3AsyncClient)client;
+    }
+
+    @Override
+    protected S3Client generateClient (String bucketName) {
+        return (S3Client)client;
+    }
+
+}

--- a/src/main/java/software/amazon/nio/spi/s3/S3BasicFileAttributes.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3BasicFileAttributes.java
@@ -47,7 +47,7 @@ public class S3BasicFileAttributes implements BasicFileAttributes {
      * @param path the path to represent the attributes of
      */
     protected S3BasicFileAttributes(S3Path path){
-        this(path, S3ClientStore.getInstance().getAsyncClientForBucketName(path.bucketName()));
+         this(path, path.getFileSystem().client());
     }
 
     /**

--- a/src/main/java/software/amazon/nio/spi/s3/S3ClientProvider.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3ClientProvider.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.nio.spi.s3;
+
+import java.io.IOException;
+import java.net.URI;
+import java.time.Duration;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.awscore.AwsClient;
+import software.amazon.awssdk.core.exception.ApiCallAttemptTimeoutException;
+import software.amazon.awssdk.core.exception.ApiCallTimeoutException;
+import software.amazon.awssdk.core.exception.RetryableException;
+import software.amazon.awssdk.core.retry.backoff.EqualJitterBackoffStrategy;
+import software.amazon.awssdk.core.retry.conditions.OrRetryCondition;
+import software.amazon.awssdk.core.retry.conditions.RetryCondition;
+import software.amazon.awssdk.core.retry.conditions.RetryOnClockSkewCondition;
+import software.amazon.awssdk.core.retry.conditions.RetryOnExceptionsCondition;
+import software.amazon.awssdk.core.retry.conditions.RetryOnStatusCodeCondition;
+import software.amazon.awssdk.core.retry.conditions.RetryOnThrottlingCondition;
+import software.amazon.awssdk.http.HttpStatusCode;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
+import software.amazon.awssdk.services.s3.S3CrtAsyncClientBuilder;
+import software.amazon.awssdk.services.s3.model.HeadBucketResponse;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.nio.spi.s3.config.S3NioSpiConfiguration;
+
+/**
+ *
+ */
+public class S3ClientProvider {
+
+    /**
+     * Default S3CrtAsyncClientBuilder
+     */
+    protected S3CrtAsyncClientBuilder asyncClientBuilder = S3AsyncClient.crtBuilder();
+
+
+    /**
+     * Default client using the "https://s3.us-east-1.amazonaws.com" endpoint
+     */
+    private static final S3Client DEFAULT_CLIENT = S3Client.builder()
+            .endpointOverride(URI.create("https://s3.us-east-1.amazonaws.com"))
+            .region(Region.US_EAST_1)
+            .build();
+
+    /**
+     * Default asynchronous client using the "https://s3.us-east-1.amazonaws.com" endpoint
+     */
+    private static final S3AsyncClient DEFAULT_ASYNC_CLIENT = S3AsyncClient.builder()
+            .endpointOverride(URI.create("https://s3.us-east-1.amazonaws.com"))
+            .region(Region.US_EAST_1)
+            .build();
+
+        private final EqualJitterBackoffStrategy backoffStrategy = EqualJitterBackoffStrategy.builder()
+            .baseDelay(Duration.ofMillis(200L))
+            .maxBackoffTime(Duration.ofSeconds(5L))
+            .build();
+
+    final RetryCondition retryCondition;
+
+    {
+        final Set<Integer> RETRYABLE_STATUS_CODES = Stream.of(
+                HttpStatusCode.INTERNAL_SERVER_ERROR,
+                HttpStatusCode.BAD_GATEWAY,
+                HttpStatusCode.SERVICE_UNAVAILABLE,
+                HttpStatusCode.GATEWAY_TIMEOUT
+        ).collect(Collectors.toSet());
+
+        final Set<Class<? extends Exception>> RETRYABLE_EXCEPTIONS = Stream.of(
+                RetryableException.class,
+                IOException.class,
+                ApiCallAttemptTimeoutException.class,
+                ApiCallTimeoutException.class).collect(Collectors.toSet());
+
+        retryCondition = OrRetryCondition.create(
+                RetryOnStatusCodeCondition.create(RETRYABLE_STATUS_CODES),
+                RetryOnExceptionsCondition.create(RETRYABLE_EXCEPTIONS),
+                RetryOnClockSkewCondition.create(),
+                RetryOnThrottlingCondition.create()
+        );
+    }
+
+    Logger logger = LoggerFactory.getLogger("S3ClientStoreProvider");
+
+
+    /**
+     * This method returns a universal client (i.e. not bound to any region)
+     * that can be used by certain S3 operations for discovery.
+     * This is the same as universalClient(false);
+     *
+     * @return a S3Client not bound to a region
+     */
+    public S3Client universalClient() {
+        return universalClient(false);
+    }
+
+    /**
+     * This method returns a universal client (i.e.not bound to any region)
+     * that can be used by certain S3 operations for discovery
+     *
+     * @param async true to return an asynchronous client, false otherwise
+     * @return a S3Client not bound to a region
+     */
+    public <T extends AwsClient> T universalClient(boolean async) {
+        return (T)((async) ? DEFAULT_ASYNC_CLIENT : DEFAULT_CLIENT);
+    }
+
+    /**
+     * Generate a client for the named bucket using a default client to determine the location of the named bucket
+     * @param bucketName the named of the bucket to make the client for
+     * @return an S3 client appropriate for the region of the named bucket
+     */
+    protected S3Client generateClient(String bucketName){
+        //
+        // TODO: use generics like in universalClient()
+        //
+        return generateClient(bucketName, universalClient());
+    }
+
+    /**
+     * Generate an asynchronous client for the named bucket using a default client to determine the location of the named bucket
+     * @param bucketName the named of the bucket to make the client for
+     * @return an asynchronous S3 client appropriate for the region of the named bucket
+     */
+    protected S3AsyncClient generateAsyncClient(String bucketName){
+        return generateAsyncClient(bucketName, DEFAULT_CLIENT);
+    }
+
+    /**
+     *
+     */
+    protected S3Client generateClient (String bucketName, S3Client locationClient) {
+        logger.debug("generating client for bucket: '{}'", bucketName);
+        S3Client bucketSpecificClient = null;
+
+        String bucketLocation = null;
+        try {
+            logger.debug("determining bucket location with getBucketLocation");
+            bucketLocation = locationClient.getBucketLocation(builder -> builder.bucket(bucketName)).locationConstraintAsString();
+            bucketSpecificClient = this.clientForRegion(bucketLocation);
+        } catch (S3Exception e) {
+            if(e.statusCode() == 403) {
+                logger.debug("Cannot determine location of '{}' bucket directly. Attempting to obtain bucket location with headBucket operation", bucketName);
+                try {
+                    final HeadBucketResponse headBucketResponse = locationClient.headBucket(builder -> builder.bucket(bucketName));
+                    bucketSpecificClient = this.clientForRegion(headBucketResponse.
+                            sdkHttpResponse()
+                            .firstMatchingHeader("x-amz-bucket-region")
+                            .orElseThrow(() -> new NoSuchElementException("Head Bucket Response doesn't include the header 'x-amz-bucket-region'")));
+                } catch (S3Exception e2) {
+                    if (e2.statusCode() == 301) {
+                        bucketSpecificClient = this.clientForRegion(e2.awsErrorDetails().
+                                sdkHttpResponse()
+                                .firstMatchingHeader("x-amz-bucket-region")
+                                .orElseThrow(() -> new NoSuchElementException("Head Bucket Response doesn't include the header 'x-amz-bucket-region'")));
+                    } else {
+                        throw e2;
+                    }
+                }
+            } else {
+                throw e;
+            }
+        }
+
+        //
+        // if here, no S3 nor other client has been created yet and we do not
+        // have a location; we'll let it figure out from the profile region
+        //
+        logger.warn("Unable to determine the region of bucket: '{}'. Generating a client for the profile region.", bucketName);
+
+        if (bucketSpecificClient == null) {
+            logger.warn("Unable to determine the region of bucket: '{}'. Generating a client for the profile region.", bucketName);
+            bucketSpecificClient = S3Client.builder()
+                    .overrideConfiguration(conf -> conf.retryPolicy(builder -> builder
+                        .retryCondition(retryCondition)
+                        .backoffStrategy(backoffStrategy)))
+                    .build();
+        }
+
+        return bucketSpecificClient;
+    }
+
+    /**
+     * Generate an asynchronous client for the named bucket using a default client to determine the location of the named client
+     * @param bucketName the named of the bucket to make the client for
+     * @param locationClient the client used to determine the location of the named bucket, recommend using DEFAULT_CLIENT
+     * @return an S3 client appropriate for the region of the named bucket
+     */
+    protected S3AsyncClient generateAsyncClient (String bucketName, S3Client locationClient) {
+        logger.debug("generating asynchronous client for bucket: '{}'", bucketName);
+        S3AsyncClient bucketSpecificClient = null;
+
+        String bucketLocation = null;
+        try {
+            logger.debug("determining bucket location with getBucketLocation");
+            bucketLocation = locationClient.getBucketLocation(builder -> builder.bucket(bucketName)).locationConstraintAsString();
+            bucketSpecificClient = this.asyncClientForRegion(bucketLocation);
+        } catch (S3Exception e) {
+            if(e.statusCode() == 403) {
+                logger.debug("Cannot determine location of '{}' bucket directly. Attempting to obtain bucket location with headBucket operation", bucketName);
+                try {
+                    final HeadBucketResponse headBucketResponse = locationClient.headBucket(builder -> builder.bucket(bucketName));
+                    bucketSpecificClient = this.asyncClientForRegion(headBucketResponse.sdkHttpResponse()
+                            .firstMatchingHeader("x-amz-bucket-region")
+                            .orElseThrow(() -> new NoSuchElementException("Head Bucket Response doesn't include the header 'x-amz-bucket-region'")));
+                } catch (S3Exception e2) {
+                    if (e2.statusCode() == 301) {
+                        bucketSpecificClient = this.asyncClientForRegion(e2
+                                .awsErrorDetails()
+                                .sdkHttpResponse()
+                                .firstMatchingHeader("x-amz-bucket-region")
+                                .orElseThrow(() -> new NoSuchElementException("Head Bucket Response doesn't include the header 'x-amz-bucket-region'"))
+                        );
+                    } else {
+                        throw e2;
+                    }
+                }
+            } else {
+                throw e;
+            }
+        }
+
+        //
+        // if here, no S3 nor other client has been created yet and we do not
+        // have a location; we'll let it figure out from the profile region
+        //
+        logger.warn("Unable to determine the region of bucket: '{}'. Generating a client for the profile region.", bucketName);
+
+        if (bucketSpecificClient == null) {
+            logger.warn("Unable to determine the region of bucket: '{}'. Generating a client for the profile region.", bucketName);
+            bucketSpecificClient = S3AsyncClient.builder()
+                    .overrideConfiguration(conf -> conf.retryPolicy(builder -> builder
+                            .retryCondition(retryCondition)
+                            .backoffStrategy(backoffStrategy)))
+                    .build();
+        }
+
+        return bucketSpecificClient;
+    }
+
+    private S3Client clientForRegion(String region) {
+        // It may be useful to further cache clients for regions although at some point clients for buckets may need to be
+        // specialized beyond just region end points.
+        logger.debug("bucket region is: '{}'", region);
+
+        S3ClientBuilder clientBuilder =  S3Client.builder()
+            .overrideConfiguration(conf -> conf.retryPolicy(builder -> builder
+                    .retryCondition(retryCondition)
+                    .backoffStrategy(backoffStrategy)));
+
+        //
+        // If no regionString is provided, the builder will try with the
+        // profile's region setting
+        //
+        if ((region != null) && (!region.trim().equals(""))) {
+            clientBuilder.region(Region.of(region));
+        }
+        return clientBuilder.build();
+    }
+
+    private S3AsyncClient asyncClientForRegion(String region){
+        // It may be useful to further cache clients for regions although at some point clients for buckets may need to be
+        // specialized beyond just region end points.
+        logger.debug("bucket region is: '{}'", region);
+
+        //
+        // If no regionString is provided, the builder will try with the
+        // profile's region setting
+        //
+        if ((region != null) && (!region.trim().equals(""))) {
+            asyncClientBuilder.region(Region.of(region));
+        }
+
+        return asyncClientBuilder.build();
+    }
+
+}

--- a/src/main/java/software/amazon/nio/spi/s3/S3ClientProvider.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3ClientProvider.java
@@ -257,38 +257,27 @@ public class S3ClientProvider {
         return bucketSpecificClient;
     }
 
-    private S3Client clientForRegion(String region) {
-        logger.debug("bucket region is: '{}'", region);
+    private S3Client clientForRegion(String regionName) {
+        Region region = regionName.equals("") ? Region.US_EAST_1 : Region.of(regionName);
+
+        logger.debug("bucket region is: '{}'", region.id());
 
         S3ClientBuilder clientBuilder =  S3Client.builder()
+            .region(region)
             .overrideConfiguration(conf -> conf.retryPolicy(builder -> builder
-                    .retryCondition(retryCondition)
-                    .backoffStrategy(backoffStrategy)));
+            .retryCondition(retryCondition)
+            .backoffStrategy(backoffStrategy)))
+            ;
 
-        //
-        // If no regionString is provided, the builder will try with the
-        // profile's region setting
-        //
-        if ((region != null) && (!region.trim().equals(""))) {
-            clientBuilder.region(Region.of(region));
-        }
         return clientBuilder.build();
     }
 
-    private S3AsyncClient asyncClientForRegion(String region){
-        // It may be useful to further cache clients for regions although at some point clients for buckets may need to be
-        // specialized beyond just region end points.
-        logger.debug("bucket region is: '{}'", region);
+    private S3AsyncClient asyncClientForRegion(String regionName){
+        Region region = regionName.equals("") ? Region.US_EAST_1 : Region.of(regionName);
 
-        //
-        // If no regionString is provided, the builder will try with the
-        // profile's region setting
-        //
-        if ((region != null) && (!region.trim().equals(""))) {
-            asyncClientBuilder.region(Region.of(region));
-        }
+        logger.debug("bucket region is: '{}'", region.id());
 
-        return asyncClientBuilder.build();
+        return asyncClientBuilder.region(region).build();
     }
 
 }

--- a/src/main/java/software/amazon/nio/spi/s3/S3ClientProvider.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3ClientProvider.java
@@ -33,9 +33,10 @@ import software.amazon.awssdk.services.s3.S3ClientBuilder;
 import software.amazon.awssdk.services.s3.S3CrtAsyncClientBuilder;
 import software.amazon.awssdk.services.s3.model.HeadBucketResponse;
 import software.amazon.awssdk.services.s3.model.S3Exception;
-import software.amazon.nio.spi.s3.config.S3NioSpiConfiguration;
 
 /**
+ * Factory/builder clas that creates sync and async S3 clients. It also provides
+ * default clients that can be used for basic operations (e.g. bucket discovery).
  *
  */
 public class S3ClientProvider {
@@ -62,10 +63,10 @@ public class S3ClientProvider {
             .region(Region.US_EAST_1)
             .build();
 
-        private final EqualJitterBackoffStrategy backoffStrategy = EqualJitterBackoffStrategy.builder()
-            .baseDelay(Duration.ofMillis(200L))
-            .maxBackoffTime(Duration.ofSeconds(5L))
-            .build();
+    private final EqualJitterBackoffStrategy backoffStrategy = EqualJitterBackoffStrategy.builder()
+        .baseDelay(Duration.ofMillis(200L))
+        .maxBackoffTime(Duration.ofSeconds(5L))
+        .build();
 
     final RetryCondition retryCondition;
 
@@ -138,6 +139,13 @@ public class S3ClientProvider {
     }
 
     /**
+     * Generates a sync client for the named bucket using the provided location
+     * discovery client.
+     *
+     * @param bucketName the named of the bucket to make the client for
+     * @param locationClient the client used to determine the location of the named bucket, recommend using DEFAULT_CLIENT
+     *
+     * @return an S3 client appropriate for the region of the named bucket
      *
      */
     protected S3Client generateClient (String bucketName, S3Client locationClient) {
@@ -250,8 +258,6 @@ public class S3ClientProvider {
     }
 
     private S3Client clientForRegion(String region) {
-        // It may be useful to further cache clients for regions although at some point clients for buckets may need to be
-        // specialized beyond just region end points.
         logger.debug("bucket region is: '{}'", region);
 
         S3ClientBuilder clientBuilder =  S3Client.builder()

--- a/src/main/java/software/amazon/nio/spi/s3/S3ClientProvider.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3ClientProvider.java
@@ -35,7 +35,7 @@ import software.amazon.awssdk.services.s3.model.HeadBucketResponse;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 
 /**
- * Factory/builder clas that creates sync and async S3 clients. It also provides
+ * Factory/builder class that creates sync and async S3 clients. It also provides
  * default clients that can be used for basic operations (e.g. bucket discovery).
  *
  */

--- a/src/main/java/software/amazon/nio/spi/s3/S3ClientStore.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3ClientStore.java
@@ -6,36 +6,11 @@
 package software.amazon.nio.spi.s3;
 
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import software.amazon.awssdk.core.exception.ApiCallAttemptTimeoutException;
-import software.amazon.awssdk.core.exception.ApiCallTimeoutException;
-import software.amazon.awssdk.core.exception.RetryableException;
-import software.amazon.awssdk.core.retry.backoff.EqualJitterBackoffStrategy;
-import software.amazon.awssdk.core.retry.conditions.OrRetryCondition;
-import software.amazon.awssdk.core.retry.conditions.RetryCondition;
-import software.amazon.awssdk.core.retry.conditions.RetryOnClockSkewCondition;
-import software.amazon.awssdk.core.retry.conditions.RetryOnExceptionsCondition;
-import software.amazon.awssdk.core.retry.conditions.RetryOnStatusCodeCondition;
-import software.amazon.awssdk.core.retry.conditions.RetryOnThrottlingCondition;
-import software.amazon.awssdk.http.HttpStatusCode;
-import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.S3CrtAsyncClientBuilder;
-import software.amazon.awssdk.services.s3.model.HeadBucketResponse;
-import software.amazon.awssdk.services.s3.model.S3Exception;
-
-import java.io.IOException;
-import java.net.URI;
-import java.time.Duration;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.NoSuchElementException;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import java.util.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A Singleton cache of clients for buckets configured for the region of those buckets
@@ -44,62 +19,15 @@ public class S3ClientStore {
 
     private static final S3ClientStore instance = new S3ClientStore();
 
-    /**
-     * Default S3CrtAsyncClientBuilder
-     */
-    protected S3CrtAsyncClientBuilder asyncClientBuilder = S3AsyncClient.crtBuilder();
-
-    /**
-     * Default client using the "https://s3.us-east-1.amazonaws.com" endpoint
-     */
-    @SuppressWarnings("JavadocLinkAsPlainText")
-    public static final S3Client DEFAULT_CLIENT = S3Client.builder()
-            .endpointOverride(URI.create("https://s3.us-east-1.amazonaws.com"))
-            .region(Region.US_EAST_1)
-            .build();
-
-    /**
-     * Default asynchronous client using the "https://s3.us-east-1.amazonaws.com" endpoint
-     */
-    @SuppressWarnings("JavadocLinkAsPlainText")
-    public static final S3AsyncClient DEFAULT_ASYNC_CLIENT = S3AsyncClient.builder()
-            .endpointOverride(URI.create("https://s3.us-east-1.amazonaws.com"))
-            .region(Region.US_EAST_1)
-            .build();
 
     private final Map<String, S3Client> bucketToClientMap = Collections.synchronizedMap(new HashMap<>());
     private final Map<String, S3AsyncClient> bucketToAsyncClientMap = Collections.synchronizedMap(new HashMap<>());
 
-    private final EqualJitterBackoffStrategy backoffStrategy = EqualJitterBackoffStrategy.builder()
-            .baseDelay(Duration.ofMillis(200L))
-            .maxBackoffTime(Duration.ofSeconds(5L))
-            .build();
+    Logger logger = LoggerFactory.getLogger("S3ClientStore");
 
-    final RetryCondition retryCondition;
-
-    {
-        final Set<Integer> RETRYABLE_STATUS_CODES = Stream.of(
-                HttpStatusCode.INTERNAL_SERVER_ERROR,
-                HttpStatusCode.BAD_GATEWAY,
-                HttpStatusCode.SERVICE_UNAVAILABLE,
-                HttpStatusCode.GATEWAY_TIMEOUT
-        ).collect(Collectors.toSet());
-
-        final Set<Class<? extends Exception>> RETRYABLE_EXCEPTIONS = Stream.of(
-                RetryableException.class,
-                IOException.class,
-                ApiCallAttemptTimeoutException.class,
-                ApiCallTimeoutException.class).collect(Collectors.toSet());
-
-        retryCondition = OrRetryCondition.create(
-                RetryOnStatusCodeCondition.create(RETRYABLE_STATUS_CODES),
-                RetryOnExceptionsCondition.create(RETRYABLE_EXCEPTIONS),
-                RetryOnClockSkewCondition.create(),
-                RetryOnThrottlingCondition.create()
-        );
-    }
-
-    final Logger logger = LoggerFactory.getLogger("S3ClientStore");
+    private static final S3ClientProvider DEFAULT_PROVIDER = new S3ClientProvider();
+    public static final S3Client DEFAULT_CLIENT = DEFAULT_PROVIDER.universalClient(false);
+    public static final S3AsyncClient DEFAULT_ASYNC_CLIENT = DEFAULT_PROVIDER.universalClient(true);
 
     private S3ClientStore(){}
 
@@ -107,8 +35,10 @@ public class S3ClientStore {
      * Get the ClientStore instance
      * @return a singleton
      */
+    @Deprecated
     public static S3ClientStore getInstance() { return instance; }
 
+    protected S3ClientProvider provider = new S3ClientProvider();
     /**
      * Get an existing client or generate a new client for the named bucket if one doesn't exist
      * @param bucketName the bucket name. If this value is null or empty a default client is returned
@@ -117,10 +47,10 @@ public class S3ClientStore {
     public S3Client getClientForBucketName( String bucketName ) {
         logger.debug("obtaining client for bucket '{}'", bucketName);
         if (bucketName == null || bucketName.trim().equals("")) {
-            return DEFAULT_CLIENT;
+            return provider.universalClient();
         }
 
-        return bucketToClientMap.computeIfAbsent(bucketName, this::generateClient);
+        return bucketToClientMap.computeIfAbsent(bucketName, provider::generateClient);
     }
 
     /**
@@ -131,155 +61,11 @@ public class S3ClientStore {
     public S3AsyncClient getAsyncClientForBucketName( String bucketName ) {
         logger.debug("obtaining async client for bucket '{}'", bucketName);
         if (bucketName == null || bucketName.trim().equals("")) {
-            return DEFAULT_ASYNC_CLIENT;
+            return provider.universalClient(true);
         }
 
-        return bucketToAsyncClientMap.computeIfAbsent(bucketName, this::generateAsyncClient);
+        return bucketToAsyncClientMap.computeIfAbsent(bucketName, provider::generateAsyncClient);
     }
 
-    /**
-     * Generate a client for the named bucket using a default client to determine the location of the named bucket
-     * @param bucketName the named of the bucket to make the client for
-     * @return an S3 client appropriate for the region of the named bucket
-     */
-    protected S3Client generateClient(String bucketName){
-        return this.generateClient(bucketName, DEFAULT_CLIENT);
-    }
-
-    /**
-     * Generate an asynchronous client for the named bucket using a default client to determine the location of the named bucket
-     * @param bucketName the named of the bucket to make the client for
-     * @return an asynchronous S3 client appropriate for the region of the named bucket
-     */
-    protected S3AsyncClient generateAsyncClient(String bucketName){
-        return this.generateAsyncClient(bucketName, DEFAULT_CLIENT);
-    }
-
-    /**
-     * Generate a client for the named bucket using a default client to determine the location of the named client
-     * @param bucketName the named of the bucket to make the client for
-     * @param locationClient the client used to determine the location of the named bucket, recommend using DEFAULT_CLIENT
-     * @return an S3 client appropriate for the region of the named bucket
-     */
-    protected S3Client generateClient (String bucketName, S3Client locationClient) {
-        logger.debug("generating client for bucket: '{}'", bucketName);
-        S3Client bucketSpecificClient;
-        try {
-            logger.debug("determining bucket location with getBucketLocation");
-            String bucketLocation = locationClient.getBucketLocation(builder -> builder.bucket(bucketName)).locationConstraintAsString();
-
-            bucketSpecificClient = this.clientForRegion(bucketLocation);
-
-        } catch (S3Exception e) {
-            if(e.statusCode() == 403) {
-                logger.debug("Cannot determine location of '{}' bucket directly. Attempting to obtain bucket location with headBucket operation", bucketName);
-                try {
-                    final HeadBucketResponse headBucketResponse = locationClient.headBucket(builder -> builder.bucket(bucketName));
-                    bucketSpecificClient = this.clientForRegion(headBucketResponse.
-                            sdkHttpResponse()
-                            .firstMatchingHeader("x-amz-bucket-region")
-                            .orElseThrow(() -> new NoSuchElementException("Head Bucket Response doesn't include the header 'x-amz-bucket-region'")));
-                } catch (S3Exception e2) {
-                    if (e2.statusCode() == 301) {
-                        bucketSpecificClient = this.clientForRegion(e2.awsErrorDetails().
-                                sdkHttpResponse()
-                                .firstMatchingHeader("x-amz-bucket-region")
-                                .orElseThrow(() -> new NoSuchElementException("Head Bucket Response doesn't include the header 'x-amz-bucket-region'")));
-                    } else {
-                        throw e2;
-                    }
-                }
-            } else {
-                throw e;
-            }
-        }
-
-        if (bucketSpecificClient == null) {
-            logger.warn("Unable to determine the region of bucket: '{}'. Generating a client for the profile region.", bucketName);
-            bucketSpecificClient = S3Client.builder()
-                    .overrideConfiguration(conf -> conf.retryPolicy(builder -> builder
-                        .retryCondition(retryCondition)
-                        .backoffStrategy(backoffStrategy)))
-                    .build();
-        }
-
-        return bucketSpecificClient;
-    }
-
-    /**
-     * Generate an asynchronous client for the named bucket using a default client to determine the location of the named client
-     * @param bucketName the named of the bucket to make the client for
-     * @param locationClient the client used to determine the location of the named bucket, recommend using DEFAULT_CLIENT
-     * @return an S3 client appropriate for the region of the named bucket
-     */
-    protected S3AsyncClient generateAsyncClient (String bucketName, S3Client locationClient) {
-        logger.debug("generating asynchronous client for bucket: '{}'", bucketName);
-        S3AsyncClient bucketSpecificClient;
-        try {
-            logger.debug("determining bucket location with getBucketLocation");
-            String bucketLocation = locationClient.getBucketLocation(builder -> builder.bucket(bucketName)).locationConstraintAsString();
-
-            bucketSpecificClient = this.asyncClientForRegion(bucketLocation);
-
-        } catch (S3Exception e) {
-            if(e.statusCode() == 403) {
-                logger.debug("Cannot determine location of '{}' bucket directly. Attempting to obtain bucket location with headBucket operation", bucketName);
-                try {
-                    final HeadBucketResponse headBucketResponse = locationClient.headBucket(builder -> builder.bucket(bucketName));
-                    bucketSpecificClient = this.asyncClientForRegion(headBucketResponse.sdkHttpResponse()
-                            .firstMatchingHeader("x-amz-bucket-region")
-                            .orElseThrow(() -> new NoSuchElementException("Head Bucket Response doesn't include the header 'x-amz-bucket-region'")));
-                } catch (S3Exception e2) {
-                    if (e2.statusCode() == 301) {
-                        bucketSpecificClient = this.asyncClientForRegion(e2
-                                .awsErrorDetails()
-                                .sdkHttpResponse()
-                                .firstMatchingHeader("x-amz-bucket-region")
-                                .orElseThrow(() -> new NoSuchElementException("Head Bucket Response doesn't include the header 'x-amz-bucket-region'")));
-                    } else {
-                        throw e2;
-                    }
-                }
-            } else {
-                throw e;
-            }
-        }
-
-        if (bucketSpecificClient == null) {
-            logger.warn("Unable to determine the region of bucket: '{}'. Generating a client for the profile region.", bucketName);
-            bucketSpecificClient = S3AsyncClient.builder()
-                    .overrideConfiguration(conf -> conf.retryPolicy(builder -> builder
-                            .retryCondition(retryCondition)
-                            .backoffStrategy(backoffStrategy)))
-                    .build();
-        }
-
-        return bucketSpecificClient;
-    }
-
-    private S3Client clientForRegion(String regionString){
-        // It may be useful to further cache clients for regions although at some point clients for buckets may need to be
-        // specialized beyond just region end points.
-        Region region = regionString.equals("") ? Region.US_EAST_1 : Region.of(regionString);
-        logger.debug("bucket region is: '{}'", region.id());
-
-        return S3Client.builder()
-                .region(region)
-                .overrideConfiguration(conf -> conf.retryPolicy(builder -> builder
-                        .retryCondition(retryCondition)
-                        .backoffStrategy(backoffStrategy)))
-                .build();
-    }
-
-    private S3AsyncClient asyncClientForRegion(String regionString){
-        // It may be useful to further cache clients for regions although at some point clients for buckets may need to be
-        // specialized beyond just region end points.
-        Region region = regionString.equals("") ? Region.US_EAST_1 : Region.of(regionString);
-        logger.debug("bucket region is: '{}'", region.id());
-
-        return S3AsyncClient.crtBuilder()
-                .region(region)
-                .build();
-    }
 
 }

--- a/src/main/java/software/amazon/nio/spi/s3/S3ClientStore.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3ClientStore.java
@@ -14,7 +14,15 @@ import org.slf4j.LoggerFactory;
 
 /**
  * A Singleton cache of clients for buckets configured for the region of those buckets
+ *
+ * @deprecated This class is not used any more and should not be used in new
+ *             implementations as it will be removed in a later version. It has
+ *             been replaced by {@link S3ClientProvider} which provides the same
+ *             functionality but the singleton instance. Now many instances of
+ *             a {@code S3(Async)Client} can be created, each accessing its own
+ *             bucket with its own connection settings.
  */
+@Deprecated
 public class S3ClientStore {
 
     private static final S3ClientStore instance = new S3ClientStore();
@@ -33,9 +41,10 @@ public class S3ClientStore {
 
     /**
      * Get the ClientStore instance
+     *
      * @return a singleton
+     *
      */
-    @Deprecated
     public static S3ClientStore getInstance() { return instance; }
 
     protected S3ClientProvider provider = new S3ClientProvider();

--- a/src/main/java/software/amazon/nio/spi/s3/S3FileSystem.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3FileSystem.java
@@ -26,7 +26,7 @@ import software.amazon.awssdk.services.s3.S3AsyncClient;
 /**
  * A Java NIO FileSystem for an S3 bucket as seen through the lens of the AWS Principal calling the class.
  *
- * TODO: provide constructrs with configuration settings like endpoint, bucket
+ * TODO: provide constructors with configuration settings like endpoint, bucket
  *       and credentials
  */
 public class S3FileSystem extends FileSystem {

--- a/src/main/java/software/amazon/nio/spi/s3/S3FileSystem.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3FileSystem.java
@@ -66,6 +66,7 @@ public class S3FileSystem extends FileSystem {
         this.bucketName = uri.getAuthority();
         logger.debug("creating FileSystem for 's3://{}'", this.bucketName);
         this.provider = s3FileSystemProvider;
+        this.clientProvider = new S3ClientProvider();
     }
 
     /**

--- a/src/main/java/software/amazon/nio/spi/s3/S3FileSystem.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3FileSystem.java
@@ -26,7 +26,8 @@ import software.amazon.awssdk.services.s3.S3AsyncClient;
 /**
  * A Java NIO FileSystem for an S3 bucket as seen through the lens of the AWS Principal calling the class.
  *
- * TODO: replace uriString in constructors with endpoint, bucket and credentials
+ * TODO: provide constructrs with configuration settings like endpoint, bucket
+ *       and credentials
  */
 public class S3FileSystem extends FileSystem {
     final Logger logger = LoggerFactory.getLogger(this.getClass());

--- a/src/main/java/software/amazon/nio/spi/s3/S3FileSystem.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3FileSystem.java
@@ -37,7 +37,7 @@ public class S3FileSystem extends FileSystem {
      */
     public static final String BASIC_FILE_ATTRIBUTE_VIEW = "basic";
 
-    protected S3ClientProvider clientProvider;
+    private S3ClientProvider clientProvider;
 
     private final S3FileSystemProvider provider;
     private boolean open = true;

--- a/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
@@ -324,8 +324,24 @@ public class S3FileSystemProvider extends FileSystemProvider {
     }
 
     /**
-     * @deprecate -- TODO how to address the deprecation
      *
+     * @deprecated in favour of using a proper S3ClientProvider in S3FileSystem.
+     *             For instance, instead of the following code:
+     *             <pre>
+     *             S3FileSystemProvider p = ...;
+     *             S3Path dir = ...;
+     *             S3AsyncClient s3 = ...;
+     *             DirectoryStream filter = ...;
+     *
+     *             p.newDirectoryStream(s3, path, filter);
+     *             </pre>
+     *             something equivalent to the below should be used:
+     *             <pre>
+     *             S3FileSystemProvider p = new MyFileSystemProvider(new MyClientProvider());
+     *             S3Path dir = ...;
+     *
+     *             p.newDirectoryStreampath, filter);
+     *             </pre>
      */
     @Deprecated
     protected DirectoryStream<Path> newDirectoryStream(S3AsyncClient s3Client, Path dir, DirectoryStream.Filter<? super Path> filter) throws IOException, ExecutionException, InterruptedException {
@@ -568,8 +584,8 @@ public class S3FileSystemProvider extends FileSystemProvider {
     @Override
     public void copy(Path source, Path target, CopyOption... options) throws IOException {
         //
-        // TODO: source and target can belong to any file system, we can not
-        //       assume they points to S3 objects
+        // TODO: check if source and target can belong to any file system; if
+        //       that is the case, we can not assume they points to S3 objects
         //
         try {
             // If both paths point to the same object, this is a no-op
@@ -1066,12 +1082,13 @@ public class S3FileSystemProvider extends FileSystemProvider {
     }
 
     private String getFileSystemKey(URI uri) {
-        String host = uri.getHost();
-        int port = uri.getPort();
-
-        return (port<0) && (!host.contains("."))
-               ? host
-               : (host + ((port < 0) ? "" : (":" + port)) + S3Path.PATH_SEPARATOR + uri.getPath().split(S3Path.PATH_SEPARATOR)[1]);
+        //
+        // TODO: this duplicates the logic in S3FileSystem and assumes the key
+        //       is the bucket name; we need to move the source of truth in
+        //       S3FileSystemProvider or a separate class and pass it to the
+        //       file system constructor.
+        //
+        return uri.getAuthority();
     }
 
     private S3Path forceAwsClient(final Path path, final S3AsyncClient client) {

--- a/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
@@ -623,7 +623,7 @@ public class S3FileSystemProvider extends FileSystemProvider {
                                             .destinationBucket(resolvedS3TargetPath.bucketName())
                                             .destinationKey(resolvedS3TargetPath.getKey())
                                             .build())
-                                    .build()).completionFuture().join();
+                                    .build()).completionFuture().get(timeOut, unit);
                         }
                     }
                 }
@@ -896,7 +896,7 @@ public class S3FileSystemProvider extends FileSystemProvider {
     }
 
     /**
-     * Returns a file attribute view of a given type.This method works in
+     * Returns a file attribute view of a given type. This method works in
      * exactly the manner specified by the {@link Files#getFileAttributeView}
      * method.
      *

--- a/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
@@ -402,14 +402,10 @@ public class S3FileSystemProvider extends FileSystemProvider {
      * @param listObjectsV2Publisher the publisher that returns objects and common prefixes that are iterated on.
      * @return an iterator for {@code Path}s constructed from the {@code ListObjectsV2Publisher}s responses.
      */
-    //
-    // TODO: shall this be private?
-    //
-    protected Iterator<Path> pathIteratorForPublisher(
+    private Iterator<Path> pathIteratorForPublisher (
             final DirectoryStream.Filter<? super Path> filter,
             final FileSystem fs, String finalDirName,
             final ListObjectsV2Publisher listObjectsV2Publisher) {
-
         return Flowable.fromPublisher(listObjectsV2Publisher)
                 .flatMapIterable(response -> {
 

--- a/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
@@ -580,8 +580,9 @@ public class S3FileSystemProvider extends FileSystemProvider {
     @Override
     public void copy(Path source, Path target, CopyOption... options) throws IOException {
         //
-        // TODO: check if source and target can belong to any file system; if
-        //       that is the case, we can not assume they points to S3 objects
+        // TODO: source and target can belong to any file system (confirmed, see
+        //       https://github.com/awslabs/aws-java-nio-spi-for-s3/issues/135),
+        //       we can not assume they points to S3 objects
         //
         try {
             // If both paths point to the same object, this is a no-op

--- a/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
@@ -274,7 +274,7 @@ public class S3FileSystemProvider extends FileSystemProvider {
      *             S3FileSystemProvider p = ...;
      *             S3Path path = ...;
      *             S3AsyncClient s3 = ...;
-     *             Set<? extends OpenOption> options = ...;
+     *             Set<OpenOption> options = ...;
      *
      *             p.newByteChannel(s3, path, options);
      *             </pre>

--- a/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
@@ -123,12 +123,12 @@ public class S3FileSystemProvider extends FileSystemProvider {
         }
         if (uri.getScheme() == null) {
             throw new IllegalArgumentException(
-                String.format("invalid uri '%s', please provide an uri as s3://[key:secret@][host:port]/bucket", uri.toString())
+                String.format("invalid uri '%s', please provide an uri as s3://bucket", uri.toString())
             );
         }
         if (uri.getAuthority() == null) {
             throw new IllegalArgumentException(
-                String.format("invalid uri '%s', please provide an uri as s3://[key:secret@][host:port]/bucket", uri.toString())
+                String.format("invalid uri '%s', please provide an uri as s3://bucket", uri.toString())
             );
         }
 
@@ -148,7 +148,12 @@ public class S3FileSystemProvider extends FileSystemProvider {
      *
      * @param uri URI reference
      *
-     * @return newFileSystem(uri, Collections.EMPTY_MPA)
+     * @return newFileSystem(uri, Collections.EMPTY_MAP)
+     *
+     * @throws FileSystemAlreadyExistsException if the file system has already been created
+     * @throws IllegalArgumentException if the pre-conditions for the uri parameter
+     *         are not met, or the env parameter does not contain properties
+     *         required by the provider, or a property value is invalid
      */
     public S3FileSystem newFileSystem(URI uri) {
         return newFileSystem(uri, Collections.EMPTY_MAP);
@@ -255,7 +260,8 @@ public class S3FileSystemProvider extends FileSystemProvider {
      */
     @SuppressWarnings("NullableProblems")
     @Override
-    public S3Path getPath(URI uri) {
+    public S3Path getPath(URI uri)
+    throws IllegalArgumentException, FileSystemNotFoundException, SecurityException {
         Objects.requireNonNull(uri);
         return getFileSystem(uri, true).getPath(uri.getScheme() + ":/" + uri.getPath());
     }

--- a/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
@@ -267,6 +267,31 @@ public class S3FileSystemProvider extends FileSystemProvider {
     }
 
     /**
+     *
+     * @deprecated in favour of using a proper S3ClientProvider in S3FileSystem.
+     *             For instance, instead of the following code:
+     *             <pre>
+     *             S3FileSystemProvider p = ...;
+     *             S3Path path = ...;
+     *             S3AsyncClient s3 = ...;
+     *             Set<? extends OpenOption> options = ...;
+     *
+     *             p.newByteChannel(s3, path, options);
+     *             </pre>
+     *             something equivalent to the below should be used:
+     *             <pre>
+     *             S3FileSystemProvider p = new MyFileSystemProvider(new MyClientProvider());
+     *             S3Path path = ...;
+     *
+     *             p.newByteChannel(path, filter);
+     *             </pre>
+     */
+    @Deprecated
+    protected SeekableByteChannel newByteChannel(S3AsyncClient client, Path path, Set<? extends OpenOption> options, FileAttribute<?>... attrs) throws IOException {
+        return newByteChannel(path, options, attrs);
+    }
+
+    /**
      * Opens or creates a file, returning a seekable byte channel to access the
      * file. This method works in exactly the manner specified by the {@link
      * Files#newByteChannel(Path, Set, FileAttribute[])} method.
@@ -295,20 +320,6 @@ public class S3FileSystemProvider extends FileSystemProvider {
      */
     @Override
     public SeekableByteChannel newByteChannel(Path path, Set<? extends OpenOption> options, FileAttribute<?>... attrs) throws IOException {
-        return this.newByteChannel(null, path, options, attrs);
-    }
-
-    /**
-     * Construct a byte channel for the path with the specified client. A more composable and testable (by using a Mock Client)
-     * version of the public method
-     * @param client The client to use for the channel
-     * @param path The path to open
-     * @param options The options to use
-     * @param attrs The attributes to use
-     * @return A new byte channel for the object at {@code path}
-     * @throws IOException If the channel could not be created
-     */
-    protected SeekableByteChannel newByteChannel(S3AsyncClient client, Path path, Set<? extends OpenOption> options, FileAttribute<?>... attrs) throws IOException {
         if (Objects.isNull(options)) {
             options = Collections.emptySet();
         }
@@ -371,10 +382,10 @@ public class S3FileSystemProvider extends FileSystemProvider {
         }
 
         final String bucketName = s3Path.bucketName();
-        final FileSystem fs = s3Path.getFileSystem();
+        final S3FileSystem fs = s3Path.getFileSystem();
         final String finalDirName = dirName;
 
-        final ListObjectsV2Publisher listObjectsV2Publisher = s3Path.getFileSystem().client().listObjectsV2Paginator(req -> req
+        final ListObjectsV2Publisher listObjectsV2Publisher = fs.client().listObjectsV2Paginator(req -> req
                 .bucket(bucketName)
                 .prefix(finalDirName)
                 .delimiter(S3Path.PATH_SEPARATOR));

--- a/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
@@ -274,7 +274,7 @@ public class S3FileSystemProvider extends FileSystemProvider {
      *             S3FileSystemProvider p = ...;
      *             S3Path path = ...;
      *             S3AsyncClient s3 = ...;
-     *             Set<OpenOption> options = ...;
+     *             Set&lt;OpenOption&gt; options = ...;
      *
      *             p.newByteChannel(s3, path, options);
      *             </pre>

--- a/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
@@ -423,7 +423,7 @@ public class S3FileSystemProvider extends FileSystemProvider {
 
                     // convert to S3Path and apply directory stream filter
                     return items.stream()
-                            .filter(p -> !p.equals(finalDirName))  // including the parent will induce loops
+                            .filter(p -> !((S3Path)fs.getPath(p)).getKey().equals(finalDirName))  // including the parent will induce loops
                             .map(fs::getPath)
                             .filter(path -> {
                                 try {

--- a/src/main/java/software/amazon/nio/spi/s3/S3SeekableByteChannel.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3SeekableByteChannel.java
@@ -28,6 +28,9 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+//
+// TODO: simplify: S3Path brings already the client to use with getFileSystem().client()
+//
 public class S3SeekableByteChannel implements SeekableByteChannel {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(S3SeekableByteChannel.class);
@@ -67,11 +70,11 @@ public class S3SeekableByteChannel implements SeekableByteChannel {
      */
     @Deprecated
     protected S3SeekableByteChannel(S3Path s3Path, long startAt) throws IOException {
-        this(s3Path, S3ClientStore.getInstance().getAsyncClientForBucketName(s3Path.bucketName()), startAt);
+        this(s3Path, s3Path.getFileSystem().client(), startAt);
     }
 
     protected S3SeekableByteChannel(S3Path s3Path) throws IOException {
-        this(s3Path, S3ClientStore.getInstance().getAsyncClientForBucketName(s3Path.bucketName()), Collections.singleton(StandardOpenOption.READ));
+        this(s3Path, s3Path.getFileSystem().client(), Collections.singleton(StandardOpenOption.READ));
     }
 
     protected S3SeekableByteChannel(S3Path s3Path, S3AsyncClient s3Client, Set<? extends OpenOption> options) throws IOException {

--- a/src/test/java/software/amazon/nio/spi/s3/FakeAsyncS3ClientBuilder.java
+++ b/src/test/java/software/amazon/nio/spi/s3/FakeAsyncS3ClientBuilder.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.nio.spi.s3;
+
+import java.net.URI;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3CrtAsyncClientBuilder;
+import software.amazon.awssdk.services.s3.crt.S3CrtHttpConfiguration;
+import software.amazon.awssdk.services.s3.crt.S3CrtRetryConfiguration;
+
+/**
+ * This class fakes a S3CrtAsyncClientBuilder for testability purposes. It
+ * records all configuration passed to the builder in public fields that can
+ * easily checked. It then delegates the implementation to the builder created
+ * with <code>S3AsyncClient.crtBuilder()</code>
+ */
+public class FakeAsyncS3ClientBuilder implements S3CrtAsyncClientBuilder {
+
+    private final S3CrtAsyncClientBuilder BUILDER = S3AsyncClient.crtBuilder();
+
+    public AwsCredentialsProvider credentialsProvider = null;
+    public Region region = null;
+    public Long minimumPartSizeInBytes = null,
+                initialReadBufferSizeInBytes = null;
+    public Double targetThroughputInGbps = null;
+    public Integer maxConcurrency = null;
+    public URI endpointOverride = null;
+    public Boolean checksumValidationEnabled = null,
+                   accelerate = null,
+                   forcePathStyle = null;
+    public S3CrtHttpConfiguration httpConfiguration = null;
+    public S3CrtRetryConfiguration retryConfiguration = null;
+
+    @Override
+    public S3CrtAsyncClientBuilder credentialsProvider(AwsCredentialsProvider acp) {
+        return BUILDER.credentialsProvider(credentialsProvider = acp);
+    }
+
+    @Override
+    public S3CrtAsyncClientBuilder region(Region r) {
+        return BUILDER.region(region = r);
+    }
+
+    @Override
+    public S3CrtAsyncClientBuilder minimumPartSizeInBytes(Long l) {
+        return BUILDER.minimumPartSizeInBytes(minimumPartSizeInBytes = l);
+    }
+
+    @Override
+    public S3CrtAsyncClientBuilder targetThroughputInGbps(Double d) {
+        return BUILDER.targetThroughputInGbps(targetThroughputInGbps = d);
+    }
+
+    @Override
+    public S3CrtAsyncClientBuilder maxConcurrency(Integer i) {
+        return BUILDER.maxConcurrency(maxConcurrency = i);
+    }
+
+    @Override
+    public S3CrtAsyncClientBuilder endpointOverride(URI u) {
+       return BUILDER.endpointOverride(endpointOverride = u);
+    }
+
+    @Override
+    public S3CrtAsyncClientBuilder checksumValidationEnabled(Boolean b) {
+        return BUILDER.checksumValidationEnabled(checksumValidationEnabled = b);
+    }
+
+    @Override
+    public S3CrtAsyncClientBuilder initialReadBufferSizeInBytes(Long l) {
+        return BUILDER.initialReadBufferSizeInBytes(initialReadBufferSizeInBytes = l);
+    }
+
+    @Override
+    public S3CrtAsyncClientBuilder httpConfiguration(S3CrtHttpConfiguration c) {
+        return BUILDER.httpConfiguration(httpConfiguration = c);
+    }
+
+    @Override
+    public S3CrtAsyncClientBuilder retryConfiguration(S3CrtRetryConfiguration c) {
+        return BUILDER.retryConfiguration(retryConfiguration = c);
+    }
+
+    @Override
+    public S3CrtAsyncClientBuilder accelerate(Boolean b) {
+        return BUILDER.accelerate(accelerate = b);
+    }
+
+    @Override
+    public S3CrtAsyncClientBuilder forcePathStyle(Boolean b) {
+        return BUILDER.forcePathStyle(forcePathStyle = b);
+    }
+
+    @Override
+    public S3AsyncClient build() {
+        return BUILDER.build();
+    }
+
+    @Override
+    public S3CrtAsyncClientBuilder crossRegionAccessEnabled(Boolean b) {
+        return BUILDER.crossRegionAccessEnabled(b);
+    }
+}

--- a/src/test/java/software/amazon/nio/spi/s3/FakeAsyncS3ClientBuilder.java
+++ b/src/test/java/software/amazon/nio/spi/s3/FakeAsyncS3ClientBuilder.java
@@ -104,4 +104,9 @@ public class FakeAsyncS3ClientBuilder implements S3CrtAsyncClientBuilder {
     public S3CrtAsyncClientBuilder crossRegionAccessEnabled(Boolean b) {
         return BUILDER.crossRegionAccessEnabled(b);
     }
+
+    @Override
+    public S3CrtAsyncClientBuilder thresholdInBytes(Long l) {
+        return BUILDER.thresholdInBytes(l);
+    }
 }

--- a/src/test/java/software/amazon/nio/spi/s3/S3ClientProviderTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3ClientProviderTest.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.nio.spi.s3;
+
+import java.util.NoSuchElementException;
+import java.util.function.Consumer;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import static org.mockito.ArgumentMatchers.any;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.when;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetBucketLocationResponse;
+import software.amazon.awssdk.services.s3.model.HeadBucketResponse;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.nio.spi.s3.config.S3NioSpiConfiguration;
+
+@ExtendWith(MockitoExtension.class)
+public class S3ClientProviderTest {
+
+    @Mock
+    S3Client mockClient; //client used to determine bucket location
+
+    S3ClientProvider provider;
+
+    @BeforeEach
+    public void before() throws Exception {
+        provider = new S3ClientProvider();
+    }
+
+    @Test
+    public void initialization() {
+        final S3ClientProvider P = new S3ClientProvider();
+
+        assertTrue(P.universalClient() instanceof S3Client);
+        assertNotNull(P.universalClient());
+
+        assertTrue(P.universalClient(true) instanceof S3AsyncClient);
+        assertNotNull(P.universalClient());
+
+        S3NioSpiConfiguration config = new S3NioSpiConfiguration();
+    }
+
+    @Test
+    public void testGenerateAsyncClientWithNoErrors() {
+        when(mockClient.getBucketLocation(any(Consumer.class)))
+                .thenReturn(GetBucketLocationResponse.builder().locationConstraint("us-west-2").build());
+        final S3AsyncClient s3Client = provider.generateAsyncClient("test-bucket", mockClient);
+        assertNotNull(s3Client);
+    }
+
+    @Test
+    public void testGenerateClientWith403Response() {
+        // when you get a forbidden response from getBucketLocation
+        when(mockClient.getBucketLocation(any(Consumer.class))).thenThrow(
+                S3Exception.builder().statusCode(403).build()
+        );
+        // you should fall back to a head bucket attempt
+        when(mockClient.headBucket(any(Consumer.class)))
+                .thenReturn((HeadBucketResponse) HeadBucketResponse.builder()
+                        .sdkHttpResponse(SdkHttpResponse.builder()
+                                .putHeader("x-amz-bucket-region", "us-west-2")
+                                .build())
+                        .build());
+
+        // which should get you a client
+        final S3Client s3Client = provider.generateClient("test-bucket", mockClient);
+        assertNotNull(s3Client);
+
+        final InOrder inOrder = inOrder(mockClient);
+        inOrder.verify(mockClient).getBucketLocation(any(Consumer.class));
+        inOrder.verify(mockClient).headBucket(any(Consumer.class));
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void testGenerateAsyncClientWith403Response() {
+        // when you get a forbidden response from getBucketLocation
+        when(mockClient.getBucketLocation(any(Consumer.class))).thenThrow(
+                S3Exception.builder().statusCode(403).build()
+        );
+        // you should fall back to a head bucket attempt
+        when(mockClient.headBucket(any(Consumer.class)))
+                .thenReturn((HeadBucketResponse) HeadBucketResponse.builder()
+                        .sdkHttpResponse(SdkHttpResponse.builder()
+                                .putHeader("x-amz-bucket-region", "us-west-2")
+                                .build())
+                        .build());
+
+        // which should get you a client
+        final S3AsyncClient s3Client = provider.generateAsyncClient("test-bucket", mockClient);
+        assertNotNull(s3Client);
+
+        final InOrder inOrder = inOrder(mockClient);
+        inOrder.verify(mockClient).getBucketLocation(any(Consumer.class));
+        inOrder.verify(mockClient).headBucket(any(Consumer.class));
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void testGenerateAsyncClientWith403Then301Responses(){
+        // when you get a forbidden response from getBucketLocation
+        when(mockClient.getBucketLocation(any(Consumer.class))).thenThrow(
+                S3Exception.builder().statusCode(403).build()
+        );
+        // and you get a 301 response on headBucket
+        when(mockClient.headBucket(any(Consumer.class))).thenThrow(
+                S3Exception.builder()
+                        .statusCode(301)
+                        .awsErrorDetails(AwsErrorDetails.builder()
+                                .sdkHttpResponse(SdkHttpResponse.builder()
+                                        .putHeader("x-amz-bucket-region", "us-west-2")
+                                        .build())
+                                .build())
+                        .build()
+        );
+
+        // then you should be able to get a client as long as the error response header contains the region
+        final S3AsyncClient s3Client = provider.generateAsyncClient("test-bucket", mockClient);
+        assertNotNull(s3Client);
+
+        final InOrder inOrder = inOrder(mockClient);
+        inOrder.verify(mockClient).getBucketLocation(any(Consumer.class));
+        inOrder.verify(mockClient).headBucket(any(Consumer.class));
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void testGenerateClientWith403Then301ResponsesNoHeader(){
+        // when you get a forbidden response from getBucketLocation
+        when(mockClient.getBucketLocation(any(Consumer.class))).thenThrow(
+                S3Exception.builder().statusCode(403).build()
+        );
+        // and you get a 301 response on headBucket but no header for region
+        when(mockClient.headBucket(any(Consumer.class))).thenThrow(
+                S3Exception.builder()
+                        .statusCode(301)
+                        .awsErrorDetails(AwsErrorDetails.builder()
+                                .sdkHttpResponse(SdkHttpResponse.builder()
+                                        .build())
+                                .build())
+                        .build()
+        );
+
+        // then you should get a NoSuchElement exception when you try to get the header
+        try {
+            provider.generateClient("test-bucket", mockClient);
+        } catch (Exception e) {
+            assertEquals(NoSuchElementException.class, e.getClass());
+        }
+
+        final InOrder inOrder = inOrder(mockClient);
+        inOrder.verify(mockClient).getBucketLocation(any(Consumer.class));
+        inOrder.verify(mockClient).headBucket(any(Consumer.class));
+        inOrder.verifyNoMoreInteractions();
+    }
+
+
+    @Test
+    public void testGenerateAsyncClientWith403Then301ResponsesNoHeader(){
+        // when you get a forbidden response from getBucketLocation
+        when(mockClient.getBucketLocation(any(Consumer.class))).thenThrow(
+                S3Exception.builder().statusCode(403).build()
+        );
+        // and you get a 301 response on headBucket but no header for region
+        when(mockClient.headBucket(any(Consumer.class))).thenThrow(
+                S3Exception.builder()
+                        .statusCode(301)
+                        .awsErrorDetails(AwsErrorDetails.builder()
+                                .sdkHttpResponse(SdkHttpResponse.builder()
+                                        .build())
+                                .build())
+                        .build()
+        );
+
+        // then you should get a NoSuchElement exception when you try to get the header
+        try {
+            provider.generateAsyncClient("test-bucket", mockClient);
+        } catch (Exception e) {
+            assertEquals(NoSuchElementException.class, e.getClass());
+        }
+
+        final InOrder inOrder = inOrder(mockClient);
+        inOrder.verify(mockClient).getBucketLocation(any(Consumer.class));
+        inOrder.verify(mockClient).headBucket(any(Consumer.class));
+        inOrder.verifyNoMoreInteractions();
+    }
+}

--- a/src/test/java/software/amazon/nio/spi/s3/S3ClientStoreTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3ClientStoreTest.java
@@ -5,39 +5,26 @@
 
 package software.amazon.nio.spi.s3;
 
-import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
-import software.amazon.awssdk.http.SdkHttpResponse;
-import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.s3.S3AsyncClient;
-import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.GetBucketLocationResponse;
-import software.amazon.awssdk.services.s3.model.HeadBucketResponse;
-import software.amazon.awssdk.services.s3.model.S3Exception;
-
-import java.util.NoSuchElementException;
-import java.util.function.Consumer;
+import static com.github.stefanbirkner.systemlambda.SystemLambda.restoreSystemProperties;
 import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InOrder;
 import org.mockito.Mock;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
-import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3Client;
 
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings("unchecked")
+@Deprecated
 public class S3ClientStoreTest {
     S3ClientStore instance;
 
     @Mock
     S3Client mockClient; //client used to determine bucket location
 
-    @Spy
-    final S3ClientStore spyInstance = S3ClientStore.getInstance();
 
     @BeforeEach
     public void setUp() throws Exception {
@@ -46,218 +33,59 @@ public class S3ClientStoreTest {
 
     @Test
     public void testGetClientForNullBucketName() {
-        assertEquals(S3ClientStore.DEFAULT_CLIENT, instance.getClientForBucketName(null));
+        assertEquals(instance.provider.universalClient(), instance.getClientForBucketName(null));
     }
 
     @Test
     public void testGetAsyncClientForNullBucketName() {
-        assertEquals(S3ClientStore.DEFAULT_ASYNC_CLIENT, instance.getAsyncClientForBucketName(null));
+        assertEquals(instance.provider.universalClient(true), instance.getAsyncClientForBucketName(null));
     }
 
     @Test
     public void testGetClientForEmptyBucketName() {
-        assertEquals(S3ClientStore.DEFAULT_CLIENT, instance.getClientForBucketName(""));
-        assertEquals(S3ClientStore.DEFAULT_CLIENT, instance.getClientForBucketName(" "));
+        assertEquals(instance.provider.universalClient(), instance.getClientForBucketName(""));
+        assertEquals(instance.provider.universalClient(), instance.getClientForBucketName(" "));
     }
 
     @Test
     public void testGetAsyncClientForEmptyBucketName() {
-        assertEquals(S3ClientStore.DEFAULT_ASYNC_CLIENT, instance.getAsyncClientForBucketName(""));
-        assertEquals(S3ClientStore.DEFAULT_ASYNC_CLIENT, instance.getAsyncClientForBucketName(" "));
+        assertEquals(instance.provider.universalClient(true), instance.getAsyncClientForBucketName(""));
+        assertEquals(instance.provider.universalClient(true), instance.getAsyncClientForBucketName(" "));
     }
 
     @Test
-    public void testGenerateClientWithNoErrors() {
-        when(mockClient.getBucketLocation(any(Consumer.class)))
-                .thenReturn(GetBucketLocationResponse.builder().locationConstraint("us-west-2").build());
-        final S3Client s3Client = instance.generateClient("test-bucket", mockClient);
-        assertNotNull(s3Client);
+    public void testCaching() throws Exception {
+        instance.provider = new S3ClientProvider() {
+            @Override
+            protected S3Client generateClient(String bucketName) {
+                return S3Client.create();
+            }
+        };
 
+        restoreSystemProperties(() -> {
+            System.setProperty("aws.region", "us-east-1");
+            final S3Client client1 = instance.getClientForBucketName("test-bucket1");
+            assertSame(client1, instance.getClientForBucketName("test-bucket1"));
+            assertNotSame(client1, instance.getClientForBucketName("test-bucket2"));
+        });
     }
 
     @Test
-    public void testGenerateAsyncClientWithNoErrors() {
-        when(mockClient.getBucketLocation(any(Consumer.class)))
-                .thenReturn(GetBucketLocationResponse.builder().locationConstraint("us-west-2").build());
-        final S3AsyncClient s3Client = instance.generateAsyncClient("test-bucket", mockClient);
-        assertNotNull(s3Client);
+    public void testAsyncCaching() throws Exception {
+        instance.provider = new S3ClientProvider() {
+            @Override
+            protected S3AsyncClient generateAsyncClient(String bucketName) {
+                return S3AsyncClient.create();
+            }
+        };
+
+        restoreSystemProperties(() -> {
+            System.setProperty("aws.region", "us-east-1");
+            final S3AsyncClient client1 = instance.getAsyncClientForBucketName("test-bucket1");
+            assertSame(client1, instance.getAsyncClientForBucketName("test-bucket1"));
+            assertNotSame(client1, instance.getAsyncClientForBucketName("test-bucket2"));
+        });
     }
 
-    @Test
-    public void testGenerateClientWith403Response() {
-        // when you get a forbidden response from getBucketLocation
-        when(mockClient.getBucketLocation(any(Consumer.class))).thenThrow(
-                S3Exception.builder().statusCode(403).build()
-        );
-        // you should fall back to a head bucket attempt
-        when(mockClient.headBucket(any(Consumer.class)))
-                .thenReturn((HeadBucketResponse) HeadBucketResponse.builder()
-                        .sdkHttpResponse(SdkHttpResponse.builder()
-                                .putHeader("x-amz-bucket-region", "us-west-2")
-                                .build())
-                        .build());
-
-        // which should get you a client
-        final S3Client s3Client = instance.generateClient("test-bucket", mockClient);
-        assertNotNull(s3Client);
-
-        final InOrder inOrder = inOrder(mockClient);
-        inOrder.verify(mockClient).getBucketLocation(any(Consumer.class));
-        inOrder.verify(mockClient).headBucket(any(Consumer.class));
-        inOrder.verifyNoMoreInteractions();
-    }
-
-    @Test
-    public void testGenerateAsyncClientWith403Response() {
-        // when you get a forbidden response from getBucketLocation
-        when(mockClient.getBucketLocation(any(Consumer.class))).thenThrow(
-                S3Exception.builder().statusCode(403).build()
-        );
-        // you should fall back to a head bucket attempt
-        when(mockClient.headBucket(any(Consumer.class)))
-                .thenReturn((HeadBucketResponse) HeadBucketResponse.builder()
-                        .sdkHttpResponse(SdkHttpResponse.builder()
-                                .putHeader("x-amz-bucket-region", "us-west-2")
-                                .build())
-                        .build());
-
-        // which should get you a client
-        final S3AsyncClient s3Client = instance.generateAsyncClient("test-bucket", mockClient);
-        assertNotNull(s3Client);
-
-        final InOrder inOrder = inOrder(mockClient);
-        inOrder.verify(mockClient).getBucketLocation(any(Consumer.class));
-        inOrder.verify(mockClient).headBucket(any(Consumer.class));
-        inOrder.verifyNoMoreInteractions();
-    }
-
-    @Test
-    public void testGenerateAsyncClientWith403Then301Responses(){
-        // when you get a forbidden response from getBucketLocation
-        when(mockClient.getBucketLocation(any(Consumer.class))).thenThrow(
-                S3Exception.builder().statusCode(403).build()
-        );
-        // and you get a 301 response on headBucket
-        when(mockClient.headBucket(any(Consumer.class))).thenThrow(
-                S3Exception.builder()
-                        .statusCode(301)
-                        .awsErrorDetails(AwsErrorDetails.builder()
-                                .sdkHttpResponse(SdkHttpResponse.builder()
-                                        .putHeader("x-amz-bucket-region", "us-west-2")
-                                        .build())
-                                .build())
-                        .build()
-        );
-
-        // then you should be able to get a client as long as the error response header contains the region
-        final S3AsyncClient s3Client = instance.generateAsyncClient("test-bucket", mockClient);
-        assertNotNull(s3Client);
-
-        final InOrder inOrder = inOrder(mockClient);
-        inOrder.verify(mockClient).getBucketLocation(any(Consumer.class));
-        inOrder.verify(mockClient).headBucket(any(Consumer.class));
-        inOrder.verifyNoMoreInteractions();
-    }
-
-    @Test
-    public void testGenerateClientWith403Then301ResponsesNoHeader(){
-        // when you get a forbidden response from getBucketLocation
-        when(mockClient.getBucketLocation(any(Consumer.class))).thenThrow(
-                S3Exception.builder().statusCode(403).build()
-        );
-        // and you get a 301 response on headBucket but no header for region
-        when(mockClient.headBucket(any(Consumer.class))).thenThrow(
-                S3Exception.builder()
-                        .statusCode(301)
-                        .awsErrorDetails(AwsErrorDetails.builder()
-                                .sdkHttpResponse(SdkHttpResponse.builder()
-                                        .build())
-                                .build())
-                        .build()
-        );
-
-        // then you should get a NoSuchElement exception when you try to get the header
-        try {
-            instance.generateClient("test-bucket", mockClient);
-        } catch (Exception e) {
-            assertEquals(NoSuchElementException.class, e.getClass());
-        }
-
-        final InOrder inOrder = inOrder(mockClient);
-        inOrder.verify(mockClient).getBucketLocation(any(Consumer.class));
-        inOrder.verify(mockClient).headBucket(any(Consumer.class));
-        inOrder.verifyNoMoreInteractions();
-    }
-
-
-    @Test
-    public void testGenerateAsyncClientWith403Then301ResponsesNoHeader(){
-        // when you get a forbidden response from getBucketLocation
-        when(mockClient.getBucketLocation(any(Consumer.class))).thenThrow(
-                S3Exception.builder().statusCode(403).build()
-        );
-        // and you get a 301 response on headBucket but no header for region
-        when(mockClient.headBucket(any(Consumer.class))).thenThrow(
-                S3Exception.builder()
-                        .statusCode(301)
-                        .awsErrorDetails(AwsErrorDetails.builder()
-                                .sdkHttpResponse(SdkHttpResponse.builder()
-                                        .build())
-                                .build())
-                        .build()
-        );
-
-        // then you should get a NoSuchElement exception when you try to get the header
-        try {
-            instance.generateAsyncClient("test-bucket", mockClient);
-        } catch (Exception e) {
-            assertEquals(NoSuchElementException.class, e.getClass());
-        }
-
-        final InOrder inOrder = inOrder(mockClient);
-        inOrder.verify(mockClient).getBucketLocation(any(Consumer.class));
-        inOrder.verify(mockClient).headBucket(any(Consumer.class));
-        inOrder.verifyNoMoreInteractions();
-    }
-
-    @Test
-    public void testCaching() {
-        S3Client client = S3Client.builder().region(Region.US_EAST_1).build();
-        doReturn(client).when(spyInstance).generateClient("test-bucket");
-
-        final S3Client client1 = spyInstance.getClientForBucketName("test-bucket");
-        verify(spyInstance).generateClient("test-bucket");
-        assertSame(client1, client);
-
-        S3Client differentClient = S3Client.builder().region(Region.US_EAST_1).build();
-        assertNotSame(client, differentClient);
-
-        lenient().doReturn(differentClient).when(spyInstance).generateClient("test-bucket");
-        final S3Client client2 = spyInstance.getClientForBucketName("test-bucket");
-        // same instance because second is cached.
-        assertSame(client1, client2);
-        assertSame(client2, client);
-        assertNotSame(client2, differentClient);
-    }
-
-    @Test
-    public void testAsyncCaching() {
-        S3AsyncClient client = S3AsyncClient.builder().region(Region.US_EAST_1).build();
-        doReturn(client).when(spyInstance).generateAsyncClient("test-bucket");
-
-        final S3AsyncClient client1 = spyInstance.getAsyncClientForBucketName("test-bucket");
-        verify(spyInstance).generateAsyncClient("test-bucket");
-        assertSame(client1, client);
-
-        S3AsyncClient differentClient = S3AsyncClient.builder().region(Region.US_EAST_1).build();
-        assertNotSame(client, differentClient);
-
-        lenient().doReturn(differentClient).when(spyInstance).generateAsyncClient("test-bucket");
-        final S3AsyncClient client2 = spyInstance.getAsyncClientForBucketName("test-bucket");
-        // same instance because second is cached.
-        assertSame(client1, client2);
-        assertSame(client2, client);
-        assertNotSame(client2, differentClient);
-    }
 }
 

--- a/src/test/java/software/amazon/nio/spi/s3/S3ClientStoreTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3ClientStoreTest.java
@@ -16,6 +16,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3Client;
 
+/**
+ * @deprecated {@link S3ClientStore} is not used any more and should not be used in new
+ *             implementations as it will be removed in a later version. It has
+ *             been replaced by {@link S3ClientProvider} which provides the same
+ *             functionality but the singleton instance. Now many instances of
+ *             a {@code S3(Async)Client} can be created, each accessing its own
+ *             bucket with its own connection settings.
+ */
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings("unchecked")
 @Deprecated

--- a/src/test/java/software/amazon/nio/spi/s3/S3FileSystemProviderTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3FileSystemProviderTest.java
@@ -142,7 +142,7 @@ public class S3FileSystemProviderTest {
             fail("mising argument check!");
         } catch (IllegalArgumentException x) {
             assertEquals(
-                "invalid uri 'noscheme', please provide an uri as s3://[key:secret@][host:port]/bucket",
+                "invalid uri 'noscheme', please provide an uri as s3://bucket",
                 x.getMessage()
             );
         }
@@ -152,7 +152,7 @@ public class S3FileSystemProviderTest {
             fail("mising argument check!");
         } catch (IllegalArgumentException x) {
             assertEquals(
-                "invalid uri 's3:///', please provide an uri as s3://[key:secret@][host:port]/bucket",
+                "invalid uri 's3:///', please provide an uri as s3://bucket",
                 x.getMessage()
             );
         }

--- a/src/test/java/software/amazon/nio/spi/s3/S3FileSystemProviderTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3FileSystemProviderTest.java
@@ -59,7 +59,6 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterEach;
 
 import static org.junit.jupiter.api.Assertions.*;
-import org.junit.jupiter.api.Disabled;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
@@ -256,7 +255,7 @@ public class S3FileSystemProviderTest {
         when(mockClient.listObjectsV2Paginator(any(Consumer.class))).thenReturn(publisher);
         when(mockClient.listObjectsV2(any(ListObjectsV2Request.class))).thenReturn(CompletableFuture.supplyAsync(() ->
                 ListObjectsV2Response.builder().contents(object1, object2, object3).build()));
-        
+
         Iterator<Path> pathIterator =
             provider.newDirectoryStream(fs.getPath(pathUri + "/"), path -> true).iterator();
 

--- a/src/test/java/software/amazon/nio/spi/s3/S3FileSystemProviderTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3FileSystemProviderTest.java
@@ -237,16 +237,12 @@ public class S3FileSystemProviderTest {
         when(mockClient.listObjectsV2(any(ListObjectsV2Request.class))).thenReturn(CompletableFuture.supplyAsync(() ->
                 ListObjectsV2Response.builder().contents(object1, object2).build()));
 
-        final DirectoryStream<Path> stream = provider.newDirectoryStream(Paths.get(URI.create(pathUri+"/")), entry -> true);
+        final DirectoryStream<Path> stream = provider.newDirectoryStream(fs.getPath(pathUri+"/"), entry -> true);
         assertNotNull(stream);
         assertEquals(2, countDirStreamItems(stream));
     }
 
     @Test
-    @Disabled
-    //
-    // TODO: fix this - why pagination does not take place?
-    //
     public void pathIteratorForPublisher_withPagination() throws IOException {
         final ListObjectsV2Publisher publisher = new ListObjectsV2Publisher(mockClient,
                 ListObjectsV2Request.builder()
@@ -260,10 +256,9 @@ public class S3FileSystemProviderTest {
         when(mockClient.listObjectsV2Paginator(any(Consumer.class))).thenReturn(publisher);
         when(mockClient.listObjectsV2(any(ListObjectsV2Request.class))).thenReturn(CompletableFuture.supplyAsync(() ->
                 ListObjectsV2Response.builder().contents(object1, object2, object3).build()));
-
-        DirectoryStream.Filter<? super Path> filter = path -> true;
+        
         Iterator<Path> pathIterator =
-            provider.newDirectoryStream(Paths.get(URI.create(pathUri+"/")), filter).iterator();
+            provider.newDirectoryStream(fs.getPath(pathUri + "/"), path -> true).iterator();
 
         assertNotNull(pathIterator);
         assertTrue(pathIterator.hasNext());

--- a/src/test/java/software/amazon/nio/spi/s3/S3FileSystemProviderTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3FileSystemProviderTest.java
@@ -82,7 +82,7 @@ public class S3FileSystemProviderTest {
         lenient().when(mockClient.headObject(any(Consumer.class))).thenReturn(
                 CompletableFuture.supplyAsync(() -> HeadObjectResponse.builder().contentLength(100L).build()));
         fs = provider.newFileSystem(URI.create(pathUri));
-        fs.clientProvider = new FixedS3ClientProvider(mockClient);
+        fs.clientProvider(new FixedS3ClientProvider(mockClient));
     }
 
     @AfterEach

--- a/src/test/java/software/amazon/nio/spi/s3/S3FileSystemTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3FileSystemTest.java
@@ -40,7 +40,7 @@ public class S3FileSystemTest {
     public void init() {
         provider = new S3FileSystemProvider();
         s3FileSystem = this.provider.newFileSystem(s3Uri, Collections.emptyMap());
-        s3FileSystem.clientProvider = new FixedS3ClientProvider(mockClient);
+        s3FileSystem.clientProvider(new FixedS3ClientProvider(mockClient));
         lenient().when(mockClient.headObject(any(Consumer.class))).thenReturn(
                 CompletableFuture.supplyAsync(() -> HeadObjectResponse.builder().contentLength(100L).build()));
     }

--- a/src/test/java/software/amazon/nio/spi/s3/S3PathTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3PathTest.java
@@ -45,7 +45,7 @@ public class S3PathTest {
     @BeforeEach
     public void init(){
         fileSystem = provider.newFileSystem(URI.create(uriString));
-        fileSystem.clientProvider = new FixedS3ClientProvider(mockClient);
+        fileSystem.clientProvider(new FixedS3ClientProvider(mockClient));
         lenient().when(mockClient.headObject(any(Consumer.class))).thenReturn(
                 CompletableFuture.supplyAsync(() -> HeadObjectResponse.builder().contentLength(100L).build()));
         root = S3Path.getPath(fileSystem, S3Path.PATH_SEPARATOR);

--- a/src/test/java/software/amazon/nio/spi/s3/S3SeekableByteChannelTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3SeekableByteChannelTest.java
@@ -58,7 +58,7 @@ public class S3SeekableByteChannelTest {
 
         S3FileSystemProvider provider = new S3FileSystemProvider();
         fs = provider.newFileSystem(URI.create("s3://test-bucket"));
-        fs.clientProvider = new FixedS3ClientProvider(mockClient);
+        fs.clientProvider(new FixedS3ClientProvider(mockClient));
         path = fs.getPath("/object");
     }
 

--- a/src/test/java/software/amazon/nio/spi/s3/S3SeekableByteChannelTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3SeekableByteChannelTest.java
@@ -13,6 +13,7 @@ import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.*;
 
 import java.io.IOException;
+import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.OpenOption;
@@ -21,6 +22,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
+import org.junit.jupiter.api.AfterEach;
 import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -54,8 +56,15 @@ public class S3SeekableByteChannelTest {
                         GetObjectResponse.builder().contentLength(6L).build(),
                         bytes)));
 
-        fs = new S3FileSystem("test-bucket");
+        S3FileSystemProvider provider = new S3FileSystemProvider();
+        fs = provider.newFileSystem(URI.create("s3://test-bucket"));
+        fs.clientProvider = new FixedS3ClientProvider(mockClient);
         path = fs.getPath("/object");
+    }
+
+    @AfterEach
+    public void after() throws IOException {
+        fs.close();
     }
 
     @Test

--- a/src/test/java/software/amazon/nio/spi/s3/config/S3NioSpiConfigurationTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/config/S3NioSpiConfigurationTest.java
@@ -11,7 +11,6 @@ import java.util.Map;
 import java.util.Properties;
 
 import static org.assertj.core.api.BDDAssertions.then;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 import org.junit.jupiter.api.BeforeEach;
@@ -59,23 +58,23 @@ public class S3NioSpiConfigurationTest {
         map.put(S3_SPI_READ_MAX_FRAGMENT_SIZE_PROPERTY, "1212");
         S3NioSpiConfiguration c = new S3NioSpiConfiguration(map);
 
-        assertEquals(1212, c.getMaxFragmentSize());
+        then(c.getMaxFragmentSize()).isEqualTo(1212);
     }
 
     @Test
     public void getS3SpiReadMaxFragmentSize() {
-        assertEquals(S3_SPI_READ_MAX_FRAGMENT_SIZE_DEFAULT, config.getMaxFragmentSize());
+        then(config.getMaxFragmentSize()).isEqualTo(S3_SPI_READ_MAX_FRAGMENT_SIZE_DEFAULT);
 
-        assertEquals(1111, overriddenConfig.getMaxFragmentSize());
-        assertEquals(S3_SPI_READ_MAX_FRAGMENT_SIZE_DEFAULT, badOverriddenConfig.getMaxFragmentSize());
+        then(overriddenConfig.getMaxFragmentSize()).isEqualTo(1111);
+        then(badOverriddenConfig.getMaxFragmentSize()).isEqualTo(S3_SPI_READ_MAX_FRAGMENT_SIZE_DEFAULT);
     }
 
     @Test
     public void getS3SpiReadMaxFragmentNumber() {
-        assertEquals(S3_SPI_READ_MAX_FRAGMENT_NUMBER_DEFAULT, config.getMaxFragmentNumber());
+        then(config.getMaxFragmentNumber()).isEqualTo(S3_SPI_READ_MAX_FRAGMENT_NUMBER_DEFAULT);
 
-        assertEquals(2, overriddenConfig.getMaxFragmentNumber());
-        assertEquals(S3_SPI_READ_MAX_FRAGMENT_NUMBER_DEFAULT, badOverriddenConfig.getMaxFragmentNumber());
+        then(overriddenConfig.getMaxFragmentNumber()).isEqualTo(2);
+        then(badOverriddenConfig.getMaxFragmentNumber()).isEqualTo(S3_SPI_READ_MAX_FRAGMENT_NUMBER_DEFAULT);
     }
 
     @Test
@@ -198,6 +197,7 @@ public class S3NioSpiConfigurationTest {
         then(config.withCredentials(C2)).isSameAs(config);
         then(config.getCredentials()).isSameAs(C2);
         then(config.withCredentials(null).getCredentials()).isNull();
+        then(config.withCredentials(C1).withCredentials(null, null).getCredentials()).isNull();
 
         //
         // withCredentials(AwsCredentials) takes priority over withCredentialas(String, String)
@@ -212,10 +212,10 @@ public class S3NioSpiConfigurationTest {
     @Test
     public void convertPropertyNameToEnvVar() {
         String expected = "FOO_BAA_FIZZ_BUZZ";
-        assertEquals(expected, config.convertPropertyNameToEnvVar("foo.baa.fizz-buzz"));
+        then(config.convertPropertyNameToEnvVar("foo.baa.fizz-buzz")).isEqualTo(expected);
 
         expected = "";
-        assertEquals(expected, config.convertPropertyNameToEnvVar(null));
-        assertEquals(expected, config.convertPropertyNameToEnvVar("  "));
+        then(config.convertPropertyNameToEnvVar(null)).isEqualTo(expected);
+        then(config.convertPropertyNameToEnvVar("  ")).isEqualTo(expected);
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
#30 

*Description of changes:*
As per the discussion on #30 we want to implement NIO FileSystem semantic, which is lead by the methods newFileSystem() and getFileSystem(); the former shall return a new instance or throw an exception, while the latter should return an existing instance. This means that S3FileSystem instances shall be cached (as opposed to the current implementation that caches AWSClients).
Another change introduced and discussed in other thread is the use of S3ClientProvider at S3FileSystem level in order to better decouple file system logic from the aws client creation logic (discussed in #50). This obsoletes IMHO the methods in S3FileSystemProvider that receives a AWSAsyncClient, which I would remove in future version to keep S3FileSystemProvider cleaner and simpler.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

PS: as often gradle complains, this time about javadoc I think :( it builds locally with both gradle and maven ...
