### PR TITLE
Improve maintainability / readability / javadoc

### DIFF
--- a/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
@@ -693,17 +693,12 @@ public class S3FileSystemProvider extends FileSystemProvider {
      */
     S3FileSystem getFileSystem(URI uri, boolean create) {
         S3FileSystemInfo info = fileSystemInfo(uri);
-        S3FileSystem fs = cache.get(info.key());
-
-        if (fs == null) {
+        return cache.computeIfAbsent(info.key(), (key) -> {
             if (!create) {
                 throw new FileSystemNotFoundException("file system not found for '" + info.key() + "'");
             }
-            fs = forUri(uri);
-            cache.put(info.key(), fs);
-        }
-
-        return fs;
+            return forUri(uri);
+        });
     }
 
     S3FileSystem forUri(URI uri){

--- a/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
@@ -700,6 +700,7 @@ public class S3FileSystemProvider extends FileSystemProvider {
                 throw new FileSystemNotFoundException("file system not found for '" + info.key() + "'");
             }
             fs = forUri(uri);
+            cache.put(info.key(), fs);
         }
 
         return fs;
@@ -731,12 +732,7 @@ public class S3FileSystemProvider extends FileSystemProvider {
             config.withCredentials(info.accessKey(), info.accessSecret());
         }
 
-        S3FileSystem fs = null;
-        cache.put(
-                info.key(),
-                fs = new S3FileSystem(this, config)
-        );
-        return fs;
+        return new S3FileSystem(this, config);
     }
 
     void closeFileSystem(FileSystem fs) {

--- a/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
@@ -697,11 +697,11 @@ public class S3FileSystemProvider extends FileSystemProvider {
             if (!create) {
                 throw new FileSystemNotFoundException("file system not found for '" + info.key() + "'");
             }
-            return forUri(uri);
+            return forUri(uri, info);
         });
     }
 
