### PR TITLE
chore(S3FS): Extract supported file attribute views to static field

### DIFF
--- a/src/main/java/software/amazon/nio/spi/s3/S3FileSystem.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3FileSystem.java
@@ -316,6 +316,8 @@ public class S3FileSystem extends FileSystem {
         return Collections.EMPTY_SET;
     }
 
+    private static final Set<String> supportedFileAttributeViews =
+            Collections.singleton(BASIC_FILE_ATTRIBUTE_VIEW);
     /**
      * Returns the set of the file attribute views supported by this {@code FileSystem}.
      * <br>
@@ -326,9 +328,7 @@ public class S3FileSystem extends FileSystem {
      */
     @Override
     public Set<String> supportedFileAttributeViews() {
-        HashSet<String> views = new HashSet<>(2);
-        views.add(BASIC_FILE_ATTRIBUTE_VIEW);
-        return Collections.unmodifiableSet(views);
+        return supportedFileAttributeViews;
     }
 
     /**


### PR DESCRIPTION
*Description of changes:*

This PR extracts `supportedFileAttributeViews` into a static field so that the creation of the temporary `HashSet` and the call to `unmodifiable...` do not happen each time the method is called. It also uses just the supported value instead of having a size of `2`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
