### PR TITLE
use standard nio patterns

### DIFF
--- a/src/examples/java/software/amazon/nio/spi/examples/ListPrefix.java
+++ b/src/examples/java/software/amazon/nio/spi/examples/ListPrefix.java
@@ -1,11 +1,15 @@
 package software.amazon.nio.spi.examples;
 
+import software.amazon.nio.spi.s3.S3FileSystem;
+import software.amazon.nio.spi.s3.S3Path;
+
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
-import java.util.Collections;
+
+import static java.util.Collections.*;
 
 public class ListPrefix {
     public static void main(String[] args) throws IOException {
@@ -15,8 +19,12 @@ public class ListPrefix {
         }
 
         String prefix = args[0];
-        try (final FileSystem fileSystem = FileSystems.newFileSystem(URI.create(prefix), Collections.EMPTY_MAP)) {
+        try (final FileSystem fileSystem = FileSystems.newFileSystem(URI.create(prefix), emptyMap())) {
             Path s3Path = fileSystem.getPath(prefix);
+
+            assert fileSystem.getClass().getName().contains("S3FileSystem");
+            assert s3Path.getClass().getName().contains("S3Path");
+
             fileSystem.provider()
                     .newDirectoryStream(s3Path, item -> true)
                     .forEach(path -> System.out.println(path.getFileName()));


### PR DESCRIPTION
*Issue #, if available:*
#230 

*Description of changes:*
Update examples to use standard nio patterns.
Use try with resources.
Use Collections.emptyMap() to make generics implicit.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
