### PR TITLE
Provide content-type while putting object to S3

### DIFF
--- a/src/main/java/software/amazon/nio/spi/s3/S3WritableByteChannel.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3WritableByteChannel.java
@@ -108,6 +108,7 @@ public class S3WritableByteChannel implements WritableByteChannel {
                             .putObjectRequest(PutObjectRequest.builder()
                                     .bucket(path.bucketName())
                                     .key(path.getKey())
+                                    .contentType(Files.probeContentType(tempFile))
                                     .build())
                             .source(tempFile)
                             .build()


### PR DESCRIPTION

*Issue #194:*
[S3WritableByteChannel does not consider contentType while putting an object into the bucket](https://github.com/awslabs/aws-java-nio-spi-for-s3/issues/194)

*Description of changes:*
Upon putting an object into the S3 bucket (for instance, while copying), we need to also provide the content-type of the file. This could come crucial in cases like when the uploaded file (let's say an XML file) is going to be used by a specific application later.
While checking the implementation of `PutObjectRequest`, I didn't fine anywhere that `contentType` acquires a default value, so if `Files::probeContentType` returns a null value, it is the same as not calling the builder method. Hence I don't see any negative side-effects with this change.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
