### PR TITLE
Fixing issues #115 and #161

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,11 +122,34 @@ on I/O, up to the limits of your network connection.
 
 ### Configuration
 
-The read-ahead buffer asynchronously prefetches `n` sequential fragments of `m` bytes from S3. The
-values of `n` and `m` can be configured to your needs by using command line properties or environment variables.
+There are two types of configuration parameters: local and system. Local configuration parameters are set when creating
+a file system calling _FileSystems.newFileSystem(uri, env)_ or directly calling _newFileSystem(uri, env)_ on a
+_S3FileSystemProvider_ or _S3XFileSystemProvider_ instance. System configuration parameters can be set like local paramenters
+or as environment variables or java system properties. Therefore these parameters apply to all file systems created with
+S3 and S3X providers. Some parameters can have both system and local scopes; for these, local values overwrite the system
+values.
 
 If no configuration is supplied the values in `resources/s3-nio-spi.properties` are used. Currently, 50 fragments of 5MB.
 Each fragment is downloaded concurrently on a unique thread.
+
+#### Local parameters
+**aws.region** specifies the default region for API calls
+**aws.accessKey** specifies the key id to use for authentication
+**aws.secretAccessKey** specifies the secret to use for authentication
+
+**s3.spi.read.fragment-number** buffer asynchronously prefetches `n` sequential fragments from S3 (currently 50)
+**s3.spi.read.fragment-size** size of each fragment (currently 5MB)
+**s3.spi.endpoint** the endpoint to use to access the bucket; this is extracted from the uri by the S3X provider
+**s3.spi.force-path-style** (true|false) to set if path-style shall be used instead of host style; unless otherwise
+specified, this is undefined for the S3 provider and set to true when using the S3X provider.
+
+#### System parameter ####
+**aws.region** specifies the default region for API calls
+**aws.accessKey** specifies the key id to use for authentication
+**aws.secretAccessKey** specifies the secret to use for authentication
+
+**s3.spi.read.fragment-number** buffer asynchronously prefetches `n` sequential fragments from S3 (currently 50)
+**s3.spi.read.fragment-size** size of each fragment (currently 5MB)
 
 #### Environment Variables
 
@@ -152,9 +175,10 @@ java -Djava.ext.dirs=$JAVA_HOME/jre/lib/ext:<location-of-this-spi-jar> -Ds3.spi.
 
 Configurations use the following order of precedence from highest to lowest:
 
-1. Java properties
-2. Environment variables
-3. Default values
+1. Local parameters
+2. Java properties
+3. Environment variables
+4. Default values
 
 #### S3 limits
 

--- a/src/main/java/software/amazon/nio/spi/s3/S3ClientProvider.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3ClientProvider.java
@@ -294,13 +294,14 @@ public class S3ClientProvider {
         logger.debug("bucket region is: '{}'", region.id());
 
         S3ClientBuilder clientBuilder =  S3Client.builder()
+            .forcePathStyle(configuration.getForcePathStyle())
             .region(region)
             .overrideConfiguration(
                 conf -> conf.retryPolicy(
                     builder -> builder.retryCondition(retryCondition).backoffStrategy(backoffStrategy)
                 )
             );
-
+        
         if (!isBlank(endpoint)) {
             clientBuilder.endpointOverride(URI.create(configuration.getEndpointProtocol() + "://" + endpoint));
         }
@@ -328,6 +329,6 @@ public class S3ClientProvider {
             asyncClientBuilder.credentialsProvider(() -> credentials);
         }
 
-        return asyncClientBuilder.region(region).build();
+        return asyncClientBuilder.forcePathStyle(configuration.getForcePathStyle()).region(region).build();
     }
 }

