### PR TITLE
refactor(S3ClientProvider): Reduce complexity of `generateClient`

### DIFF
--- a/src/main/java/software/amazon/nio/spi/s3/S3ClientProvider.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3ClientProvider.java
@@ -187,7 +187,7 @@ public class S3ClientProvider {
             S3Client locationClient,
             Function<String, T> getClientForRegion
     ) {
-        logger.debug("generating asynchronous client for bucket: '{}'", bucketName);
+        logger.debug("generating client for bucket: '{}'", bucketName);
         T bucketSpecificClient = null;
 
         if ((configuration.getEndpoint() == null) || configuration.getEndpoint().isBlank()) {
@@ -197,13 +197,13 @@ public class S3ClientProvider {
             //
             String bucketLocation = determineBucketLocation(bucketName, locationClient);
 
-            if ( bucketLocation != null) bucketSpecificClient = getClientForRegion.apply(bucketLocation);
-
-            //
-            // if here, no S3 nor other client has been created yet and we do not
-            // have a location; we'll let it figure out from the profile region
-            //
-            logger.warn("Unable to determine the region of bucket: '{}'. Generating a client for the profile region.", bucketName);
+            if ( bucketLocation != null) {
+                bucketSpecificClient = getClientForRegion.apply(bucketLocation);
+            } else {
+                // if here, no S3 nor other client has been created yet, and we do not
+                // have a location; we'll let it figure out from the profile region
+                logger.warn("Unable to determine the region of bucket: '{}'. Generating a client for the profile region.", bucketName);
+            }
         }
 
         return (bucketSpecificClient != null)

--- a/src/main/java/software/amazon/nio/spi/s3/S3ClientProvider.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3ClientProvider.java
@@ -121,7 +121,7 @@ public class S3ClientProvider {
      *
      * @return a S3Client not bound to a region
      */
-    public S3Client universalClient() {
+    S3Client universalClient() {
         return universalClient(false);
     }
 
@@ -133,7 +133,7 @@ public class S3ClientProvider {
      * @param <T> type of AwsClient
      * @return a S3Client not bound to a region
      */
-    public <T extends AwsClient> T universalClient(boolean async) {
+    <T extends AwsClient> T universalClient(boolean async) {
         return (T)((async) ? DEFAULT_ASYNC_CLIENT : DEFAULT_CLIENT);
     }
 
@@ -160,7 +160,7 @@ public class S3ClientProvider {
      *
      * @return an S3 client appropriate for the region of the named bucket
      */
-    protected S3Client generateSyncClient(String bucketName, S3Client locationClient) {
+    S3Client generateSyncClient(String bucketName, S3Client locationClient) {
         return getClientForBucket(bucketName, locationClient, this::clientForRegion);
     }
 
@@ -174,11 +174,11 @@ public class S3ClientProvider {
      *
      * @return an S3 client appropriate for the region of the named bucket
      */
-    protected S3AsyncClient generateAsyncClient (String bucketName, S3Client locationClient) {
+    S3AsyncClient generateAsyncClient (String bucketName, S3Client locationClient) {
         return getClientForBucket(bucketName, locationClient, this::asyncClientForRegion);
     }
 
-    protected <T extends AwsClient> T getClientForBucket(
+    private <T extends AwsClient> T getClientForBucket(
             String bucketName,
             S3Client locationClient,
             Function<String, T> getClientForRegion

--- a/src/main/java/software/amazon/nio/spi/s3/S3ClientProvider.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3ClientProvider.java
@@ -105,10 +105,6 @@ public class S3ClientProvider {
         this.configuration = (c == null) ? new S3NioSpiConfiguration() : c;
     }
 
-    public S3ClientProvider() {
-        this(null);
-    }
-
     public S3CrtAsyncClientBuilder asyncClientBuilder() {
         return asyncClientBuilder;
     }

--- a/src/main/java/software/amazon/nio/spi/s3/S3ClientProvider.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3ClientProvider.java
@@ -99,7 +99,7 @@ public class S3ClientProvider {
         );
     }
 
-    Logger logger = LoggerFactory.getLogger("S3ClientStoreProvider");
+    static private final Logger logger = LoggerFactory.getLogger(S3ClientProvider.class);
 
     public S3ClientProvider(S3NioSpiConfiguration c) {
         this.configuration = (c == null) ? new S3NioSpiConfiguration() : c;

--- a/src/test/java/software/amazon/nio/spi/s3/FixedS3ClientProvider.java
+++ b/src/test/java/software/amazon/nio/spi/s3/FixedS3ClientProvider.java
@@ -24,7 +24,7 @@ public class FixedS3ClientProvider extends S3ClientProvider {
     }
 
     @Override
-    public S3Client universalClient() {
+    S3Client universalClient() {
         return (S3Client)client;
     }
 

--- a/src/test/java/software/amazon/nio/spi/s3/FixedS3ClientProvider.java
+++ b/src/test/java/software/amazon/nio/spi/s3/FixedS3ClientProvider.java
@@ -19,6 +19,7 @@ public class FixedS3ClientProvider extends S3ClientProvider {
     final public AwsClient client;
 
     public FixedS3ClientProvider(S3AsyncClient client) {
+        super(null);
         this.client = client;
     }
 

--- a/src/test/java/software/amazon/nio/spi/s3/S3ClientProviderTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3ClientProviderTest.java
@@ -37,13 +37,13 @@ public class S3ClientProviderTest {
     S3ClientProvider provider;
 
     @BeforeEach
-    public void before() throws Exception {
-        provider = new S3ClientProvider();
+    public void before() {
+        provider = new S3ClientProvider(null);
     }
 
     @Test
     public void initialization() {
-        final S3ClientProvider P = new S3ClientProvider();
+        final S3ClientProvider P = new S3ClientProvider(null);
 
         assertNotNull(P.configuration);
 

--- a/src/test/java/software/amazon/nio/spi/s3/S3ClientProviderTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3ClientProviderTest.java
@@ -80,7 +80,7 @@ public class S3ClientProviderTest {
                         .build());
 
         // which should get you a client
-        final S3Client s3Client = provider.generateClient("test-bucket", mockClient);
+        final S3Client s3Client = provider.generateSyncClient("test-bucket", mockClient);
         assertNotNull(s3Client);
 
         final InOrder inOrder = inOrder(mockClient);
@@ -159,7 +159,7 @@ public class S3ClientProviderTest {
         );
 
         // then you should get a NoSuchElement exception when you try to get the header
-        assertThrows(NoSuchElementException.class, () -> provider.generateClient("test-bucket", mockClient));
+        assertThrows(NoSuchElementException.class, () -> provider.generateSyncClient("test-bucket", mockClient));
 
         final InOrder inOrder = inOrder(mockClient);
         inOrder.verify(mockClient).getBucketLocation(anyConsumer());

--- a/src/test/java/software/amazon/nio/spi/s3/S3FileSystemTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3FileSystemTest.java
@@ -88,8 +88,8 @@ public class S3FileSystemTest {
 
     @Test
     public void getAndSetClientProvider() {
-        final S3ClientProvider P1 = new S3ClientProvider();
-        final S3ClientProvider P2 = new S3ClientProvider();
+        final S3ClientProvider P1 = new S3ClientProvider(null);
+        final S3ClientProvider P2 = new S3ClientProvider(null);
         s3FileSystem.clientProvider(P1); then(s3FileSystem.clientProvider()).isSameAs(P1);
         s3FileSystem.clientProvider(P2); then(s3FileSystem.clientProvider()).isSameAs(P2);
     }


### PR DESCRIPTION
*Description of changes:*

The `generateClient` (and `generateAsyncClient`) method was quite complex, had several nested blocks (if/try/if/try/if). Some new methods have been extracted in order to make the code more readable and maintainable.

Both `generateClient` and `generateAsyncClient` shared the same logic - except for the underlying client that was generated. A new method `getClientForBucket` has been extracted that receives a function to construct the client for the given bucket location. The _old_ `generateClient` has been renamed to `generateSyncClient`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
