### PR TITLE
chore(test): Replace try/fail/catch/assert with assertThat

### DIFF
--- a/src/test/java/software/amazon/nio/spi/s3/S3ClientProviderTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3ClientProviderTest.java
@@ -186,11 +186,7 @@ public class S3ClientProviderTest {
         );
 
         // then you should get a NoSuchElement exception when you try to get the header
-        try {
-            provider.generateAsyncClient("test-bucket", mockClient);
-        } catch (Exception e) {
-            assertEquals(NoSuchElementException.class, e.getClass());
-        }
+        assertThrows(NoSuchElementException.class, () -> provider.generateAsyncClient("test-bucket", mockClient));
 
         final InOrder inOrder = inOrder(mockClient);
         inOrder.verify(mockClient).getBucketLocation(any(Consumer.class));

--- a/src/test/java/software/amazon/nio/spi/s3/S3ClientProviderTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3ClientProviderTest.java
@@ -159,11 +159,7 @@ public class S3ClientProviderTest {
         );
 
         // then you should get a NoSuchElement exception when you try to get the header
-        try {
-            provider.generateClient("test-bucket", mockClient);
-        } catch (Exception e) {
-            assertEquals(NoSuchElementException.class, e.getClass());
-        }
+        assertThrows(NoSuchElementException.class, () -> provider.generateClient("test-bucket", mockClient));
 
         final InOrder inOrder = inOrder(mockClient);
         inOrder.verify(mockClient).getBucketLocation(any(Consumer.class));

--- a/src/test/java/software/amazon/nio/spi/s3/S3FileSystemProviderTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3FileSystemProviderTest.java
@@ -6,6 +6,7 @@
 package software.amazon.nio.spi.s3;
 
 import java.io.IOException;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -57,6 +58,7 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterEach;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