-    S3FileSystem forUri(URI uri){
+    S3FileSystem forUri(URI uri, S3FileSystemInfo info){
         if (uri == null) {
             throw new IllegalArgumentException("uri can not be null");
         }
@@ -716,7 +716,6 @@ public class S3FileSystemProvider extends FileSystemProvider {
             );
         }
 
-        S3FileSystemInfo info = fileSystemInfo(uri);
         S3NioSpiConfiguration config = new S3NioSpiConfiguration().withEndpoint(info.endpoint()).withBucketName(info.bucket());
 
         if (info.accessKey() != null) {

--- a/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
@@ -722,10 +722,6 @@ public class S3FileSystemProvider extends FileSystemProvider {
         }
 
         S3FileSystemInfo info = fileSystemInfo(uri);
-        if (cache.containsKey(info.key())) {
-            throw new FileSystemAlreadyExistsException("a file system already exists for '" + info.key() + "', use getFileSystem() instead");
-        }
-
         S3NioSpiConfiguration config = new S3NioSpiConfiguration().withEndpoint(info.endpoint()).withBucketName(info.bucket());
 
         if (info.accessKey() != null) {

--- a/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
@@ -79,7 +79,7 @@ public class S3FileSystemProvider extends FileSystemProvider {
 
     private final Logger logger = LoggerFactory.getLogger(this.getClass().getName());
 
-    private static Map<String, S3FileSystem> cache = new HashMap<>();
+    private static final Map<String, S3FileSystem> cache = new HashMap<>();
 
     /**
      * Returns the URI scheme that identifies this provider.
@@ -711,12 +711,12 @@ public class S3FileSystemProvider extends FileSystemProvider {
         }
         if (uri.getScheme() == null) {
             throw new IllegalArgumentException(
-                    String.format("invalid uri '%s', please provide an uri as s3://bucket", uri.toString())
+                    String.format("invalid uri '%s', please provide an uri as s3://bucket", uri)
             );
         }
         if (uri.getAuthority() == null) {
             throw new IllegalArgumentException(
-                    String.format("invalid uri '%s', please provide an uri as s3://bucket", uri.toString())
+                    String.format("invalid uri '%s', please provide an uri as s3://bucket", uri)
             );
         }
 

--- a/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
@@ -245,7 +245,7 @@ public class S3FileSystemProvider extends FileSystemProvider {
 
         final Iterator<Path> iterator = pathIteratorForPublisher(filter, fs, finalDirName, listObjectsV2Publisher);
 
-        return new DirectoryStream<Path>() {
+        return new DirectoryStream<>() {
             @Override
             public void close() {
             }

--- a/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
@@ -91,8 +91,8 @@ public class S3FileSystemProvider extends FileSystemProvider {
         return SCHEME;
     }
 
-    /*
-     * @throws NotYetImplementedException
+    /**
+     * @throws NotYetImplementedException This method is not yet supported in v2.x. It might be implemented for bucket creation
      */
     @Override
     public FileSystem newFileSystem(URI uri, Map<String, ?> env) {

--- a/src/main/java/software/amazon/nio/spi/s3/S3Path.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3Path.java
@@ -70,8 +70,8 @@ class S3Path implements Path {
      * @return a new S3Path
      */
     static S3Path getPath(S3FileSystem fsForBucket, String first, String... more) {
-        if(fsForBucket == null)  throw new IllegalArgumentException("The S3FileSystem may not be null");
-        if(first == null ){
+        if(fsForBucket == null) throw new IllegalArgumentException("The S3FileSystem may not be null");
+        if(first == null) {
           throw new IllegalArgumentException("first element of the path may not be null");
         }
 
@@ -79,26 +79,12 @@ class S3Path implements Path {
 
         first = first.trim();
 
-        if((first.isEmpty()) && !(more == null || more.length == 0)) throw new IllegalArgumentException("The first element of the path may not be empty when more exists");
+        if( first.isEmpty() && !(more == null || more.length == 0)) throw new IllegalArgumentException("The first element of the path may not be empty when more exists");
         if(first.startsWith(fsForBucket.provider().getScheme()+":/")) {
-            first = first.substring(fsForBucket.provider().getScheme().length()+2);
-
-            String part = null;
-            if (configuration.getCredentials() != null) {
-                AwsCredentials credentials = configuration.getCredentials();
-                part = credentials.accessKeyId() + ':' + credentials.secretAccessKey();
-                if (first.startsWith('/' + part)) {
-                    first = PATH_SEPARATOR + first.substring(part.length()+2);
-                }
-            }
-            part = configuration.getEndpoint();
-            if (!part.isEmpty() && first.startsWith(PATH_SEPARATOR + part)) {
-                first = first.substring(part.length()+1);
-            }
-            part = configuration.getBucketName();
-            if (first.startsWith(PATH_SEPARATOR + part)) {
-                first = first.substring(part.length()+1);
-            }
+            first = removeScheme(first, fsForBucket.provider().getScheme());
+            first = removeCredentials(first, configuration);
+            first = removeEndpoint(first, configuration.getEndpoint());
+            first = removeBucket(first, configuration.getBucketName());
         }
 
         return new S3Path(fsForBucket, PosixLikePathRepresentation.of(first, more));
@@ -861,4 +847,32 @@ class S3Path implements Path {
         }
     }
 
+    private static String removeScheme(String path, String scheme){
+        return path.substring(scheme.length()+2);
+    }
+
+    private static String removeCredentials(String first, S3NioSpiConfiguration configuration) {
+        if (configuration.getCredentials() != null) {
+            AwsCredentials credentials = configuration.getCredentials();
+            String credentialsAsString = credentials.accessKeyId() + ':' + credentials.secretAccessKey();
+            if (first.startsWith('/' + credentialsAsString)) {
+                first = PATH_SEPARATOR + first.substring(credentialsAsString.length()+2);
+            }
+        }
+        return first;
+    }
+
+    private static String removeEndpoint(String first, String endpoint) {
+        if (!endpoint.isEmpty() && first.startsWith(PATH_SEPARATOR + endpoint)) {
+            first = first.substring(endpoint.length()+1);
+        }
+        return first;
+    }
+
+    private static String removeBucket(String first, String part) {
+        if (first.startsWith(PATH_SEPARATOR + part)) {
+            first = first.substring(part.length()+1);
+        }
+        return first;
+    }
 }

--- a/src/main/java/software/amazon/nio/spi/s3/S3Path.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3Path.java
@@ -80,8 +80,10 @@ class S3Path implements Path {
         first = first.trim();
 
         if( first.isEmpty() && !(more == null || more.length == 0)) throw new IllegalArgumentException("The first element of the path may not be empty when more exists");
-        if(first.startsWith(fsForBucket.provider().getScheme()+":/")) {
-            first = removeScheme(first, fsForBucket.provider().getScheme());
+
+        String scheme = fsForBucket.provider().getScheme();
+        if(first.startsWith(scheme +":/")) {
+            first = removeScheme(first, scheme);
             first = removeCredentials(first, configuration);
             first = removeEndpoint(first, configuration.getEndpoint());
             first = removeBucket(first, configuration.getBucketName());

--- a/src/main/java/software/amazon/nio/spi/s3/S3Path.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3Path.java
@@ -7,9 +7,9 @@ package software.amazon.nio.spi.s3;
 
 import java.io.File;
 import java.io.IOError;
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystem;
 import java.nio.file.InvalidPathException;
 import java.nio.file.LinkOption;
@@ -631,17 +631,10 @@ class S3Path implements Path {
         elements.forEachRemaining(
             (e) -> {
                 String name = e.getFileName().toString();
-                try {
-                    if (name.endsWith(PATH_SEPARATOR)) {
-                        name = name.substring(0, name.length()-1);
-                    }
-                    uri.append(PATH_SEPARATOR).append(URLEncoder.encode(name, "UTF-8"));
-                } catch (UnsupportedEncodingException x) {
-                    //
-                    // NOTE: I do not know how to reproduce this case...
-                    //
-                    throw new IllegalArgumentException("path '" + uri + "' can not be converted to URI: " + x.getMessage(), x);
+                if (name.endsWith(PATH_SEPARATOR)) {
+                    name = name.substring(0, name.length()-1);
                 }
+                uri.append(PATH_SEPARATOR).append(URLEncoder.encode(name, StandardCharsets.UTF_8));
             }
         );
         if (isDirectory()) {

--- a/src/main/java/software/amazon/nio/spi/s3/S3ReadAheadByteChannel.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3ReadAheadByteChannel.java
@@ -178,7 +178,7 @@ class S3ReadAheadByteChannel implements ReadableByteChannel {
                 .filter(idx -> idx < currentFragIndx)
                 .collect(Collectors.toSet());
 
-        if (priorIndexes.size() > 0) {
+        if (!priorIndexes.isEmpty()) {
             logger.debug("invalidating fragment(s) '{}' from '{}'",
                     priorIndexes.stream().map(Objects::toString).collect(Collectors.joining(", ")), path.toUri());
 

--- a/src/main/java/software/amazon/nio/spi/s3/S3SeekableByteChannel.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3SeekableByteChannel.java
@@ -66,7 +66,7 @@ class S3SeekableByteChannel implements SeekableByteChannel {
             readDelegate = null;
             writeDelegate = new S3WritableByteChannel(s3Path, s3Client, options, timeout, timeUnit);
             position = 0L;
-        } else if (options.contains(StandardOpenOption.READ) || options.size() == 0) {
+        } else if (options.contains(StandardOpenOption.READ) || options.isEmpty()) {
             LOGGER.debug("using S3ReadAheadByteChannel as read delegate for path '{}'", s3Path.toUri());
             readDelegate = new S3ReadAheadByteChannel(s3Path, config.getMaxFragmentSize(), config.getMaxFragmentNumber(), s3Client, this, timeout, timeUnit);
             writeDelegate = null;

--- a/src/test/java/software/amazon/nio/spi/s3/S3ClientProviderTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3ClientProviderTest.java
@@ -6,6 +6,8 @@
 package software.amazon.nio.spi.s3;
 
 import java.util.NoSuchElementException;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.BeforeEach;
@@ -47,11 +49,12 @@ public class S3ClientProviderTest {
 
         assertNotNull(P.configuration);
 
-        assertTrue(P.universalClient() instanceof S3Client);
         assertNotNull(P.universalClient());
+        assertThat(P.universalClient()).isInstanceOf(S3Client.class);
 
-        assertTrue(P.universalClient(true) instanceof S3AsyncClient);
-        assertNotNull(P.universalClient());
+        S3AsyncClient t = P.universalClient(true);
+        assertNotNull(t);
+        assertThat(t).isInstanceOf(S3AsyncClient.class);
 
         S3NioSpiConfiguration config = new S3NioSpiConfiguration();
         assertSame(config, new S3ClientProvider(config).configuration);

--- a/src/test/java/software/amazon/nio/spi/s3/S3FileSystemProviderTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3FileSystemProviderTest.java
@@ -23,6 +23,7 @@ import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 import software.amazon.awssdk.services.s3.model.S3Object;
@@ -283,7 +284,7 @@ public class S3FileSystemProviderTest {
         verify(mockClient, times(1)).deleteObjects(argumentCaptor.capture());
         DeleteObjectsRequest captorValue = argumentCaptor.getValue();
         assertEquals("foo", captorValue.bucket());
-        List<String> keys = captorValue.delete().objects().stream().map(objectIdentifier -> objectIdentifier.key()).collect(Collectors.toList());
+        List<String> keys = captorValue.delete().objects().stream().map(ObjectIdentifier::key).collect(Collectors.toList());
         assertEquals(2, keys.size());
         assertTrue(keys.contains("dir/key1"));
         assertTrue(keys.contains("dir/subdir/key2"));
@@ -351,7 +352,7 @@ public class S3FileSystemProviderTest {
         assertEquals("dir2/subdir/key2", requestValues.get(1).destinationKey());
         ArgumentCaptor<DeleteObjectsRequest> deleteArgumentCaptor = ArgumentCaptor.forClass(DeleteObjectsRequest.class);
         verify(mockClient, times(1)).deleteObjects(deleteArgumentCaptor.capture());
-        List<String> keys = deleteArgumentCaptor.getValue().delete().objects().stream().map(objectIdentifier -> objectIdentifier.key()).collect(Collectors.toList());
+        List<String> keys = deleteArgumentCaptor.getValue().delete().objects().stream().map(ObjectIdentifier::key).collect(Collectors.toList());
         assertEquals(2, keys.size());
         assertTrue(keys.contains("dir1/key1"));
         assertTrue(keys.contains("dir1/subdir/key2"));

--- a/src/test/java/software/amazon/nio/spi/s3/S3FileSystemProviderTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3FileSystemProviderTest.java
@@ -150,9 +150,7 @@ public class S3FileSystemProviderTest {
         provider.closeFileSystem(cfs);
 
         assertThrows(
-            FileSystemNotFoundException.class, () -> {
-                provider.getFileSystem(URI.create("s3://nobucket"));
-            }
+            FileSystemNotFoundException.class, () -> provider.getFileSystem(URI.create("s3://nobucket"))
         );
     }
 

--- a/src/test/java/software/amazon/nio/spi/s3/S3FileSystemProviderTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3FileSystemProviderTest.java
@@ -56,6 +56,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
@@ -168,7 +169,7 @@ public class S3FileSystemProviderTest {
     public void newByteChannel() throws Exception {
         final SeekableByteChannel channel = provider.newByteChannel(Paths.get(URI.create(pathUri)), Collections.singleton(StandardOpenOption.READ));
         assertNotNull(channel);
-        assertTrue(channel instanceof S3SeekableByteChannel);
+        assertThat(channel).isInstanceOf(S3SeekableByteChannel.class);
     }
 
     @Test
@@ -450,7 +451,7 @@ public class S3FileSystemProviderTest {
         Path foo = fs.getPath("/foo");
         final BasicFileAttributes basicFileAttributes = provider.readAttributes(foo, BasicFileAttributes.class);
         assertNotNull(basicFileAttributes);
-        assertTrue(basicFileAttributes instanceof S3BasicFileAttributes);
+        assertThat(basicFileAttributes).isInstanceOf(S3BasicFileAttributes.class);
     }
 
     @Test

--- a/src/test/java/software/amazon/nio/spi/s3/S3FileSystemProviderTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3FileSystemProviderTest.java
@@ -29,7 +29,6 @@ import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 import software.amazon.awssdk.services.s3.model.S3Object;
 import software.amazon.awssdk.services.s3.paginators.ListObjectsV2Publisher;
 
-import java.io.IOException;
 import java.net.URI;
 import java.nio.channels.SeekableByteChannel;
 import java.nio.file.AccessDeniedException;
@@ -53,7 +52,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -176,7 +174,7 @@ public class S3FileSystemProviderTest {
     }
 
     @Test
-    public void newDirectoryStream() throws IOException, ExecutionException, InterruptedException {
+    public void newDirectoryStream() {
 
         S3Object object1 = S3Object.builder().key(pathUri+"/key1").build();
         S3Object object2 = S3Object.builder().key(pathUri+"/key2").build();
@@ -197,7 +195,7 @@ public class S3FileSystemProviderTest {
     }
 
     @Test
-    public void pathIteratorForPublisher_withPagination() throws IOException {
+    public void pathIteratorForPublisher_withPagination() {
         final ListObjectsV2Publisher publisher = new ListObjectsV2Publisher(mockClient,
                 ListObjectsV2Request.builder()
                         .bucket(fs.bucketName())
@@ -224,7 +222,7 @@ public class S3FileSystemProviderTest {
     }
 
     @Test
-    public void pathIteratorForPublisher_appliesFilter() throws IOException {
+    public void pathIteratorForPublisher_appliesFilter() {
         final ListObjectsV2Publisher publisher = new ListObjectsV2Publisher(mockClient,
                 ListObjectsV2Request.builder()
                         .bucket(fs.bucketName())
@@ -405,7 +403,7 @@ public class S3FileSystemProviderTest {
     }
 
     @Test
-    public void checkAccessWhenAccessDenied() throws Exception {
+    public void checkAccessWhenAccessDenied() {
         when(mockClient.headObject(any(Consumer.class))).thenReturn(CompletableFuture.supplyAsync(() ->
                 HeadObjectResponse.builder()
                         .sdkHttpResponse(SdkHttpResponse.builder().statusCode(403).build())
@@ -416,7 +414,7 @@ public class S3FileSystemProviderTest {
     }
 
     @Test
-    public void checkAccessWhenNoSuchFile() throws Exception {
+    public void checkAccessWhenNoSuchFile() {
         when(mockClient.headObject(any(Consumer.class))).thenReturn(CompletableFuture.supplyAsync(() ->
                 HeadObjectResponse.builder()
                         .sdkHttpResponse(SdkHttpResponse.builder().statusCode(404).build())


### PR DESCRIPTION
*Description of changes:*

This PR addresses some suggestions of the IDE:
* Unnecessary types
* Unnecessary variable initialization
* Replace one liner lambdas with expression lambdas
* Declared exceptions that are not thrown
* Replace `assertTrue(x instanceof b)` with `assertThat().isInstanceOf`
* Use collection.isEmpty() when possible

For the cases where `Unnecessary variable initialization` was found, the code has been rewritten with smaller methods, making the code easier to understand (see 2da3ec0f81e5ebe56c725d63ff03e07d06881af9 for example)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
