### PR TITLE
chore(test): Improve S3FileSystemProviderTest robustness

### DIFF
--- a/src/test/java/software/amazon/nio/spi/s3/S3FileSystemProviderTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3FileSystemProviderTest.java
@@ -80,7 +80,7 @@ public class S3FileSystemProviderTest {
         provider = new S3FileSystemProvider();
         lenient().when(mockClient.headObject(any(Consumer.class))).thenReturn(
                 CompletableFuture.supplyAsync(() -> HeadObjectResponse.builder().contentLength(100L).build()));
-        fs = provider.newFileSystem(URI.create(pathUri));
+        fs = provider.getFileSystem(URI.create(pathUri), true);
         fs.clientProvider(new FixedS3ClientProvider(mockClient));
     }
 

--- a/src/test/java/software/amazon/nio/spi/s3/S3PathTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3PathTest.java
@@ -459,7 +459,13 @@ public class S3PathTest {
         // the working directory, which is always "/" for a bucket.
         assertEquals(S3Path.getPath(fileSystem, "dir1/"), S3Path.getPath(fileSystem, "/dir1/"));
 
-        assertNotEquals(S3Path.getPath(fileSystem, "dir1/"), S3Path.getPath(provider.newFileSystem(URI.create("s3://foo")), "/dir1/"));
+        S3FileSystem fooFS = null;
+        try{
+            fooFS = provider.newFileSystem(URI.create("s3://foo"));;
+            assertNotEquals(S3Path.getPath(fileSystem, "dir1/"), S3Path.getPath(fooFS, "/dir1/"));
+        } finally {
+            if ( fooFS != null ) provider.closeFileSystem(fooFS);
+        }
 
         // not equal because in s3 dir1 cannot be implied to be a directory unless it ends with "/"
         assertNotEquals(S3Path.getPath(fileSystem, "dir1/"), S3Path.getPath(fileSystem, "dir1"));


### PR DESCRIPTION
*Description of changes:*

After checking out the project and running the tests, they would fail or not depending on the order the tests are run (it is not guaranteed they are by default).

I've noticed `S3PathTest.testEquals` creates `foo` _fs_ but it is not closed; `S3FileSystemProviderTest` uses `foo` _fs_ for its tests.
So this PR introduces 2 changes:
* Cleanup _fs_ in `testEquals` after creating it
* Get or create _fs_ in `S3FileSystemProviderTest` so that it is not affected by other tests leaking resources

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
