### PR TITLE
Show xlint warnings and some fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ java {
 
 tasks.withType(JavaCompile).configureEach {
     options.release.set(11)
+    options.compilerArgs += ['-Xlint:all,-serial']
 }
 
 sourceSets {

--- a/src/test/java/software/amazon/nio/spi/s3/S3ClientProviderTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3ClientProviderTest.java
@@ -6,17 +6,17 @@
 package software.amazon.nio.spi.s3;
 
 import java.util.NoSuchElementException;
-import java.util.function.Consumer;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import static org.mockito.ArgumentMatchers.any;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.when;
+import static software.amazon.nio.spi.s3.S3Matchers.anyConsumer;
+
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
 import software.amazon.awssdk.http.SdkHttpResponse;
@@ -59,7 +59,7 @@ public class S3ClientProviderTest {
 
     @Test
     public void testGenerateAsyncClientWithNoErrors() {
-        when(mockClient.getBucketLocation(any(Consumer.class)))
+        when(mockClient.getBucketLocation(anyConsumer()))
                 .thenReturn(GetBucketLocationResponse.builder().locationConstraint("us-west-2").build());
         final S3AsyncClient s3Client = provider.generateAsyncClient("test-bucket", mockClient);
         assertNotNull(s3Client);
@@ -68,11 +68,11 @@ public class S3ClientProviderTest {
     @Test
     public void testGenerateClientWith403Response() {
         // when you get a forbidden response from getBucketLocation
-        when(mockClient.getBucketLocation(any(Consumer.class))).thenThrow(
+        when(mockClient.getBucketLocation(anyConsumer())).thenThrow(
                 S3Exception.builder().statusCode(403).build()
         );
         // you should fall back to a head bucket attempt
-        when(mockClient.headBucket(any(Consumer.class)))
+        when(mockClient.headBucket(anyConsumer()))
                 .thenReturn((HeadBucketResponse) HeadBucketResponse.builder()
                         .sdkHttpResponse(SdkHttpResponse.builder()
                                 .putHeader("x-amz-bucket-region", "us-west-2")
@@ -84,19 +84,19 @@ public class S3ClientProviderTest {
         assertNotNull(s3Client);
 
         final InOrder inOrder = inOrder(mockClient);
-        inOrder.verify(mockClient).getBucketLocation(any(Consumer.class));
-        inOrder.verify(mockClient).headBucket(any(Consumer.class));
+        inOrder.verify(mockClient).getBucketLocation(anyConsumer());
+        inOrder.verify(mockClient).headBucket(anyConsumer());
         inOrder.verifyNoMoreInteractions();
     }
 
     @Test
     public void testGenerateAsyncClientWith403Response() {
         // when you get a forbidden response from getBucketLocation
-        when(mockClient.getBucketLocation(any(Consumer.class))).thenThrow(
+        when(mockClient.getBucketLocation(anyConsumer())).thenThrow(
                 S3Exception.builder().statusCode(403).build()
         );
         // you should fall back to a head bucket attempt
-        when(mockClient.headBucket(any(Consumer.class)))
+        when(mockClient.headBucket(anyConsumer()))
                 .thenReturn((HeadBucketResponse) HeadBucketResponse.builder()
                         .sdkHttpResponse(SdkHttpResponse.builder()
                                 .putHeader("x-amz-bucket-region", "us-west-2")
@@ -108,19 +108,19 @@ public class S3ClientProviderTest {
         assertNotNull(s3Client);
 
         final InOrder inOrder = inOrder(mockClient);
-        inOrder.verify(mockClient).getBucketLocation(any(Consumer.class));
-        inOrder.verify(mockClient).headBucket(any(Consumer.class));
+        inOrder.verify(mockClient).getBucketLocation(anyConsumer());
+        inOrder.verify(mockClient).headBucket(anyConsumer());
         inOrder.verifyNoMoreInteractions();
     }
 
     @Test
     public void testGenerateAsyncClientWith403Then301Responses(){
         // when you get a forbidden response from getBucketLocation
-        when(mockClient.getBucketLocation(any(Consumer.class))).thenThrow(
+        when(mockClient.getBucketLocation(anyConsumer())).thenThrow(
                 S3Exception.builder().statusCode(403).build()
         );
         // and you get a 301 response on headBucket
-        when(mockClient.headBucket(any(Consumer.class))).thenThrow(
+        when(mockClient.headBucket(anyConsumer())).thenThrow(
                 S3Exception.builder()
                         .statusCode(301)
                         .awsErrorDetails(AwsErrorDetails.builder()
@@ -136,19 +136,19 @@ public class S3ClientProviderTest {
         assertNotNull(s3Client);
 
         final InOrder inOrder = inOrder(mockClient);
-        inOrder.verify(mockClient).getBucketLocation(any(Consumer.class));
-        inOrder.verify(mockClient).headBucket(any(Consumer.class));
+        inOrder.verify(mockClient).getBucketLocation(anyConsumer());
+        inOrder.verify(mockClient).headBucket(anyConsumer());
         inOrder.verifyNoMoreInteractions();
     }
 
     @Test
     public void testGenerateClientWith403Then301ResponsesNoHeader(){
         // when you get a forbidden response from getBucketLocation
-        when(mockClient.getBucketLocation(any(Consumer.class))).thenThrow(
+        when(mockClient.getBucketLocation(anyConsumer())).thenThrow(
                 S3Exception.builder().statusCode(403).build()
         );
         // and you get a 301 response on headBucket but no header for region
-        when(mockClient.headBucket(any(Consumer.class))).thenThrow(
+        when(mockClient.headBucket(anyConsumer())).thenThrow(
                 S3Exception.builder()
                         .statusCode(301)
                         .awsErrorDetails(AwsErrorDetails.builder()
@@ -162,8 +162,8 @@ public class S3ClientProviderTest {
         assertThrows(NoSuchElementException.class, () -> provider.generateClient("test-bucket", mockClient));
 
         final InOrder inOrder = inOrder(mockClient);
-        inOrder.verify(mockClient).getBucketLocation(any(Consumer.class));
-        inOrder.verify(mockClient).headBucket(any(Consumer.class));
+        inOrder.verify(mockClient).getBucketLocation(anyConsumer());
+        inOrder.verify(mockClient).headBucket(anyConsumer());
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -171,11 +171,11 @@ public class S3ClientProviderTest {
     @Test
     public void testGenerateAsyncClientWith403Then301ResponsesNoHeader(){
         // when you get a forbidden response from getBucketLocation
-        when(mockClient.getBucketLocation(any(Consumer.class))).thenThrow(
+        when(mockClient.getBucketLocation(anyConsumer())).thenThrow(
                 S3Exception.builder().statusCode(403).build()
         );
         // and you get a 301 response on headBucket but no header for region
-        when(mockClient.headBucket(any(Consumer.class))).thenThrow(
+        when(mockClient.headBucket(anyConsumer())).thenThrow(
                 S3Exception.builder()
                         .statusCode(301)
                         .awsErrorDetails(AwsErrorDetails.builder()
@@ -189,8 +189,8 @@ public class S3ClientProviderTest {
         assertThrows(NoSuchElementException.class, () -> provider.generateAsyncClient("test-bucket", mockClient));
 
         final InOrder inOrder = inOrder(mockClient);
-        inOrder.verify(mockClient).getBucketLocation(any(Consumer.class));
-        inOrder.verify(mockClient).headBucket(any(Consumer.class));
+        inOrder.verify(mockClient).getBucketLocation(anyConsumer());
+        inOrder.verify(mockClient).headBucket(anyConsumer());
         inOrder.verifyNoMoreInteractions();
     }
 

--- a/src/test/java/software/amazon/nio/spi/s3/S3FileSystemProviderTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3FileSystemProviderTest.java
@@ -65,6 +65,8 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static software.amazon.nio.spi.s3.S3Matchers.anyConsumer;
+
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 
 @SuppressWarnings("unchecked")
@@ -80,7 +82,7 @@ public class S3FileSystemProviderTest {
     @BeforeEach
     public void init() {
         provider = new S3FileSystemProvider();
-        lenient().when(mockClient.headObject(any(Consumer.class))).thenReturn(
+        lenient().when(mockClient.headObject(anyConsumer())).thenReturn(
                 CompletableFuture.supplyAsync(() -> HeadObjectResponse.builder().contentLength(100L).build()));
         fs = provider.getFileSystem(URI.create(pathUri), true);
         fs.clientProvider(new FixedS3ClientProvider(mockClient));
@@ -178,7 +180,7 @@ public class S3FileSystemProviderTest {
         S3Object object1 = S3Object.builder().key(pathUri+"/key1").build();
         S3Object object2 = S3Object.builder().key(pathUri+"/key2").build();
 
-        when(mockClient.listObjectsV2Paginator(any(Consumer.class))).thenReturn(new ListObjectsV2Publisher(mockClient,
+        when(mockClient.listObjectsV2Paginator(anyConsumer())).thenReturn(new ListObjectsV2Publisher(mockClient,
                 ListObjectsV2Request.builder()
                         .bucket(fs.bucketName())
                         .prefix(pathUri + "/")
@@ -204,7 +206,7 @@ public class S3FileSystemProviderTest {
         S3Object object2 = S3Object.builder().key(pathUri+"/key2").build();
         S3Object object3 = S3Object.builder().key(pathUri+"/").build();
 
-        when(mockClient.listObjectsV2Paginator(any(Consumer.class))).thenReturn(publisher);
+        when(mockClient.listObjectsV2Paginator(anyConsumer())).thenReturn(publisher);
         when(mockClient.listObjectsV2(any(ListObjectsV2Request.class))).thenReturn(CompletableFuture.supplyAsync(() ->
                 ListObjectsV2Response.builder().contents(object1, object2, object3).build()));
 
@@ -231,7 +233,7 @@ public class S3FileSystemProviderTest {
         S3Object object2 = S3Object.builder().key(pathUri+"/key2").build();
         S3Object object3 = S3Object.builder().key(pathUri+"/").build();
 
-        when(mockClient.listObjectsV2Paginator(any(Consumer.class))).thenReturn(publisher);
+        when(mockClient.listObjectsV2Paginator(anyConsumer())).thenReturn(publisher);
         when(mockClient.listObjectsV2(any(ListObjectsV2Request.class))).thenReturn(CompletableFuture.supplyAsync(() ->
                 ListObjectsV2Response.builder().contents(object1, object2, object3).build()));
 
@@ -270,7 +272,7 @@ public class S3FileSystemProviderTest {
     public void delete() throws Exception {
         S3Object object1 = S3Object.builder().key("dir/key1").build();
         S3Object object2 = S3Object.builder().key("dir/subdir/key2").build();
-        when(mockClient.listObjectsV2(any(Consumer.class))).thenReturn(CompletableFuture.supplyAsync(() ->
+        when(mockClient.listObjectsV2(anyConsumer())).thenReturn(CompletableFuture.supplyAsync(() ->
                 ListObjectsV2Response.builder().contents(object1, object2).isTruncated(false).nextContinuationToken(null).build()));
         when(mockClient.deleteObjects(any(DeleteObjectsRequest.class))).thenReturn(CompletableFuture.supplyAsync(() ->
                 DeleteObjectsResponse.builder().build()));
@@ -291,7 +293,7 @@ public class S3FileSystemProviderTest {
     public void copy() throws Exception {
         S3Object object1 = S3Object.builder().key("dir1/key1").build();
         S3Object object2 = S3Object.builder().key("dir1/subdir/key2").build();
-        when(mockClient.listObjectsV2(any(Consumer.class))).thenReturn(CompletableFuture.supplyAsync(() ->
+        when(mockClient.listObjectsV2(anyConsumer())).thenReturn(CompletableFuture.supplyAsync(() ->
                 ListObjectsV2Response.builder().contents(object1, object2).isTruncated(false).nextContinuationToken(null).build()));
         HeadObjectRequest headObjectRequest1 = HeadObjectRequest.builder().bucket("foo").key("dir2/key1").build();
         when(mockClient.headObject(headObjectRequest1)).thenReturn(CompletableFuture.supplyAsync(() ->
@@ -321,7 +323,7 @@ public class S3FileSystemProviderTest {
     public void move() throws Exception {
         S3Object object1 = S3Object.builder().key("dir1/key1").build();
         S3Object object2 = S3Object.builder().key("dir1/subdir/key2").build();
-        when(mockClient.listObjectsV2(any(Consumer.class))).thenReturn(CompletableFuture.supplyAsync(() ->
+        when(mockClient.listObjectsV2(anyConsumer())).thenReturn(CompletableFuture.supplyAsync(() ->
                 ListObjectsV2Response.builder().contents(object1, object2).isTruncated(false).nextContinuationToken(null).build()));
         HeadObjectRequest headObjectRequest1 = HeadObjectRequest.builder().bucket("foo").key("dir2/key1").build();
         when(mockClient.headObject(headObjectRequest1)).thenReturn(CompletableFuture.supplyAsync(() ->
@@ -459,7 +461,7 @@ public class S3FileSystemProviderTest {
         Path foo = fs.getPath("/foo");
         Path fooDir = fs.getPath("/foo/");
 
-        when(mockClient.headObject(any(Consumer.class))).thenReturn(CompletableFuture.completedFuture(
+        when(mockClient.headObject(anyConsumer())).thenReturn(CompletableFuture.completedFuture(
                 HeadObjectResponse.builder()
                         .lastModified(Instant.EPOCH)
                         .contentLength(100L)

--- a/src/test/java/software/amazon/nio/spi/s3/S3FileSystemTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3FileSystemTest.java
@@ -15,7 +15,6 @@ import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Consumer;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.BDDAssertions.then;
@@ -24,10 +23,10 @@ import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import static org.mockito.ArgumentMatchers.any;
 import org.mockito.Mock;
 import static org.mockito.Mockito.lenient;
 import static software.amazon.nio.spi.s3.Constants.PATH_SEPARATOR;
+import static software.amazon.nio.spi.s3.S3Matchers.anyConsumer;
 
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.core.exception.SdkClientException;
@@ -48,7 +47,7 @@ public class S3FileSystemTest {
         provider = new S3FileSystemProvider();
         s3FileSystem = provider.getFileSystem(s3Uri, true);
         s3FileSystem.clientProvider = new FixedS3ClientProvider(mockClient);
-        lenient().when(mockClient.headObject(any(Consumer.class))).thenReturn(
+        lenient().when(mockClient.headObject(anyConsumer())).thenReturn(
                 CompletableFuture.supplyAsync(() -> HeadObjectResponse.builder().contentLength(100L).build()));
     }
 

--- a/src/test/java/software/amazon/nio/spi/s3/S3Matchers.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3Matchers.java
@@ -1,0 +1,11 @@
+package software.amazon.nio.spi.s3;
+
+import org.mockito.ArgumentMatchers;
+
+import java.util.function.Consumer;
+
+public class S3Matchers {
+    public static <T> Consumer<T> anyConsumer() {
+        return ArgumentMatchers.any();
+    }
+}

--- a/src/test/java/software/amazon/nio/spi/s3/S3PathTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3PathTest.java
@@ -13,7 +13,6 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Consumer;
 import org.junit.jupiter.api.AfterEach;
 
 import static org.assertj.core.api.BDDAssertions.then;
@@ -21,10 +20,10 @@ import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import static org.mockito.ArgumentMatchers.any;
 import org.mockito.Mock;
 import static org.mockito.Mockito.lenient;
 import static software.amazon.nio.spi.s3.Constants.PATH_SEPARATOR;
+import static software.amazon.nio.spi.s3.S3Matchers.anyConsumer;
 
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
@@ -50,7 +49,7 @@ public class S3PathTest {
     public void init(){
         fileSystem = provider.getFileSystem(URI.create(uriString), true);
         fileSystem.clientProvider(new FixedS3ClientProvider(mockClient));
-        lenient().when(mockClient.headObject(any(Consumer.class))).thenReturn(
+        lenient().when(mockClient.headObject(anyConsumer())).thenReturn(
                 CompletableFuture.supplyAsync(() -> HeadObjectResponse.builder().contentLength(100L).build()));
 
         root = S3Path.getPath(fileSystem, PATH_SEPARATOR);

--- a/src/test/java/software/amazon/nio/spi/s3/S3ReadAheadByteChannelTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3ReadAheadByteChannelTest.java
@@ -16,7 +16,6 @@ import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Consumer;
 import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -25,6 +24,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
+import static software.amazon.nio.spi.s3.S3Matchers.anyConsumer;
+
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -54,7 +55,7 @@ public class S3ReadAheadByteChannelTest {
         final GetObjectResponse response = GetObjectResponse.builder().build();
         final ResponseBytes<GetObjectResponse> bytes1 = ResponseBytes.fromByteArray(response, "abcdefghijklmnopqrstuvwxyz".getBytes(StandardCharsets.UTF_8));
         final ResponseBytes<GetObjectResponse> bytes2 = ResponseBytes.fromByteArray(response, "ABCDEFGHIJKLMNOPQRSTUVWXYZ".getBytes(StandardCharsets.UTF_8));
-        lenient().when(client.getObject(any(Consumer.class), any(ByteArrayAsyncResponseTransformer.class))).thenReturn(CompletableFuture.supplyAsync(() -> bytes1), CompletableFuture.supplyAsync(() -> bytes2));
+        lenient().when(client.getObject(anyConsumer(), any(ByteArrayAsyncResponseTransformer.class))).thenReturn(CompletableFuture.supplyAsync(() -> bytes1), CompletableFuture.supplyAsync(() -> bytes2));
 
         readAheadByteChannel = new S3ReadAheadByteChannel(path, 26, 2, client, delegator, null, null);
     }

--- a/src/test/java/software/amazon/nio/spi/s3/S3SeekableByteChannelTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3SeekableByteChannelTest.java
@@ -22,7 +22,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Consumer;
 import org.junit.jupiter.api.AfterEach;
 import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,6 +31,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
+import static software.amazon.nio.spi.s3.S3Matchers.anyConsumer;
+
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -48,10 +49,10 @@ public class S3SeekableByteChannelTest {
     @BeforeEach
     public void init() {
         // forward to the method that uses the HeadObjectRequest parameter
-        lenient().when(mockClient.headObject(any(Consumer.class))).thenCallRealMethod();
+        lenient().when(mockClient.headObject(anyConsumer())).thenCallRealMethod();
         lenient().when(mockClient.headObject(any(HeadObjectRequest.class))).thenReturn(
                 CompletableFuture.supplyAsync(() -> HeadObjectResponse.builder().contentLength(100L).build()));
-        lenient().when(mockClient.getObject(any(Consumer.class), any(AsyncResponseTransformer.class))).thenCallRealMethod();
+        lenient().when(mockClient.getObject(anyConsumer(), any(AsyncResponseTransformer.class))).thenCallRealMethod();
         lenient().when(mockClient.getObject(any(GetObjectRequest.class), any(AsyncResponseTransformer.class))).thenReturn(
                 CompletableFuture.supplyAsync(() -> ResponseBytes.fromByteArray(
                         GetObjectResponse.builder().contentLength(6L).build(),

--- a/src/test/java/software/amazon/nio/spi/s3/config/S3NioSpiConfigurationTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/config/S3NioSpiConfigurationTest.java
@@ -17,6 +17,7 @@ import static org.assertj.core.api.BDDAssertions.entry;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
@@ -56,9 +57,13 @@ public class S3NioSpiConfigurationTest {
     }
 
     @Test
-    public void overridesAsMap() {
-        assertThrows(NullPointerException.class, () -> new S3NioSpiConfiguration((Map)null));
+    @DisplayName("new S3NioSpiConfiguration should not support `null` Map of overrides")
+    public void nullMapNotSupported() {
+        assertThrows(NullPointerException.class, () -> new S3NioSpiConfiguration((Map<String, ?>) null));
+    }
 
+    @Test
+    public void overridesAsMap() {
         Map<String, String> map = new HashMap<>();
         map.put(S3_SPI_READ_MAX_FRAGMENT_SIZE_PROPERTY, "1212");
         S3NioSpiConfiguration c = new S3NioSpiConfiguration(map);


### PR DESCRIPTION
*Description of changes:*

This PR enables Xlint checks during build; those warnings can reveal possible bugs, improper types or just add noise. With it enabled, ~53 warnings were found in the test sources. Those are also addressed in here

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