@@ -99,13 +101,10 @@ public class S3FileSystemProviderTest {
         //
         // A filesystem for pathUri has been created already ;)
         //
-        try {
-            provider.newFileSystem(URI.create(pathUri));
-            fail("filesystem created twice!");
-        } catch (FileSystemAlreadyExistsException x) {
-            assertTrue(x.getMessage().contains("'foo'"));
-        }
-
+        assertThatCode(() -> provider.newFileSystem(URI.create(pathUri)))
+                .as("filesystem created twice!")
+                .isInstanceOf(FileSystemAlreadyExistsException.class)
+                .hasMessageContaining("'foo'");
         //
         // New AWS S3 file system
         //
@@ -115,12 +114,10 @@ public class S3FileSystemProviderTest {
         //
         // New AWS S3 file system with same bucket but different path
         //
-        try {
-            provider.newFileSystem(URI.create("s3://foo2/baa2"));
-            fail("filesystem created twice!");
-        } catch (FileSystemAlreadyExistsException x) {
-            assertTrue(x.getMessage().contains("'foo2'"));
-        }
+        assertThatCode(() -> provider.newFileSystem(URI.create("s3://foo2/baa2")))
+                .as("filesystem created twice!")
+                .isInstanceOf(FileSystemAlreadyExistsException.class)
+                .hasMessageContaining("'foo2'");
         provider.closeFileSystem(fs);
     }
 
@@ -129,32 +126,22 @@ public class S3FileSystemProviderTest {
         //
         // IllegalArgumentException if URI is not good
         //
-        try {
-            provider.newFileSystem((URI)null);
-            fail("mising argument check!");
-        } catch (IllegalArgumentException x) {
-            assertEquals("uri can not be null", x.getMessage());
-        }
 
-        try {
-            provider.newFileSystem(URI.create("noscheme"));
-            fail("mising argument check!");
-        } catch (IllegalArgumentException x) {
-            assertEquals(
-                "invalid uri 'noscheme', please provide an uri as s3://bucket",
-                x.getMessage()
-            );
-        }
+        assertThatCode(() -> provider.newFileSystem(null))
+                .as("missing argument check!")
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("uri can not be null");
 
-        try {
-            provider.newFileSystem(URI.create("s3:///"));
-            fail("mising argument check!");
-        } catch (IllegalArgumentException x) {
-            assertEquals(
-                "invalid uri 's3:///', please provide an uri as s3://bucket",
-                x.getMessage()
-            );
-        }
+        assertThatCode(() -> provider.newFileSystem(URI.create("noscheme")))
+                .as("missing argument check!")
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("invalid uri 'noscheme', please provide an uri as s3://bucket");
+
+        assertThatCode(() -> provider.newFileSystem(URI.create("s3:///")))
+                .as("missing argument check!")
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("invalid uri 's3:///', please provide an uri as s3://bucket");
+        
     }
 
     @Test

--- a/src/test/java/software/amazon/nio/spi/s3/S3FileSystemTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3FileSystemTest.java
@@ -16,6 +16,8 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.BDDAssertions.then;
 import org.junit.jupiter.api.AfterEach;
 import static org.junit.jupiter.api.Assertions.*;
@@ -29,7 +31,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
-import software.amazon.awssdk.services.s3.model.NoSuchBucketException;
 
 @ExtendWith(MockitoExtension.class)
 public class S3FileSystemTest {
@@ -138,25 +139,12 @@ public class S3FileSystemTest {
     public void plainInitializationWithError() {
         //
         // Was want to try a plain initialization (i.e. without any mocks).
-        // We expect standard cluent to throw an exception because the bucket
-        // is not found
-        //
+        // We expect standard client to throw an exception due to missing credentials
         final Path path = Paths.get(URI.create("s3://does-not-exists-" + System.currentTimeMillis() + "/dir"));
         then(path).isInstanceOf(S3Path.class);
-        try {
-            then(Files.exists(path)).isFalse();
-            fail("client should fail...");
-        } catch (NoSuchBucketException x) {
-            //
-            // we get here is we have the network
-            //
-            then(x).hasMessageStartingWith("The specified bucket does not exist");
-        } catch (SdkClientException x) {
-            //
-            // or here if we don't
-            //
-
-        }
+        assertThatThrownBy(() -> Files.exists(path))
+                .isInstanceOf(SdkClientException.class)
+                .hasMessageStartingWith("Unable to load credentials");
     }
 
     @Test

--- a/src/test/java/software/amazon/nio/spi/s3/S3FileSystemTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3FileSystemTest.java
@@ -65,12 +65,8 @@ public class S3FileSystemTest {
         s3FileSystem.close();
         assertFalse(s3FileSystem.isOpen(), "File system should return false from isOpen when closed has been called");
 
-        //
-        // close() also removes the instance from the provider
-        //
-        try {
-            provider.getFileSystem(s3Uri);
-        } catch (FileSystemNotFoundException x) {} // OK
+        // close() should also remove the instance from the provider
+        assertThrows(FileSystemNotFoundException.class, () -> provider.getFileSystem(s3Uri));
     }
 
     @Test

--- a/src/test/java/software/amazon/nio/spi/s3/config/S3NioSpiConfigurationTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/config/S3NioSpiConfigurationTest.java
@@ -9,6 +9,8 @@ import static com.github.stefanbirkner.systemlambda.SystemLambda.withEnvironment
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.BDDAssertions.entry;
 
 import static org.assertj.core.api.BDDAssertions.then;
@@ -105,12 +107,10 @@ public class S3NioSpiConfigurationTest {
         then(config.withEndpoint(null).getEndpoint()).isEqualTo("");
         then(config.withEndpoint("noport.somewhere.com").getEndpoint()).isEqualTo("noport.somewhere.com");
 
-        try {
-            config.withEndpoint("wrongport.somewhere.com:aabbcc");
-            fail("missing sanity check");
-        } catch (IllegalArgumentException x) {
-            then(x).hasMessage("endpoint 'wrongport.somewhere.com:aabbcc' does not match format host:port where port is a number");
-        }
+        assertThatCode(() -> config.withEndpoint("wrongport.somewhere.com:aabbcc"))
+                .as("missing sanity check")
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("endpoint 'wrongport.somewhere.com:aabbcc' does not match format host:port where port is a number");
     }
 
     @Test
@@ -121,12 +121,10 @@ public class S3NioSpiConfigurationTest {
         then(overriddenConfig.getEndpointProtocol()).isEqualTo("https");
         then(badOverriddenConfig.getEndpointProtocol()).isEqualTo(S3_SPI_ENDPOINT_PROTOCOL_DEFAULT);
 
-        try {
-            config.withEndpointProtocol("ftp");
-            fail("missing sanity check");
-        } catch (IllegalArgumentException x) {
-            then(x).hasMessage("endpoint prococol must be one of ('http', 'https')");
-        }
+        assertThatCode(() -> config.withEndpointProtocol("ftp"))
+                .as("missing sanity check")
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("endpoint prococol must be one of ('http', 'https')");
     }
 
     @Test
@@ -134,12 +132,10 @@ public class S3NioSpiConfigurationTest {
         then(config.withMaxFragmentNumber(1000)).isSameAs(config);
         then(config.getMaxFragmentNumber()).isEqualTo(1000);
 
-        try {
-            config.withMaxFragmentNumber(-1);
-            fail("missing sanity check");
-        } catch (IllegalArgumentException x) {
-            then(x).hasMessage("maxFragmentNumber must be positive");
-        }
+        assertThatCode(() -> config.withMaxFragmentNumber(-1))
+                .as("missing sanity check")
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("maxFragmentNumber must be positive");
     }
 
     @Test
@@ -147,12 +143,10 @@ public class S3NioSpiConfigurationTest {
         then(config.withMaxFragmentSize(4000)).isSameAs(config);
         then(config.getMaxFragmentSize()).isEqualTo(4000);
 
-        try {
-            config.withMaxFragmentSize(-1);
-            fail("missing sanity check");
-        } catch (IllegalArgumentException x) {
-            then(x).hasMessage("maxFragmentSize must be positive");
-        }
+        assertThatCode(() -> config.withMaxFragmentSize(-1))
+                .as("missing sanity check")
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("maxFragmentSize must be positive");
     }
 
     @Test
@@ -168,6 +162,7 @@ public class S3NioSpiConfigurationTest {
         then(credentials.secretAccessKey()).isEqualTo("anothersecret");
 
         then(config.withCredentials(null, "something").getCredentials()).isNull();
+
 
         try {
             config.withCredentials("akey", null);
@@ -229,12 +224,10 @@ public class S3NioSpiConfigurationTest {
         then(config.withBucketName("anothername").getBucketName()).isEqualTo("anothername");
         then(config.withBucketName(null).getBucketName()).isNull();
 
-        try {
-            config.withBucketName("Wrong/bucket;name");
-            fail("missing sanity check");
-        } catch (IllegalArgumentException x) {
-            then(x).hasMessage("Bucket name should not contain uppercase characters");
-        }
+        assertThatCode(() -> config.withBucketName("Wrong/bucket;name"))
+                .as("missing sanity check")
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Bucket name should not contain uppercase characters");
     }
     
     @Test

--- a/src/test/java/software/amazon/nio/spi/s3/config/S3NioSpiConfigurationTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/config/S3NioSpiConfigurationTest.java
@@ -6,6 +6,7 @@ package software.amazon.nio.spi.s3.config;
 
 import static com.github.stefanbirkner.systemlambda.SystemLambda.restoreSystemProperties;
 import static com.github.stefanbirkner.systemlambda.SystemLambda.withEnvironmentVariable;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -15,7 +16,6 @@ import static org.assertj.core.api.BDDAssertions.entry;
 
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.fail;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
@@ -163,13 +163,10 @@ public class S3NioSpiConfigurationTest {
 
         then(config.withCredentials(null, "something").getCredentials()).isNull();
 
-
-        try {
-            config.withCredentials("akey", null);
-            fail("missing sanity check");
-        } catch (IllegalArgumentException x) {
-            then(x).hasMessage("secretAccessKey can not be null");
-        }
+        assertThatCode(() -> config.withCredentials("akey", null))
+                .as("missing sanity check")
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("secretAccessKey can not be null");
     }
 
     @Test

--- a/src/test/java/software/amazon/nio/spi/s3x/S3XFileSystemProviderTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3x/S3XFileSystemProviderTest.java
@@ -26,9 +26,10 @@ import java.nio.file.FileSystem;
 import java.nio.file.FileSystemNotFoundException;
 import java.nio.file.FileSystems;
 import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.api.BDDAssertions.then;
-import static org.junit.jupiter.api.Assertions.assertSame;
 import org.junit.jupiter.api.Test;
 import software.amazon.nio.spi.s3.FakeAsyncS3ClientBuilder;
 import software.amazon.nio.spi.s3.S3FileSystem;
@@ -83,22 +84,18 @@ public class S3XFileSystemProviderTest {
         //
         // the same file system can not be created twice
         //
-        try {
-            provider.newFileSystem(URI1);
-            fail("filesystem created twice!");
-        } catch (FileSystemAlreadyExistsException x) {
-            then(x).hasMessageContaining("'myendpoint/foo'");
-        }
+        assertThatCode(() -> provider.newFileSystem(URI1))
+                .as("filesystem created twice!")
+                .isInstanceOf(FileSystemAlreadyExistsException.class)
+                .hasMessageContaining("'myendpoint/foo'");
 
         //
         // Same bucket but different path, is still the same file system
         //
-        try {
-            provider.newFileSystem(URI2);
-            fail("filesystem created twice!");
-        } catch (FileSystemAlreadyExistsException x) {
-            then(x).hasMessageContaining("'myendpoint/foo'");
-        }
+        assertThatCode(() -> provider.newFileSystem(URI2))
+                .as("filesystem created twice!")
+                .isInstanceOf(FileSystemAlreadyExistsException.class)
+                .hasMessageContaining("'myendpoint/foo'");
         provider.closeFileSystem(fs);
 
         //
@@ -120,13 +117,12 @@ public class S3XFileSystemProviderTest {
 
         //
         // With existing endpoint and bucket, no credentials
+
         //
-        try {
-            provider.newFileSystem(URI5);
-            fail("filesystem created twice!");
-        } catch (FileSystemAlreadyExistsException x) {
-            then(x).hasMessageContaining("'myendpoint.com:1010/foo2'");
-        }
+        assertThatCode(() -> provider.newFileSystem(URI5))
+                .as("filesystem created twice!")
+                .isInstanceOf(FileSystemAlreadyExistsException.class)
+                .hasMessageContaining("'myendpoint.com:1010/foo2'");
         provider.closeFileSystem(fs);
 
         //
@@ -173,12 +169,10 @@ public class S3XFileSystemProviderTest {
         provider.closeFileSystem(fs2);
         provider.closeFileSystem(fs3);
 
-        try {
-            provider.getFileSystem(URI.create("s3://nowhere.com:2000/foo2/baa2"));
-            fail("missing error");
-        } catch (FileSystemNotFoundException x) {
-            then(x).hasMessage("file system not found for 'nowhere.com:2000/foo2'");
-        }
+        assertThatCode(() -> provider.getFileSystem(URI.create("s3://nowhere.com:2000/foo2/baa2")))
+                .as("missing error")
+                .isInstanceOf(FileSystemNotFoundException.class)
+                .hasMessageContaining("file system not found for 'nowhere.com:2000/foo2'");
     }
 
     @Test

--- a/src/test/java/software/amazon/nio/spi/s3x/util/S3XFileSystemInfoTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3x/util/S3XFileSystemInfoTest.java
@@ -16,9 +16,10 @@
 package software.amazon.nio.spi.s3x.util;
 
 import java.net.URI;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.BDDAssertions.then;
 import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.*;
 
 /**
  *
@@ -42,19 +43,15 @@ public class S3XFileSystemInfoTest {
         then(info.accessKey()).isNull();
         then(info.accessSecret()).isNull();
 
-        try {
-            new S3XFileSystemInfo(URI.create("s2://myendpoint/Wrong$bucket;name"));
-            fail("missing sanity check");
-        } catch (IllegalArgumentException x) {
-            then(x).hasMessage("Bucket name should not contain uppercase characters");
-        }
+        assertThatCode(() -> new S3XFileSystemInfo(URI.create("s2://myendpoint/Wrong$bucket;name")))
+                .as("missing sanity check")
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Bucket name should not contain uppercase characters");
 
-        try {
-            new S3XFileSystemInfo(null);
-            fail("missing sanity check");
-        } catch (IllegalArgumentException x) {
-            then(x).hasMessage("uri can not be null");
-        }
+        assertThatCode(() -> new S3XFileSystemInfo(null))
+                .as("missing sanity check")
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("uri can not be null");
     }
 
     @Test


### PR DESCRIPTION
*Description of changes:*
This PR replaces several occurrences of the idiom:
```
try {
  ... // do something that throws an Exception
  fail() // with some message to display because the exception should have been thrown
} catch ( someException ){
  ... // some assertion on the exception
}
```
with a couple of assertion methods provided by AssertJ (`assertThatCode`, `assertThatThrownBy`) and JUnit (`assertThrows`) which are already part of the dependencies of the project.

Before:
```
        try {
            provider.newFileSystem(URI.create(pathUri));
            fail("filesystem created twice!");
        } catch (FileSystemAlreadyExistsException x) {
            assertTrue(x.getMessage().contains("'foo'"));
        }
```
After:
```
assertThatCode(() -> provider.newFileSystem(URI.create(pathUri)))
                .as("filesystem created twice!")
                .isInstanceOf(FileSystemAlreadyExistsException.class)
                .hasMessageContaining("'foo'");
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
