### PR TITLE
fix(examples): Add `project` to `examples` dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,8 @@ dependencies {
     implementation 'ch.qos.logback:logback-core:1.4.11'
     // cannot use caffeine v3 because that requires java 11
     implementation('com.github.ben-manes.caffeine:caffeine:2.9.3')
+
+    examplesImplementation project
 }
 
 publishing {


### PR DESCRIPTION
*Description of changes:*

Fixes https://github.com/awslabs/aws-java-nio-spi-for-s3/pull/223#pullrequestreview-1699625620. It is related to https://github.com/awslabs/aws-java-nio-spi-for-s3/pull/202, the `examples` sourceset was missing the `project` dependency.

*Another topic*

Something that was found out while running the examples is that jvm 11 is required due to the version of `logback`. Running with java 8 results in:
```
Caused by: java.lang.UnsupportedClassVersionError: ch/qos/logback/classic/spi/LogbackServiceProvider has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0
```
According to [logback page](https://logback.qos.ch/dependencies.html), version 1.3 supports java 8 and version 1.4 (introduced in https://github.com/awslabs/aws-java-nio-spi-for-s3/pull/19 or https://github.com/awslabs/aws-java-nio-spi-for-s3/pull/12) requires java 11. This brings the question, whether to downgrade the dependency so that using the library works for java > 8, or move to a new version of java (say 11) for the source and target of the library.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
