### PR TITLE
chore(examples): Move examples to their own `SourceSet`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,13 @@ compileJava {
     options.release = 8
 }
 
+sourceSets {
+    examples {
+        java {
+        }
+    }
+}
+
 dependencies {
     implementation 'io.reactivex.rxjava3:rxjava:3.1.8'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'

--- a/src/examples/java/software/amazon/nio/spi/examples/ListPrefix.java
+++ b/src/examples/java/software/amazon/nio/spi/examples/ListPrefix.java
@@ -1,4 +1,4 @@
-package examples;
+package software.amazon.nio.spi.examples;
 
 import java.io.IOException;
 import java.net.URI;

--- a/src/examples/java/software/amazon/nio/spi/examples/Main.java
+++ b/src/examples/java/software/amazon/nio/spi/examples/Main.java
@@ -3,9 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package examples;
-
-import software.amazon.nio.spi.s3.S3Path;
+package software.amazon.nio.spi.examples;
 
 import java.io.IOException;
 import java.net.URI;
@@ -36,7 +34,7 @@ public class Main {
             final Path path = Paths.get(URI.create(pathString));
 
             // proves that the correct path type is being used
-            assert path instanceof S3Path;
+            assert path.getClass().getName().contains("S3Path");
 
             System.out.println("*** READING FROM "+path.toUri()+" ***");
             Files.readAllLines(path)

--- a/src/examples/java/software/amazon/nio/spi/examples/WalkFromRoot.java
+++ b/src/examples/java/software/amazon/nio/spi/examples/WalkFromRoot.java
@@ -1,4 +1,4 @@
-package examples;
+package software.amazon.nio.spi.examples;
 
 
 import java.io.IOException;


### PR DESCRIPTION
*Description of changes:*

This PR moves the example classes into their own `SourceSet` in order to reduce the amount of classes shipped with the library jar and it's size. As additional benefit, code coverage is not affected by those classes.

## Coverage is not affected by examples
![image](https://github.com/awslabs/aws-java-nio-spi-for-s3/assets/283778/87b72301-1e1d-4f0a-a511-f265e4a00168)

## How SourceSets look when the project is imported into IntelliJ
![image](https://github.com/awslabs/aws-java-nio-spi-for-s3/assets/283778/7885895b-a72c-4913-8888-6393b2d5c6b0)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
