### PR TITLE
Third party S3 services support + #61

### DIFF
--- a/src/main/java/examples/WalkFromRoot.java
+++ b/src/main/java/examples/WalkFromRoot.java
@@ -19,8 +19,11 @@ public class WalkFromRoot {
      * @throws IOException if a communication problem happens with the S3 service.
      */
     public static void main(String[] args) throws IOException {
-        final String bucketName = args[0];
-        final FileSystem s3 = FileSystems.newFileSystem(URI.create("s3://"+bucketName), Collections.EMPTY_MAP);
+        String bucketName = args[0];
+        if (!bucketName.startsWith("s3:") && !bucketName.startsWith("s3x:")) {
+            bucketName = "s3://" + bucketName;
+        }
+        final FileSystem s3 = FileSystems.newFileSystem(URI.create(bucketName), Collections.EMPTY_MAP);
 
         for (Path rootDir : s3.getRootDirectories()) {
             Files.walk(rootDir).forEach(System.out::println);

--- a/src/main/java/software/amazon/nio/spi/s3/FixedS3ClientProvider.java
+++ b/src/main/java/software/amazon/nio/spi/s3/FixedS3ClientProvider.java
@@ -36,5 +36,4 @@ public class FixedS3ClientProvider extends S3ClientProvider {
     protected S3Client generateClient (String bucketName) {
         return (S3Client)client;
     }
-
 }

--- a/src/main/java/software/amazon/nio/spi/s3/S3ClientProvider.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3ClientProvider.java
@@ -179,7 +179,7 @@ public class S3ClientProvider {
         logger.debug("generating client for bucket: '{}'", bucketName);
         S3Client bucketSpecificClient = null;
 
-        if ((configuration.getEndpoint() == null) || (configuration.getEndpoint().isBlank())) {
+        if ((configuration.getEndpoint() == null) || isBlank(configuration.getEndpoint())) {
             //
             // we try to locate a bucket only if no endpoint is provided, which
             // means we are dealing with AWS S3 buckets

--- a/src/main/java/software/amazon/nio/spi/s3/S3ClientProvider.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3ClientProvider.java
@@ -184,40 +184,40 @@ public class S3ClientProvider {
             // we try to locate a bucket only if no endpoint is provided, which
             // means we are dealing with AWS S3 buckets
             //
-        String bucketLocation = null;
-        try {
-            logger.debug("determining bucket location with getBucketLocation");
-            bucketLocation = locationClient.getBucketLocation(builder -> builder.bucket(bucketName)).locationConstraintAsString();
-            bucketSpecificClient = this.clientForRegion(bucketLocation);
-        } catch (S3Exception e) {
-            if(e.statusCode() == 403) {
-                logger.debug("Cannot determine location of '{}' bucket directly. Attempting to obtain bucket location with headBucket operation", bucketName);
-                try {
-                    final HeadBucketResponse headBucketResponse = locationClient.headBucket(builder -> builder.bucket(bucketName));
-                    bucketSpecificClient = this.clientForRegion(headBucketResponse.
-                            sdkHttpResponse()
-                            .firstMatchingHeader("x-amz-bucket-region")
-                            .orElseThrow(() -> new NoSuchElementException("Head Bucket Response doesn't include the header 'x-amz-bucket-region'")));
-                } catch (S3Exception e2) {
-                    if (e2.statusCode() == 301) {
-                        bucketSpecificClient = this.clientForRegion(e2.awsErrorDetails().
+            String bucketLocation = null;
+            try {
+                logger.debug("determining bucket location with getBucketLocation");
+                bucketLocation = locationClient.getBucketLocation(builder -> builder.bucket(bucketName)).locationConstraintAsString();
+                bucketSpecificClient = this.clientForRegion(bucketLocation);
+            } catch (S3Exception e) {
+                if(e.statusCode() == 403) {
+                    logger.debug("Cannot determine location of '{}' bucket directly. Attempting to obtain bucket location with headBucket operation", bucketName);
+                    try {
+                        final HeadBucketResponse headBucketResponse = locationClient.headBucket(builder -> builder.bucket(bucketName));
+                        bucketSpecificClient = this.clientForRegion(headBucketResponse.
                                 sdkHttpResponse()
                                 .firstMatchingHeader("x-amz-bucket-region")
                                 .orElseThrow(() -> new NoSuchElementException("Head Bucket Response doesn't include the header 'x-amz-bucket-region'")));
-                    } else {
-                        throw e2;
+                    } catch (S3Exception e2) {
+                        if (e2.statusCode() == 301) {
+                            bucketSpecificClient = this.clientForRegion(e2.awsErrorDetails().
+                                    sdkHttpResponse()
+                                    .firstMatchingHeader("x-amz-bucket-region")
+                                    .orElseThrow(() -> new NoSuchElementException("Head Bucket Response doesn't include the header 'x-amz-bucket-region'")));
+                        } else {
+                            throw e2;
+                        }
                     }
+                } else {
+                    throw e;
                 }
-            } else {
-                throw e;
             }
-        }
 
-        //
-        // if here, no S3 nor other client has been created yet and we do not
-        // have a location; we'll let it figure out from the profile region
-        //
-        logger.warn("Unable to determine the region of bucket: '{}'. Generating a client for the profile region.", bucketName);
+            //
+            // if here, no S3 nor other client has been created yet and we do not
+            // have a location; we'll let it figure out from the profile region
+            //
+            logger.warn("Unable to determine the region of bucket: '{}'. Generating a client for the profile region.", bucketName);
         }
 
         return (bucketSpecificClient != null)
@@ -244,41 +244,41 @@ public class S3ClientProvider {
             // we try to locate a bucket only if no endpoint is provided, which
             // means we are dealing with AWS S3 buckets
             //
-        String bucketLocation = null;
-        try {
-            logger.debug("determining bucket location with getBucketLocation");
-            bucketLocation = locationClient.getBucketLocation(builder -> builder.bucket(bucketName)).locationConstraintAsString();
-            bucketSpecificClient = this.asyncClientForRegion(bucketLocation);
-        } catch (S3Exception e) {
-            if(e.statusCode() == 403) {
-                logger.debug("Cannot determine location of '{}' bucket directly. Attempting to obtain bucket location with headBucket operation", bucketName);
-                try {
-                    final HeadBucketResponse headBucketResponse = locationClient.headBucket(builder -> builder.bucket(bucketName));
-                    bucketSpecificClient = this.asyncClientForRegion(headBucketResponse.sdkHttpResponse()
-                            .firstMatchingHeader("x-amz-bucket-region")
-                            .orElseThrow(() -> new NoSuchElementException("Head Bucket Response doesn't include the header 'x-amz-bucket-region'")));
-                } catch (S3Exception e2) {
-                    if (e2.statusCode() == 301) {
-                        bucketSpecificClient = this.asyncClientForRegion(e2
-                                .awsErrorDetails()
-                                .sdkHttpResponse()
+            String bucketLocation = null;
+            try {
+                logger.debug("determining bucket location with getBucketLocation");
+                bucketLocation = locationClient.getBucketLocation(builder -> builder.bucket(bucketName)).locationConstraintAsString();
+                bucketSpecificClient = this.asyncClientForRegion(bucketLocation);
+            } catch (S3Exception e) {
+                if(e.statusCode() == 403) {
+                    logger.debug("Cannot determine location of '{}' bucket directly. Attempting to obtain bucket location with headBucket operation", bucketName);
+                    try {
+                        final HeadBucketResponse headBucketResponse = locationClient.headBucket(builder -> builder.bucket(bucketName));
+                        bucketSpecificClient = this.asyncClientForRegion(headBucketResponse.sdkHttpResponse()
                                 .firstMatchingHeader("x-amz-bucket-region")
-                                .orElseThrow(() -> new NoSuchElementException("Head Bucket Response doesn't include the header 'x-amz-bucket-region'"))
-                        );
-                    } else {
-                        throw e2;
+                                .orElseThrow(() -> new NoSuchElementException("Head Bucket Response doesn't include the header 'x-amz-bucket-region'")));
+                    } catch (S3Exception e2) {
+                        if (e2.statusCode() == 301) {
+                            bucketSpecificClient = this.asyncClientForRegion(e2
+                                    .awsErrorDetails()
+                                    .sdkHttpResponse()
+                                    .firstMatchingHeader("x-amz-bucket-region")
+                                    .orElseThrow(() -> new NoSuchElementException("Head Bucket Response doesn't include the header 'x-amz-bucket-region'"))
+                            );
+                        } else {
+                            throw e2;
+                        }
                     }
+                } else {
+                    throw e;
                 }
-            } else {
-                throw e;
             }
-        }
 
-        //
-        // if here, no S3 nor other client has been created yet and we do not
-        // have a location; we'll let it figure out from the profile region
-        //
-        logger.warn("Unable to determine the region of bucket: '{}'. Generating a client for the profile region.", bucketName);
+            //
+            // if here, no S3 nor other client has been created yet and we do not
+            // have a location; we'll let it figure out from the profile region
+            //
+            logger.warn("Unable to determine the region of bucket: '{}'. Generating a client for the profile region.", bucketName);
         }
 
         return (bucketSpecificClient != null)

--- a/src/main/java/software/amazon/nio/spi/s3/S3ClientStore.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3ClientStore.java
@@ -27,7 +27,6 @@ public class S3ClientStore {
 
     private static final S3ClientStore instance = new S3ClientStore();
 
-
     private final Map<String, S3Client> bucketToClientMap = Collections.synchronizedMap(new HashMap<>());
     private final Map<String, S3AsyncClient> bucketToAsyncClientMap = Collections.synchronizedMap(new HashMap<>());
 
@@ -48,6 +47,7 @@ public class S3ClientStore {
     public static S3ClientStore getInstance() { return instance; }
 
     protected S3ClientProvider provider = new S3ClientProvider();
+
     /**
      * Get an existing client or generate a new client for the named bucket if one doesn't exist
      * @param bucketName the bucket name. If this value is null or empty a default client is returned
@@ -75,6 +75,4 @@ public class S3ClientStore {
 
         return bucketToAsyncClientMap.computeIfAbsent(bucketName, provider::generateAsyncClient);
     }
-
-
 }

--- a/src/main/java/software/amazon/nio/spi/s3/S3FileSystem.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3FileSystem.java
@@ -78,7 +78,7 @@ public class S3FileSystem extends FileSystem {
      *
      * {@code Path p = Paths.get("s3://mybucket");}
      *
-     * This method should be replaced with {@code new S3FileSystem(provider, config)
+     * This method should be replaced with {@code new S3FileSystem(provider, config)}
      *
      */
     @Deprecated
@@ -97,7 +97,7 @@ public class S3FileSystem extends FileSystem {
      *
      * {@code Path p = Paths.get("s3://mybucket");}
      *
-     * This method should be replaced with {@code new S3FileSystem(provider)
+     * This method should be replaced with {@code new S3FileSystem(provider)}
      */
     @Deprecated
     protected S3FileSystem(URI uri, S3FileSystemProvider provider) {
@@ -109,7 +109,7 @@ public class S3FileSystem extends FileSystem {
      * Create a filesystem that represents the bucket specified by the URI
      *
      * @param uri a valid S3 URI to a bucket, e.g <code>URI.create("s3://mybucket")</code>
-     * @param s3FileSystemProvider the provider to be used with this fileSystem
+     * @param provider the provider to be used with this fileSystem
      * @param config the configuration to use; can be null to use a default configuration
      *
      * @deprecated the preferred way to create a file system is to use NIO or
@@ -117,7 +117,7 @@ public class S3FileSystem extends FileSystem {
      *
      * {@code Path p = Paths.get("s3://mybucket");}
      *
-     * This method should be replaced with {@code new S3FileSystem(provider, config)
+     * This method should be replaced with {@code new S3FileSystem(provider, config)}
      */
     @Deprecated
     protected S3FileSystem(URI uri, S3FileSystemProvider provider, S3NioSpiConfiguration config) {
@@ -142,7 +142,7 @@ public class S3FileSystem extends FileSystem {
      *
      * {@code Path p = Paths.get("s3://mybucket");}
      *
-     * This method should be replaced with {@code new S3FileSystem(provider, config)
+     * This method should be replaced with {@code new S3FileSystem(provider, config)}
      */
     @Deprecated
     protected S3FileSystem(String bucketName){

--- a/src/main/java/software/amazon/nio/spi/s3/S3FileSystem.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3FileSystem.java
@@ -76,9 +76,7 @@ public class S3FileSystem extends FileSystem {
      * @deprecated the preferred way to create a file system is to use NIO or
      * the provider itself:
      *
-     * {@code
-     *     Path p = Paths.get("s3://mybucket");
-     * }
+     * {@code Path p = Paths.get("s3://mybucket");}
      *
      * This method should be replaced with {@code new S3FileSystem(provider, config)
      *
@@ -97,9 +95,7 @@ public class S3FileSystem extends FileSystem {
      * @deprecated the preferred way to create a file system is to use NIO or
      * the provider itself:
      *
-     * {@code
-     *     Path p = Paths.get("s3://mybucket");
-     * }
+     * {@code Path p = Paths.get("s3://mybucket");}
      *
      * This method should be replaced with {@code new S3FileSystem(provider)
      */
@@ -119,9 +115,7 @@ public class S3FileSystem extends FileSystem {
      * @deprecated the preferred way to create a file system is to use NIO or
      * the provider itself:
      *
-     * {@code
-     *     Path p = Paths.get("s3://mybucket");
-     * }
+     * {@code Path p = Paths.get("s3://mybucket");}
      *
      * This method should be replaced with {@code new S3FileSystem(provider, config)
      */
@@ -146,9 +140,7 @@ public class S3FileSystem extends FileSystem {
      * @deprecated the preferred way to create a file system is to use NIO or
      * the provider itself:
      *
-     * {@code
-     *     Path p = Paths.get("s3://mybucket");
-     * }
+     * {@code Path p = Paths.get("s3://mybucket");}
      *
      * This method should be replaced with {@code new S3FileSystem(provider, config)
      */

--- a/src/main/java/software/amazon/nio/spi/s3/S3Path.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3Path.java
@@ -26,6 +26,8 @@ import java.util.List;
 import java.util.Objects;
 
 import static java.nio.file.LinkOption.NOFOLLOW_LINKS;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.nio.spi.s3.config.S3NioSpiConfiguration;
 
 @SuppressWarnings("NullableProblems")
 public class S3Path implements Path {
@@ -85,11 +87,30 @@ public class S3Path implements Path {
           throw new IllegalArgumentException("first element of the path may not be null");
         }
 
+        S3NioSpiConfiguration configuration = fsForBucket.configuration();
+
         first = first.trim();
 
         if((first.isEmpty()) && !(more == null || more.length == 0)) throw new IllegalArgumentException("The first element of the path may not be empty when more exists");
-        if( first.startsWith(S3FileSystemProvider.SCHEME+":/")) {
-            first = first.replaceFirst(S3FileSystemProvider.SCHEME+":/", "");
+        if(first.startsWith(fsForBucket.provider().getScheme()+":/")) {
+            first = first.substring(fsForBucket.provider().getScheme().length()+2);
+
+            String part = null;
+            if (configuration.getCredentials() != null) {
+                AwsCredentials credentials = configuration.getCredentials();
+                part = credentials.accessKeyId() + ':' + credentials.secretAccessKey();
+                if (first.startsWith('/' + part)) {
+                    first = PATH_SEPARATOR + first.substring(part.length()+2);
+                }
+            }
+            part = configuration.getEndpoint();
+            if (!part.isEmpty() && first.startsWith(PATH_SEPARATOR + part)) {
+                first = first.substring(part.length()+1);
+            }
+            part = configuration.getBucketName();
+            if (first.startsWith(PATH_SEPARATOR + part)) {
+                first = first.substring(part.length()+1);
+            }
         }
 
         return new S3Path(fsForBucket, PosixLikePathRepresentation.of(first, more));
@@ -604,19 +625,19 @@ public class S3Path implements Path {
      * provider (s3). Please note that the returned URI is a well formed URI,
      * which means all special characters (e.g. blanks, %, ?, etc.) are encoded.
      * This may result in a different string from the real path (object key),
-     * which instead allows those characters. 
-     * 
+     * which instead allows those characters.
+     *
      * For instance, the S3 URI "s3://mybucket/with space and %" is a valid S3
      * object key, which must be encoded when creating a Path and that will be
      * encoded when creating a URI. E.g.:
-     * 
+     *
      * <pre>
-     * {@code 
+     * {@code
      * S3Path p = (S3Path)Paths.get("s3://mybucket/with+blank+and+%25"); // -> s3://mybucket/with blank and %
      * String s = p.toString; // -> /mybucket/with blank and %
      * URI u = p.toUri(); --> // -> s3://mybucket/with+blank+and+%25
      * ...
-     * String s = p.getFileSystem().get("with space").toString(); // -> /with space 
+     * String s = p.getFileSystem().get("with space").toString(); // -> /with space
      * }
      * </pre>
      *
@@ -629,7 +650,7 @@ public class S3Path implements Path {
      *                           is installed, the {@link #toAbsolutePath toAbsolutePath} method
      *                           throws a security exception.
      */
-    
+
     @Override
     public URI toUri() {
         Path path = toAbsolutePath().toRealPath(NOFOLLOW_LINKS);

--- a/src/main/java/software/amazon/nio/spi/s3/S3SeekableByteChannel.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3SeekableByteChannel.java
@@ -28,9 +28,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-//
-// TODO: simplify: S3Path brings already the client to use with getFileSystem().client()
-//
 public class S3SeekableByteChannel implements SeekableByteChannel {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(S3SeekableByteChannel.class);

--- a/src/main/java/software/amazon/nio/spi/s3/config/S3NioSpiConfiguration.java
+++ b/src/main/java/software/amazon/nio/spi/s3/config/S3NioSpiConfiguration.java
@@ -21,11 +21,13 @@ import software.amazon.awssdk.utils.Pair;
 import software.amazon.nio.spi.s3.util.StringUtils;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.services.s3.internal.BucketUtils;
 
 /**
  * Object to hold configuration of the S3 NIO SPI
  */
 public class S3NioSpiConfiguration extends HashMap<String, Object> {
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     public static final String AWS_REGION_PROPERTY = "aws.region";
     public static final String AWS_ACCESS_KEY_PROPERTY = "aws.accessKey";
@@ -70,7 +72,9 @@ public class S3NioSpiConfiguration extends HashMap<String, Object> {
     public static final String S3_SPI_CREDENTIALS_PROPERTY = "s3.spi.credentials";
 
     private final Pattern ENDPOINT_REGEXP = Pattern.compile("(\\w[\\w\\-\\.]*)?(:(\\d+))?");
-    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    private String bucketName;
+
 
     /**
      * Create a new, empty configuration
@@ -212,6 +216,23 @@ public class S3NioSpiConfiguration extends HashMap<String, Object> {
     }
 
     /**
+     * Fluently sets the value of bucketName
+     *
+     * @param bucketName the bucket name
+     *
+     * @throws IllegalArgumentException if bucketName is not compliant with
+     *         https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
+     *
+     * @return this instance
+     */
+    public S3NioSpiConfiguration withBucketName(String bucketName) {
+        if (bucketName != null) {
+            BucketUtils.isValidDnsBucketName(bucketName, true);
+        }
+        this.bucketName = bucketName; return this;
+    }
+
+     /**
      * Fluently sets the value of accessKey and secretAccessKey
      *
      * @param accessKey the accesskey; if null, credentials are removed
@@ -332,6 +353,15 @@ public class S3NioSpiConfiguration extends HashMap<String, Object> {
      */
     public String getRegion() {
         return (String)get(AWS_REGION_PROPERTY);
+    }
+
+    /**
+     * Get the configured bucket name if configured
+     *
+     * @return the configured value or null if not provided
+     */
+    public String getBucketName() {
+        return bucketName;
     }
 
     /**

--- a/src/main/java/software/amazon/nio/spi/s3/util/S3FileSystemInfo.java
+++ b/src/main/java/software/amazon/nio/spi/s3/util/S3FileSystemInfo.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2023 ste.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.nio.spi.s3.util;
+
+import java.net.URI;
+import software.amazon.awssdk.services.s3.internal.BucketUtils;
+
+/**
+ * Populates fields with information extracted by the S3 URI provided. This
+ * implementation is for standard AWS buckets as described in section
+ * "Accessing a bucket using S3://" in https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-bucket-intro.html
+ *
+ * It also computes the file system key that can be used to identify a runtime
+ * instance of a S3FileSystem (for caching purposes for example). In this
+ * implementation the key is the bucket name (which is unique in the AWS S3
+ * namespace).
+ *
+ */
+public class S3FileSystemInfo {
+
+    protected String key;
+    protected String endpoint;
+    protected String bucket;
+    protected String accessKey;
+    protected String accessSecret;
+
+    protected S3FileSystemInfo() {}
+
+    /**
+     * Creates a new instance and populates it with key and bucket. The name of
+     * the bucket must follow AWS S3 bucket naming rules (https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html)
+     *
+     * @param uri a S3 URI
+     *
+     * @throws IllegalArgumentException if URI contains invalid components
+     *         (e.g. an invalid bucket name)
+     */
+    public S3FileSystemInfo(URI uri) throws IllegalArgumentException {
+        if (uri == null) {
+            throw new IllegalArgumentException("uri can not be null");
+        }
+
+        key = bucket = uri.getAuthority();
+        endpoint = accessKey = accessSecret = null;
+
+        BucketUtils.isValidDnsBucketName(bucket, true);
+    }
+
+    public String key() { return key; }
+    public String endpoint() { return endpoint; }
+    public String bucket() { return bucket; }
+    public String accessKey() { return accessKey; }
+    public String accessSecret() { return accessSecret; }
+}

--- a/src/main/java/software/amazon/nio/spi/s3x/S3XFileSystemProvider.java
+++ b/src/main/java/software/amazon/nio/spi/s3x/S3XFileSystemProvider.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2023 ste.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.nio.spi.s3x;
+
+import java.net.URI;
+import software.amazon.nio.spi.s3.S3FileSystemProvider;
+import software.amazon.nio.spi.s3.util.S3FileSystemInfo;
+import software.amazon.nio.spi.s3x.util.S3XFileSystemInfo;
+
+/**
+ *
+ */
+public class S3XFileSystemProvider extends S3FileSystemProvider {
+
+    public static final String SCHEME = "s3x";
+
+    /**
+     * Returns the URI scheme that identifies this provider.
+     *
+     * @return The URI scheme (s3x)
+     */
+    @Override
+    public String getScheme() {
+        return SCHEME;
+    }
+
+    /**
+     * This overrides the default AWS implementation to be able to address 3rd
+     * party S3 services. To do so, we relax the default S3 URI format to the
+     * following:
+     *
+     * {@code
+     *
+     * s3x://[accessKey:accessSecret@]endpoint/bucket/key
+     *
+     * }
+     *
+     * Please note that the authority part of the URI (endpoint above) is always
+     * considered a HTTP(S) endpoint, therefore the name of the bucket is the
+     * first element of the path. The remaining path elements will be the object
+     * key.
+     *
+     * @param uri the URI to extract the information from
+     *
+     * @return the information extracted from {@code uri}
+     */
+    @Override
+    protected S3FileSystemInfo fileSystemInfo(URI uri) {
+        return new S3XFileSystemInfo(uri);
+    }
+
+}

--- a/src/main/java/software/amazon/nio/spi/s3x/util/S3XFileSystemInfo.java
+++ b/src/main/java/software/amazon/nio/spi/s3x/util/S3XFileSystemInfo.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2023 ste.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.nio.spi.s3x.util;
+
+import java.net.URI;
+import software.amazon.awssdk.services.s3.internal.BucketUtils;
+import software.amazon.nio.spi.s3.S3Path;
+import software.amazon.nio.spi.s3.util.S3FileSystemInfo;
+
+/**
+ * Populates fields with information extracted by the S3 URI provided. This
+ * implementation is for standard AWS buckets as described in section
+ * "Accessing a bucket using S3://" in https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-bucket-intro.html
+ *
+ * It also computes the file system key that can be used to identify a runtime
+ * instance of a S3FileSystem (for caching purposes for example). In this
+ * implementation the key is the bucket name (which is unique in the AWS S3
+ * namespace).
+ *
+ */
+public class S3XFileSystemInfo extends S3FileSystemInfo {
+
+    /**
+     * Creates a new instance and populates it with the information extracted
+     * from {@code uri}. The provided uri is parsed accordingly to the following
+     * format:
+     *
+     * {@code
+     *
+     * s3x://[accessKey:accessSecret@]endpoint[:port]/bucket/key
+     *
+     * }
+     *
+     * Please note that the authority part of the URI (endpoint[:port] above) is always
+     * considered a HTTP(S) endpoint, therefore the name of the bucket is the
+     * first element of the path. The remaining path elements will be the object
+     * key.
+     *
+     * Additionally {@code key} is computed as endpoint/bucket/accessKey
+     *
+     * @param uri a S3 URI
+     *
+     * @throws IllegalArgumentException if URI contains invalid components
+     *         (e.g. an invalid bucket name)
+     */
+    public S3XFileSystemInfo(URI uri) throws IllegalArgumentException {
+        if (uri == null) {
+            throw new IllegalArgumentException("uri can not be null");
+        }
+
+        final String userInfo = uri.getUserInfo();
+
+        if (userInfo != null) {
+            int pos = userInfo.indexOf(':');
+            accessKey = (pos < 0) ? userInfo : userInfo.substring(0, pos);
+            accessSecret = (pos < 0) ? null : userInfo.substring(pos+1);
+        } else {
+            accessKey = accessSecret = null;
+        }
+
+        endpoint = uri.getHost();
+        if (uri.getPort() > 0) {
+            endpoint += ":" + uri.getPort();
+        }
+        bucket = uri.getPath().split(S3Path.PATH_SEPARATOR)[1];
+
+        BucketUtils.isValidDnsBucketName(bucket, true);
+
+        key = endpoint + '/' + bucket;
+        if (accessKey != null) {
+            key = accessKey + '@' + key;
+        }
+    }
+}

--- a/src/main/resources/META-INF/services/java.nio.file.spi.FileSystemProvider
+++ b/src/main/resources/META-INF/services/java.nio.file.spi.FileSystemProvider
@@ -4,3 +4,4 @@
 #
 
 software.amazon.nio.spi.s3.S3FileSystemProvider
+software.amazon.nio.spi.s3x.S3XFileSystemProvider

--- a/src/test/java/software/amazon/nio/spi/s3/S3ClientProviderTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3ClientProviderTest.java
@@ -7,6 +7,7 @@ package software.amazon.nio.spi.s3;
 
 import java.util.NoSuchElementException;
 import java.util.function.Consumer;
+import static org.assertj.core.api.BDDAssertions.then;
 import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -19,6 +20,7 @@ import static org.mockito.Mockito.when;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
 import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetBucketLocationResponse;
@@ -198,5 +200,21 @@ public class S3ClientProviderTest {
         inOrder.verify(mockClient).getBucketLocation(any(Consumer.class));
         inOrder.verify(mockClient).headBucket(any(Consumer.class));
         inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void generateAsyncClientByEndpointBucketCredentials() {
+        final FakeAsyncS3ClientBuilder BUILDER = new FakeAsyncS3ClientBuilder();
+        provider.asyncClientBuilder = BUILDER;
+
+        provider.configuration.withEndpoint("endpoint1:1010");
+        provider.generateAsyncClient("bucket1");
+        then(BUILDER.endpointOverride.toString()).isEqualTo("https://endpoint1:1010");
+        then(BUILDER.region).isEqualTo(Region.US_EAST_1);  // just a default in the case not provide
+
+        provider.configuration.withEndpoint("endpoint2:2020");
+        provider.generateAsyncClient("bucket2");
+        then(BUILDER.endpointOverride.toString()).isEqualTo("https://endpoint2:2020");
+        then(BUILDER.region).isEqualTo(Region.US_EAST_1);  // just a default in the case not provide
     }
 }

--- a/src/test/java/software/amazon/nio/spi/s3/S3ClientProviderTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3ClientProviderTest.java
@@ -43,6 +43,8 @@ public class S3ClientProviderTest {
     public void initialization() {
         final S3ClientProvider P = new S3ClientProvider();
 
+        assertNotNull(P.configuration);
+
         assertTrue(P.universalClient() instanceof S3Client);
         assertNotNull(P.universalClient());
 
@@ -50,6 +52,7 @@ public class S3ClientProviderTest {
         assertNotNull(P.universalClient());
 
         S3NioSpiConfiguration config = new S3NioSpiConfiguration();
+        assertSame(config, new S3ClientProvider(config).configuration);
     }
 
     @Test

--- a/src/test/java/software/amazon/nio/spi/s3/S3ClientStoreTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3ClientStoreTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3Client;

--- a/src/test/java/software/amazon/nio/spi/s3/S3ClientStoreTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3ClientStoreTest.java
@@ -32,7 +32,6 @@ public class S3ClientStoreTest {
     @Mock
     S3Client mockClient; //client used to determine bucket location
 
-
     @BeforeEach
     public void setUp() throws Exception {
         instance = S3ClientStore.getInstance();

--- a/src/test/java/software/amazon/nio/spi/s3/S3PathTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3PathTest.java
@@ -48,6 +48,7 @@ public class S3PathTest {
         fileSystem.clientProvider(new FixedS3ClientProvider(mockClient));
         lenient().when(mockClient.headObject(any(Consumer.class))).thenReturn(
                 CompletableFuture.supplyAsync(() -> HeadObjectResponse.builder().contentLength(100L).build()));
+
         root = S3Path.getPath(fileSystem, S3Path.PATH_SEPARATOR);
         absoluteDirectory = S3Path.getPath(fileSystem, S3Path.PATH_SEPARATOR, "dir1", "dir2/");
         relativeDirectory = S3Path.getPath(fileSystem, "..", "dir3/");

--- a/src/test/java/software/amazon/nio/spi/s3/S3ReadAheadByteChannelTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3ReadAheadByteChannelTest.java
@@ -12,6 +12,7 @@ import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 
 import java.io.IOException;
+import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
@@ -30,7 +31,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @SuppressWarnings("unchecked")
 public class S3ReadAheadByteChannelTest {
 
-    S3Path path = S3Path.getPath(new S3FileSystem("my-bucket"), "/object");
+    final S3FileSystemProvider provider = new S3FileSystemProvider();
+
+    S3Path path;
 
     @Mock
     S3SeekableByteChannel delegator;
@@ -43,6 +46,7 @@ public class S3ReadAheadByteChannelTest {
 
     @BeforeEach
     public void setup() throws IOException {
+        path = S3Path.getPath(provider.getFileSystem(URI.create("s3://my-bucket"), true), "/object");
 
         // mocking
         lenient().when(delegator.size()).thenReturn(52L);

--- a/src/test/java/software/amazon/nio/spi/s3/config/S3NioSpiConfigurationTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/config/S3NioSpiConfigurationTest.java
@@ -46,6 +46,7 @@ public class S3NioSpiConfigurationTest {
         then(config.getMaxFragmentSize()).isEqualTo(S3_SPI_READ_MAX_FRAGMENT_SIZE_DEFAULT);
         then(config.getEndpointProtocol()).isEqualTo("https");
         then(config.getEndpoint()).isEmpty();
+        then(config.getBucketName()).isNull();
         then(config.getRegion()).isNull();
         then(config.getCredentials()).isNull();
     }
@@ -217,5 +218,20 @@ public class S3NioSpiConfigurationTest {
         expected = "";
         then(config.convertPropertyNameToEnvVar(null)).isEqualTo(expected);
         then(config.convertPropertyNameToEnvVar("  ")).isEqualTo(expected);
+    }
+
+    @Test
+    public void withAndGetBucketName() {
+        then(config.withBucketName("aname")).isSameAs(config);
+        then(config.getBucketName()).isEqualTo("aname");
+        then(config.withBucketName("anothername").getBucketName()).isEqualTo("anothername");
+        then(config.withBucketName(null).getBucketName()).isNull();
+
+        try {
+            config.withBucketName("Wrong/bucket;name");
+            fail("missing sanity check");
+        } catch (IllegalArgumentException x) {
+            then(x).hasMessage("Bucket name should not contain uppercase characters");
+        }
     }
 }


### PR DESCRIPTION
This pull request should finalize the work to seamlessly support 3rd party S3 services like minio. It brings three main improvements, which I kept together as they are small enough and they complement each other.

1. All information to build a file system (bucket, endpoint, credentials, etc.) are now encapsulated in a S3NioConfiguration object that is passed to the constructor; this simplifies quite a bit the constructors and the need of accessors. This should also close #61 
2. Deprecation of constructors taking a URI: in the NIO world, the FileSystem object is usually create indirectly, by the provider or even more subtly by using Files or Path; it is therefore cleaner the provider digests the URIs creating a corresponding configuration object that can then be passed to S3FileSystem's constructor. This brings also the valuable advantage of making the file S3FileSystem completely independent by the URI used to create and configure it.
3. Last but most importantly, it introduces a new file system provider, which manages the s3x:// URI schema as per the following URI pattern (as discussed earlier in other tickets and PRs):

    `s3x://[key:secret#@]hostename[:port]/bucket/key`

Thanks to bullet 1 above, it handed up to be quite clean, as the new S3XFileSystemProvider extends S3FileSystemProvider with very little code, while S3FileSystem is i completely in common between the two providers.

@markjschreiber , let me know what you think


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
