### PR TITLE
chore(deps): Remove duplicate `rxjava` dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,6 @@ compileJava {
 
 dependencies {
     implementation 'io.reactivex.rxjava3:rxjava:3.1.7'
-    implementation 'io.reactivex.rxjava3:rxjava:3.1.7'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'
     testImplementation 'org.mockito:mockito-core:5.5.0'
     testImplementation 'org.assertj:assertj-core:3.24.2'


### PR DESCRIPTION
This PR removes a duplicate declaration of the dependency on rxjava