--- a/src/main/java/software/amazon/nio/spi/s3/config/S3NioSpiConfiguration.java
+++ b/src/main/java/software/amazon/nio/spi/s3/config/S3NioSpiConfiguration.java
@@ -65,16 +65,19 @@ public class S3NioSpiConfiguration extends HashMap<String, Object> {
      * The default value of the endpoint protocol property
      */
     public static final String S3_SPI_ENDPOINT_PROTOCOL_DEFAULT = "https";
-
     /**
-     * The default value of the endpoint protocol property
+     * The name of the force path style property
+     */
+    public static final String S3_SPI_FORCE_PATH_STYLE_PROPERTY = "s3.spi.force-path-style";
+    /**
+     * The default value of the credentials property
      */
     public static final String S3_SPI_CREDENTIALS_PROPERTY = "s3.spi.credentials";
 
     private final Pattern ENDPOINT_REGEXP = Pattern.compile("(\\w[\\w\\-\\.]*)?(:(\\d+))?");
 
     private String bucketName;
-
+    
 
     /**
      * Create a new, empty configuration
@@ -85,6 +88,8 @@ public class S3NioSpiConfiguration extends HashMap<String, Object> {
 
     /**
      * Create a new, empty configuration
+     * 
+     * @param overrides configuration to override default values
      */
     public S3NioSpiConfiguration(Map<String, ?> overrides) {
         Objects.requireNonNull(overrides);
@@ -92,8 +97,8 @@ public class S3NioSpiConfiguration extends HashMap<String, Object> {
         //
         // setup defaults
         //
-        put(S3_SPI_READ_MAX_FRAGMENT_NUMBER_PROPERTY, String .valueOf(S3_SPI_READ_MAX_FRAGMENT_NUMBER_DEFAULT));
-        put(S3_SPI_READ_MAX_FRAGMENT_SIZE_PROPERTY, String .valueOf(S3_SPI_READ_MAX_FRAGMENT_SIZE_DEFAULT));
+        put(S3_SPI_READ_MAX_FRAGMENT_NUMBER_PROPERTY, String.valueOf(S3_SPI_READ_MAX_FRAGMENT_NUMBER_DEFAULT));
+        put(S3_SPI_READ_MAX_FRAGMENT_SIZE_PROPERTY, String.valueOf(S3_SPI_READ_MAX_FRAGMENT_SIZE_DEFAULT));
         put(S3_SPI_ENDPOINT_PROTOCOL_PROPERTY, S3_SPI_ENDPOINT_PROTOCOL_DEFAULT);
 
         //
@@ -115,7 +120,7 @@ public class S3NioSpiConfiguration extends HashMap<String, Object> {
             key -> Optional.ofNullable(System.getProperty(key)).ifPresent(val -> put(key, val))
         );
 
-        overrides.keySet().forEach(key -> put(key, String.valueOf(overrides.get(key))));
+        overrides.keySet().forEach(key -> put(key, overrides.get(key)));
     }
 
     /**
@@ -272,7 +277,27 @@ public class S3NioSpiConfiguration extends HashMap<String, Object> {
         }
         return this;
     }
-
+    
+    /**
+     * Fluently sets the value of {@code forcePathStyle} and adds 
+     * {@code S3_SPI_FORCE_PATH_STYLE_PROPERTY} to the map unless the given
+     * value is null. If null, {@code S3_SPI_FORCE_PATH_STYLE_PROPERTY} is
+     * removed from the map.
+     *
+     * @param forcePathStyle the new value; can be null
+     *
+     * @return this instance
+     */
+    public S3NioSpiConfiguration withForcePathStyle(Boolean forcePathStyle) {
+        if (forcePathStyle == null) {
+            remove(S3_SPI_FORCE_PATH_STYLE_PROPERTY);
+        } else {
+            put(S3_SPI_FORCE_PATH_STYLE_PROPERTY, forcePathStyle); 
+        }
+        
+        return this;
+    }  
+    
     /**
      * Get the value of the Maximum Fragment Size
      * @return the configured value or the default if not overridden
@@ -362,6 +387,10 @@ public class S3NioSpiConfiguration extends HashMap<String, Object> {
      */
     public String getBucketName() {
         return bucketName;
+    }
+    
+    public boolean getForcePathStyle() {
+        return (boolean)getOrDefault(S3_SPI_FORCE_PATH_STYLE_PROPERTY, false);
     }
 
     /**

--- a/src/main/java/software/amazon/nio/spi/s3x/S3XFileSystemProvider.java
+++ b/src/main/java/software/amazon/nio/spi/s3x/S3XFileSystemProvider.java
@@ -17,7 +17,11 @@
 package software.amazon.nio.spi.s3x;
 
 import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import software.amazon.nio.spi.s3.S3FileSystem;
 import software.amazon.nio.spi.s3.S3FileSystemProvider;
+import static software.amazon.nio.spi.s3.config.S3NioSpiConfiguration.S3_SPI_FORCE_PATH_STYLE_PROPERTY;
 import software.amazon.nio.spi.s3.util.S3FileSystemInfo;
 import software.amazon.nio.spi.s3x.util.S3XFileSystemInfo;
 
@@ -27,6 +31,17 @@ import software.amazon.nio.spi.s3x.util.S3XFileSystemInfo;
 public class S3XFileSystemProvider extends S3FileSystemProvider {
 
     public static final String SCHEME = "s3x";
+    
+    @Override
+    public S3FileSystem newFileSystem(final URI uri, Map<String, ?> env) {
+        Map<String, Object> newEnv = new HashMap<>();
+        
+        newEnv.putAll(env);
+        newEnv.putIfAbsent(S3_SPI_FORCE_PATH_STYLE_PROPERTY, true);
+
+        return super.newFileSystem(uri, newEnv);
+    }
+    
 
     /**
      * Returns the URI scheme that identifies this provider.

--- a/src/test/java/software/amazon/nio/spi/s3/FakeAsyncS3ClientBuilder.java
+++ b/src/test/java/software/amazon/nio/spi/s3/FakeAsyncS3ClientBuilder.java
@@ -37,62 +37,64 @@ public class FakeAsyncS3ClientBuilder implements S3CrtAsyncClientBuilder {
 
     @Override
     public S3CrtAsyncClientBuilder credentialsProvider(AwsCredentialsProvider acp) {
-        return BUILDER.credentialsProvider(credentialsProvider = acp);
+        BUILDER.credentialsProvider(credentialsProvider = acp); return this;
     }
 
     @Override
     public S3CrtAsyncClientBuilder region(Region r) {
-        return BUILDER.region(region = r);
+        BUILDER.region(region = r); return this;
     }
 
     @Override
     public S3CrtAsyncClientBuilder minimumPartSizeInBytes(Long l) {
-        return BUILDER.minimumPartSizeInBytes(minimumPartSizeInBytes = l);
+        BUILDER.minimumPartSizeInBytes(minimumPartSizeInBytes = l); return this;
     }
 
     @Override
     public S3CrtAsyncClientBuilder targetThroughputInGbps(Double d) {
-        return BUILDER.targetThroughputInGbps(targetThroughputInGbps = d);
+        BUILDER.targetThroughputInGbps(targetThroughputInGbps = d); return this;
     }
 
     @Override
     public S3CrtAsyncClientBuilder maxConcurrency(Integer i) {
-        return BUILDER.maxConcurrency(maxConcurrency = i);
+        BUILDER.maxConcurrency(maxConcurrency = i); return this;
     }
 
     @Override
     public S3CrtAsyncClientBuilder endpointOverride(URI u) {
-       return BUILDER.endpointOverride(endpointOverride = u);
+        BUILDER.endpointOverride(endpointOverride = u); return this;
     }
 
     @Override
     public S3CrtAsyncClientBuilder checksumValidationEnabled(Boolean b) {
-        return BUILDER.checksumValidationEnabled(checksumValidationEnabled = b);
+        BUILDER.checksumValidationEnabled(checksumValidationEnabled = b);
+        return this;
     }
 
     @Override
     public S3CrtAsyncClientBuilder initialReadBufferSizeInBytes(Long l) {
-        return BUILDER.initialReadBufferSizeInBytes(initialReadBufferSizeInBytes = l);
+        BUILDER.initialReadBufferSizeInBytes(initialReadBufferSizeInBytes = l);
+        return this;
     }
 
     @Override
     public S3CrtAsyncClientBuilder httpConfiguration(S3CrtHttpConfiguration c) {
-        return BUILDER.httpConfiguration(httpConfiguration = c);
+        BUILDER.httpConfiguration(httpConfiguration = c); return this;
     }
 
     @Override
     public S3CrtAsyncClientBuilder retryConfiguration(S3CrtRetryConfiguration c) {
-        return BUILDER.retryConfiguration(retryConfiguration = c);
+        BUILDER.retryConfiguration(retryConfiguration = c);  return this;
     }
 
     @Override
     public S3CrtAsyncClientBuilder accelerate(Boolean b) {
-        return BUILDER.accelerate(accelerate = b);
+        BUILDER.accelerate(accelerate = b); return this;
     }
 
     @Override
     public S3CrtAsyncClientBuilder forcePathStyle(Boolean b) {
-        return BUILDER.forcePathStyle(forcePathStyle = b);
+        BUILDER.forcePathStyle(forcePathStyle = b); return this;
     }
 
     @Override
@@ -102,11 +104,11 @@ public class FakeAsyncS3ClientBuilder implements S3CrtAsyncClientBuilder {
 
     @Override
     public S3CrtAsyncClientBuilder crossRegionAccessEnabled(Boolean b) {
-        return BUILDER.crossRegionAccessEnabled(b);
+        BUILDER.crossRegionAccessEnabled(b); return this;
     }
 
     @Override
     public S3CrtAsyncClientBuilder thresholdInBytes(Long l) {
-        return BUILDER.thresholdInBytes(l);
+        BUILDER.thresholdInBytes(l); return this;
     }
 }

--- a/src/test/java/software/amazon/nio/spi/s3/S3FileSystemProviderTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3FileSystemProviderTest.java
@@ -36,7 +36,6 @@ import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystemAlreadyExistsException;
 import java.nio.file.FileSystemNotFoundException;
-import java.nio.file.FileSystems;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -48,7 +47,6 @@ import java.nio.file.attribute.FileAttributeView;
 import java.nio.file.attribute.FileTime;
 import java.time.Instant;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -66,7 +64,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
-import static software.amazon.nio.spi.s3.config.S3NioSpiConfiguration.AWS_REGION_PROPERTY;
 
 @SuppressWarnings("unchecked")
 @ExtendWith(MockitoExtension.class)
@@ -526,5 +523,16 @@ public class S3FileSystemProviderTest {
     public void setAttribute() {
         S3Path foo = fs.getPath("/foo");
         assertThrows(UnsupportedOperationException.class, () -> provider.setAttribute(foo, "x", "y"));
+    }
+    
+        
+    @Test
+    public void defaultForcePathStyle() throws Exception {
+        final FakeAsyncS3ClientBuilder BUILDER = new FakeAsyncS3ClientBuilder();
+        
+        fs.clientProvider().asyncClientBuilder(BUILDER);
+        fs.client(); fs.close();
+
+        assertNull(BUILDER.forcePathStyle);
     }
 }

--- a/src/test/java/software/amazon/nio/spi/s3/config/S3NioSpiConfigurationTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/config/S3NioSpiConfigurationTest.java
@@ -9,6 +9,7 @@ import static com.github.stefanbirkner.systemlambda.SystemLambda.withEnvironment
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import static org.assertj.core.api.BDDAssertions.entry;
 
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -49,6 +50,7 @@ public class S3NioSpiConfigurationTest {
         then(config.getBucketName()).isNull();
         then(config.getRegion()).isNull();
         then(config.getCredentials()).isNull();
+        then(config.getForcePathStyle()).isFalse();
     }
 
     @Test
@@ -233,5 +235,23 @@ public class S3NioSpiConfigurationTest {
         } catch (IllegalArgumentException x) {
             then(x).hasMessage("Bucket name should not contain uppercase characters");
         }
+    }
+    
+    @Test
+    public void withAndGetForcePathStyle() {
+        then(config).doesNotContainKey(S3_SPI_FORCE_PATH_STYLE_PROPERTY);
+        then(config.withForcePathStyle(true)).isSameAs(config);
+        then(config).contains(entry(S3_SPI_FORCE_PATH_STYLE_PROPERTY, true));
+        then(config.getForcePathStyle()).isTrue();
+        then(config.withForcePathStyle(false).getForcePathStyle()).isFalse();
+        
+        Map<String, Object> map = new HashMap<>(); config = new S3NioSpiConfiguration(map);
+        then(config.getForcePathStyle()).isFalse();
+        map.put(S3_SPI_FORCE_PATH_STYLE_PROPERTY, true); config = new S3NioSpiConfiguration(map);
+        then(config .getForcePathStyle()).isTrue();
+        map.remove(S3_SPI_FORCE_PATH_STYLE_PROPERTY); // same S3NioSpiConfiguration on purpose
+        then(config.getForcePathStyle()).isTrue();
+        then(config.withForcePathStyle(null).getForcePathStyle()).isFalse();
+        then(config).doesNotContainKey(S3_SPI_FORCE_PATH_STYLE_PROPERTY);
     }
 }

--- a/src/test/java/software/amazon/nio/spi/s3x/S3XFileSystemProviderTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3x/S3XFileSystemProviderTest.java
@@ -1,0 +1,319 @@
+/*
+ * Copyright 2023 ste.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.nio.spi.s3x;
+
+import java.net.URI;
+import java.nio.file.FileSystemAlreadyExistsException;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.HashMap;
+import static com.github.stefanbirkner.systemlambda.SystemLambda.restoreSystemProperties;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystemNotFoundException;
+import java.nio.file.FileSystems;
+import java.util.Collections;
+import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import org.junit.jupiter.api.Test;
+import software.amazon.nio.spi.s3.FakeAsyncS3ClientBuilder;
+import software.amazon.nio.spi.s3.S3FileSystem;
+import software.amazon.nio.spi.s3.S3Path;
+import software.amazon.nio.spi.s3.config.S3NioSpiConfiguration;
+import static software.amazon.nio.spi.s3.config.S3NioSpiConfiguration.AWS_REGION_PROPERTY;
+import static software.amazon.nio.spi.s3.config.S3NioSpiConfiguration.AWS_ACCESS_KEY_PROPERTY;
+import static software.amazon.nio.spi.s3.config.S3NioSpiConfiguration.AWS_SECRET_ACCESS_KEY_PROPERTY;
+
+
+/**
+ *
+ */
+public class S3XFileSystemProviderTest {
+
+    final static FakeAsyncS3ClientBuilder BUILDER = new FakeAsyncS3ClientBuilder();
+
+    final static URI URI1 = URI.create("s3x://myendpoint/foo");
+    final static URI URI2 = URI.create("s3x://myendpoint/foo/baa2");
+    final static URI URI3 = URI.create("s3x://myendpoint.com:1010/foo/baa2/dir");
+    final static URI URI4 = URI.create("s3x://myendpoint.com:1010/foo2/baa2");
+    final static URI URI5 = URI.create("s3x://myendpoint.com:1010/foo2/dir2");
+    final static URI URI6 = URI.create("s3x://myendpoint.com:1234/foo3/baa2");
+    final static URI URI7 = URI.create("s3x://key:secret@myendpoint.com:1010/foo/baa2");
+    final static URI URI8 = URI.create("s3x://key:anothersecret@myendpoint.com:1010/foo/baa2");
+    final static URI URI9 = URI.create("s3x://akey:asecret@somewhere.com:2020/foo2/baa2");
+    final static URI URI10 = URI.create("s3x://akey:anothersecret@somewhere.com:2020/foo2/baa2");
+
+    @Test
+    public void nio_provider() {
+        S3Path path = (S3Path)Paths.get(URI.create("s3x://myendpoint/mybucket/myfolder"));
+
+        S3FileSystem fs = path.getFileSystem();
+        then(fs.provider()).isInstanceOf(S3XFileSystemProvider.class);
+        then(fs.configuration().getEndpoint()).isEqualTo("myendpoint");
+        then(fs.configuration().getBucketName()).isEqualTo("mybucket");
+        then(path.getKey()).isEqualTo("myfolder");
+    }
+
+    @Test
+    public void newFileSystem() {
+        S3XFileSystemProvider provider = new S3XFileSystemProvider();
+
+        //
+        // a first file system
+        //
+        S3FileSystem fs = provider.newFileSystem(URI1);
+        then(fs).isNotNull();
+        then(fs.configuration().getBucketName()).isEqualTo("foo");
+        then(fs.configuration().getCredentials()).isNull();
+
+        //
+        // the same file system can not be created twice
+        //
+        try {
+            provider.newFileSystem(URI1);
+            fail("filesystem created twice!");
+        } catch (FileSystemAlreadyExistsException x) {
+            then(x).hasMessageContaining("'myendpoint/foo'");
+        }
+
+        //
+        // Same bucket but different path, is still the same file system
+        //
+        try {
+            provider.newFileSystem(URI2);
+            fail("filesystem created twice!");
+        } catch (FileSystemAlreadyExistsException x) {
+            then(x).hasMessageContaining("'myendpoint/foo'");
+        }
+        provider.closeFileSystem(fs);
+
+        //
+        // With endpoint no credentials
+        //
+        fs = provider.newFileSystem(URI3);
+        then(fs.configuration().getCredentials()).isNull();
+        then(fs.configuration().getBucketName()).isEqualTo("foo");
+        then(fs.configuration().getEndpoint()).isEqualTo("myendpoint.com:1010");
+        provider.closeFileSystem(fs);
+
+        //
+        // With existing endpoint, different bucket, no credentials
+        //
+        fs = provider.newFileSystem(URI4);
+        then(fs.configuration().getCredentials()).isNull();
+        then(fs.configuration().getBucketName()).isEqualTo("foo2");
+        then(fs.configuration().getEndpoint()).isEqualTo("myendpoint.com:1010");
+
+        //
+        // With existing endpoint and bucket, no credentials
+        //
+        try {
+            provider.newFileSystem(URI5);
+            fail("filesystem created twice!");
+        } catch (FileSystemAlreadyExistsException x) {
+            then(x).hasMessageContaining("'myendpoint.com:1010/foo2'");
+        }
+        provider.closeFileSystem(fs);
+
+        //
+        // Same hostname, different port, different bucket, no credentials
+        //
+        fs = provider.newFileSystem(URI6);
+        then(fs.configuration().getCredentials()).isNull();
+        then(fs.configuration().getBucketName()).isEqualTo("foo3");
+        then(fs.configuration().getEndpoint()).isEqualTo("myendpoint.com:1234");
+        provider.closeFileSystem(fs);
+
+        //
+        // With existing endpoint, same bucket, credentials
+        //
+        fs = provider.newFileSystem(URI9);
+        then(fs.configuration().getCredentials().accessKeyId()).isEqualTo("akey");
+        then(fs.configuration().getCredentials().secretAccessKey()).isEqualTo("asecret");
+        then(fs.configuration().getBucketName()).isEqualTo("foo2");
+        then(fs.configuration().getEndpoint()).isEqualTo("somewhere.com:2020");
+
+        //
+        // With same endpoint, same bucket, different credentials
+        //
+        try {
+            fs = provider.newFileSystem(URI10);
+            fail("filesystem created twice!");
+        } catch (FileSystemAlreadyExistsException x) {
+            then(x).hasMessageContaining("'akey@somewhere.com:2020/foo2");
+        }
+        provider.closeFileSystem(fs);
+    }
+
+    @Test
+    public void getFileSystem() {
+        S3XFileSystemProvider provider = new S3XFileSystemProvider();
+
+        FileSystem fs2 = provider.newFileSystem(URI1);
+        then(provider.getFileSystem(URI1)).isSameAs(fs2);
+        FileSystem fs3 = provider.newFileSystem(URI3);
+        then(fs3).isNotSameAs(fs2);
+        then(provider.getFileSystem(URI2)).isSameAs(fs2);
+        then(provider.newFileSystem(URI7)).isNotSameAs(fs3);
+        then(provider.getFileSystem(URI8)).isNotSameAs(fs3);
+        provider.closeFileSystem(fs2);
+        provider.closeFileSystem(fs3);
+
+        try {
+            provider.getFileSystem(URI.create("s3://nowhere.com:2000/foo2/baa2"));
+            fail("missing error");
+        } catch (FileSystemNotFoundException x) {
+            then(x).hasMessage("file system not found for 'nowhere.com:2000/foo2'");
+        }
+    }
+
+    @Test
+    public void setEndpointProtocolThroughConfiguration() throws Exception {
+        S3NioSpiConfiguration env = new S3NioSpiConfiguration();
+
+        S3XFileSystemProvider p = new S3XFileSystemProvider();
+
+        S3FileSystem fs = p.newFileSystem(URI.create("s3://some.where.com:1010/bucket"), env);
+        fs.clientProvider().asyncClientBuilder(BUILDER);
+        fs.client(); fs.close();
+
+        then(fs.bucketName()).isEqualTo("bucket");
+        then(fs.configuration().getEndpoint()).isEqualTo("some.where.com:1010");
+        then(BUILDER.endpointOverride.toString()).isEqualTo("https://some.where.com:1010");
+
+        env.withEndpointProtocol("http");
+
+        fs = p.newFileSystem(URI.create("s3://any.where.com:2020/foo"), env);
+        fs.clientProvider().asyncClientBuilder(BUILDER);
+        fs.client(); fs.close();
+
+        then(fs.bucketName()).isEqualTo("foo");
+        then(fs.configuration().getEndpoint()).isEqualTo("any.where.com:2020");
+        then(BUILDER.endpointOverride.toString()).isEqualTo("http://any.where.com:2020");
+    }
+    
+    @Test
+    public void setForcePathStyleThroughConfiguration() throws Exception {
+        S3NioSpiConfiguration env = new S3NioSpiConfiguration();
+
+        S3XFileSystemProvider p = new S3XFileSystemProvider();
+
+        //
+        // true by default
+        //
+        S3FileSystem fs = p.newFileSystem(URI.create("s3x://some.where.com:1010/bucket"), env);
+        fs.clientProvider().asyncClientBuilder(BUILDER);
+        fs.client(); fs.close();
+
+        then(BUILDER.forcePathStyle).isTrue();
+
+        //
+        // false by withForcePath()
+        //
+        env.withForcePathStyle(false);
+        fs = p.newFileSystem(URI.create("s3x://any.where.com:2020/foo"), env);
+        fs.clientProvider().asyncClientBuilder(BUILDER);
+        fs.client(); fs.close();
+
+        then(BUILDER.forcePathStyle).isFalse();
+        
+        //
+        // false if set directly to false
+        //
+        env.put(S3NioSpiConfiguration.S3_SPI_FORCE_PATH_STYLE_PROPERTY, false);
+        fs = p.newFileSystem(URI.create("s3x://any.where.com:2020/foo"), env);
+        fs.clientProvider().asyncClientBuilder(BUILDER);
+        fs.client(); fs.close();
+
+        then(BUILDER.forcePathStyle).isFalse();
+    }
+
+    @Test
+    public void setCredentialsThroughMap() throws Exception {
+        S3XFileSystemProvider p = new S3XFileSystemProvider();
+        Map<String, String> env = new HashMap<>();
+        env.put(AWS_ACCESS_KEY_PROPERTY, "envkey");
+        env.put(AWS_SECRET_ACCESS_KEY_PROPERTY, "envsecret");
+
+        restoreSystemProperties(() -> {
+            System.setProperty("aws.region", "us-west-1");
+            System.setProperty(AWS_ACCESS_KEY_PROPERTY, "systemkey");
+            System.setProperty(AWS_SECRET_ACCESS_KEY_PROPERTY, "systemsecret");
+
+            S3FileSystem fs = p.newFileSystem(URI.create("s3x://some.where.com:1010/bucket"), env);
+            fs.clientProvider().asyncClientBuilder(BUILDER);
+            fs.client(); fs.close();
+
+            then(fs.configuration().getBucketName()).isEqualTo("bucket");
+            then(fs.configuration().getEndpoint()).isEqualTo("some.where.com:1010");
+            then(BUILDER.endpointOverride.toString()).isEqualTo("https://some.where.com:1010");
+            then(BUILDER.credentialsProvider.resolveCredentials().accessKeyId()).isEqualTo("envkey");
+            then(BUILDER.credentialsProvider.resolveCredentials().secretAccessKey()).isEqualTo("envsecret");
+        });
+    }
+
+    @Test
+    public void setCredentialsThroughURI() throws Exception {
+        S3XFileSystemProvider p = new S3XFileSystemProvider();
+        Map<String, String> env = new HashMap<>();
+        env.put(AWS_ACCESS_KEY_PROPERTY, "envkey");
+        env.put(AWS_SECRET_ACCESS_KEY_PROPERTY, "envsecret");
+
+        restoreSystemProperties(() -> {
+            System.setProperty("aws.region", "us-west-1");
+
+            S3FileSystem fs = p.newFileSystem(URI.create("s3://urikey:urisecret@some.where.com:1010/bucket"), env);
+            fs.clientProvider().asyncClientBuilder(BUILDER);
+            fs.client(); fs.close();
+
+            then(fs.configuration().getBucketName()).isEqualTo("bucket");
+            then(fs.configuration().getEndpoint()).isEqualTo("some.where.com:1010");
+            then(BUILDER.endpointOverride.toString()).isEqualTo("https://some.where.com:1010");
+            then(BUILDER.credentialsProvider.resolveCredentials().accessKeyId()).isEqualTo("urikey");
+            then(BUILDER.credentialsProvider.resolveCredentials().secretAccessKey()).isEqualTo("urisecret");
+        });
+    }
+
+    @Test
+    public void getPath() {
+        S3XFileSystemProvider p = new S3XFileSystemProvider();
+
+        then(p.getPath(URI1)).isNotNull();
+
+        //
+        // Make sure a file system is created if not already done (if the file
+        // system is has not been created getFilaSystem would throw an exception)
+        //
+        p.closeFileSystem(p.getFileSystem(URI1));
+    }
+
+    @Test
+    public void getS3FileSystemFromS3XURI() throws Exception {
+        Map<String, String> env = new HashMap<>();
+        env.put(AWS_REGION_PROPERTY, "us-west-1");
+
+        S3FileSystem fs = (S3FileSystem)FileSystems.newFileSystem(URI7, Collections.EMPTY_MAP);
+        then(fs).isNotNull();
+        try {
+            FileSystems.newFileSystem(URI7, Collections.EMPTY_MAP);
+        } catch (FileSystemAlreadyExistsException x) {
+            then(x).hasMessage("a file system already exists for 'key@myendpoint.com:1010/foo', use getFileSystem() instead");
+        }
+        then(FileSystems.getFileSystem(URI7)).isSameAs(fs);
+        fs.close();
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*
This PR covers issue #115 and #161 

S3 compatible services like minio do not like AWS S3 virtual-style addressing, where the bucket name is considered part of the hostname (e.g. pippo -> pippo.s3.eu-central-1.amazonaws.com).
We therefore set the path-style addressing by default for s3x provider, while we also give the possibility to configure it via the s3.spi.force-path-style.

I took this opportunity to make some improvements to the readme about the different configuration parameters. Please have a look and let me know if you like it. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
