### PR TITLE
test(Files): Add integration tests for Files.copy / read*

### DIFF
--- a/src/integrationTest/java/software/amazon/nio/spi/s3/Containers.java
+++ b/src/integrationTest/java/software/amazon/nio/spi/s3/Containers.java
@@ -37,6 +37,17 @@ abstract class Containers {
          .doesNotThrowAnyException();
     }
 
+    public static void putObject(String bucket, String key, String content) {
+        assertThatCode(() -> {
+            Container.ExecResult execResultCreateFile = LOCAL_STACK_CONTAINER.execInContainer("sh", "-c", "echo -n '" + content + "' > " + key);
+            Container.ExecResult execResultPut = LOCAL_STACK_CONTAINER.execInContainer(("awslocal s3api put-object --bucket " + bucket + " --key " + key + " --body " + key).split(" "));
+
+            assertThat(execResultCreateFile.getExitCode()).isZero();
+            assertThat(execResultPut.getExitCode()).withFailMessage("Failed put: %s ", execResultPut.getStderr()).isZero();
+        }).as("Failed to put object '%s' in bucket '%s'", key, bucket)
+                .doesNotThrowAnyException();
+    }
+
     public static String localStackConnectionEndpoint() {
         return localStackConnectionEndpoint(null, null);
     }

--- a/src/integrationTest/java/software/amazon/nio/spi/s3/FilesCopyTest.java
+++ b/src/integrationTest/java/software/amazon/nio/spi/s3/FilesCopyTest.java
@@ -1,0 +1,32 @@
+package software.amazon.nio.spi.s3;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static software.amazon.nio.spi.s3.Containers.localStackConnectionEndpoint;
+import static software.amazon.nio.spi.s3.Containers.putObject;
+
+@DisplayName("Files$copy should load file contents from localstack")
+public class FilesCopyTest
+{
+    @TempDir
+    Path tempDir;
+
+    @Test
+    @DisplayName("when doing copy of existing file")
+    public void fileCopyShouldCopyFileWhenFileFound() throws IOException {
+        Containers.createBucket("sink");
+        putObject("sink", "files-copy.txt", "some content");
+        final Path path = Paths.get(URI.create(localStackConnectionEndpoint() + "/sink/files-copy.txt"));
+        Path copiedFile = Files.copy(path, tempDir.resolve("sample-file-local.txt"));
+        assertThat(copiedFile).hasContent("some content");
+    }
+}

--- a/src/integrationTest/java/software/amazon/nio/spi/s3/FilesReadTest.java
+++ b/src/integrationTest/java/software/amazon/nio/spi/s3/FilesReadTest.java
@@ -1,0 +1,40 @@
+package software.amazon.nio.spi.s3;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.assertj.core.api.BDDAssertions.then;
+import static software.amazon.nio.spi.s3.Containers.localStackConnectionEndpoint;
+import static software.amazon.nio.spi.s3.Containers.putObject;
+
+@DisplayName("Files$read* should load file contents from localstack")
+public class FilesReadTest
+{
+    private final Path path = Paths.get(URI.create(localStackConnectionEndpoint() + "/sink/files-read.txt"));
+
+    @BeforeAll
+    public static void createBucketAndFile(){
+        Containers.createBucket("sink");
+        putObject("sink", "files-read.txt", "some content");
+    }
+
+    @Test
+    @DisplayName("when doing readAllBytes from existing file in s3")
+    public void fileReadAllBytesShouldReturnFileContentsWhenFileFound() throws IOException {
+        then(Files.readAllBytes(path)).isEqualTo("some content".getBytes());
+    }
+
+    @Test
+    @DisplayName("when doing readAllLines from existing file in s3")
+    public void fileReadAllLinesShouldReturnFileContentWhenFileFound() throws IOException {
+        then(String.join("", Files.readAllLines(path))).isEqualTo("some content");
+    }
+
+}

--- a/src/main/java/software/amazon/nio/spi/s3/S3ClientProvider.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3ClientProvider.java
@@ -142,10 +142,11 @@ public class S3ClientProvider {
      * discovery client.
      *
      * @param bucket the named of the bucket to make the client for
+     * @param crt    whether to return a CRT async client or not
      * @return an S3 client appropriate for the region of the named bucket
      */
-    protected S3AsyncClient generateAsyncClient(String bucket) {
-        return generateAsyncClient(bucket, universalClient());
+    protected S3AsyncClient generateAsyncClient(String bucket, boolean crt) {
+        return generateAsyncClient(bucket, universalClient(), crt);
     }
 
     /**
@@ -168,10 +169,11 @@ public class S3ClientProvider {
      * @param bucketName     the name of the bucket to make the client for
      * @param locationClient the client used to determine the location of the
      *                       named bucket, recommend using DEFAULT_CLIENT
+     * @param crt            whether to return a CRT async client or not
      * @return an S3 client appropriate for the region of the named bucket
      */
-    S3AsyncClient generateAsyncClient(String bucketName, S3Client locationClient) {
-        return getClientForBucket(bucketName, locationClient, this::asyncClientForRegion);
+    S3AsyncClient generateAsyncClient(String bucketName, S3Client locationClient, boolean crt) {
+        return getClientForBucket(bucketName, locationClient, (region) -> asyncClientForRegion(region, crt));
     }
 
     private <T extends AwsClient> T getClientForBucket(
@@ -247,7 +249,10 @@ public class S3ClientProvider {
         return configureClientForRegion(regionName, S3Client.builder());
     }
 
-    private S3AsyncClient asyncClientForRegion(String regionName) {
+    private S3AsyncClient asyncClientForRegion(String regionName, boolean crt) {
+        if (!crt) {
+            return configureClientForRegion(regionName, S3AsyncClient.builder());
+        }
         Region region = getRegionFromRegionName(regionName);
         logger.debug("bucket region is: '{}'", region.id());
 

--- a/src/main/java/software/amazon/nio/spi/s3/S3ClientProvider.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3ClientProvider.java
@@ -288,6 +288,6 @@ public class S3ClientProvider {
     }
 
     private static Region getRegionFromRegionName(String regionName) {
-        return ((regionName == null) || (regionName.trim().isEmpty())) ? Region.US_EAST_1 : Region.of(regionName);
+        return (regionName == null || regionName.isBlank()) ? Region.US_EAST_1 : Region.of(regionName);
     }
 }

--- a/src/main/java/software/amazon/nio/spi/s3/S3ClientProvider.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3ClientProvider.java
@@ -130,11 +130,11 @@ public class S3ClientProvider {
      * that can be used by certain S3 operations for discovery
      *
      * @param async true to return an asynchronous client, false otherwise
-     * @param <T> type of AwsClient
+     * @param <T>   type of AwsClient
      * @return a S3Client not bound to a region
      */
     <T extends AwsClient> T universalClient(boolean async) {
-        return (T)((async) ? DEFAULT_ASYNC_CLIENT : DEFAULT_CLIENT);
+        return (T) ((async) ? DEFAULT_ASYNC_CLIENT : DEFAULT_CLIENT);
     }
 
     /**
@@ -142,22 +142,19 @@ public class S3ClientProvider {
      * discovery client.
      *
      * @param bucket the named of the bucket to make the client for
-     *
      * @return an S3 client appropriate for the region of the named bucket
-     *
      */
     protected S3AsyncClient generateAsyncClient(String bucket) {
-        return generateAsyncClient(bucket,  universalClient());
+        return generateAsyncClient(bucket, universalClient());
     }
 
     /**
      * Generate a client for the named bucket using a provided client to
      * determine the location of the named client
      *
-     * @param bucketName the name of the bucket to make the client for
+     * @param bucketName     the name of the bucket to make the client for
      * @param locationClient the client used to determine the location of the
-     *        named bucket, recommend using DEFAULT_CLIENT
-     *
+     *                       named bucket, recommend using DEFAULT_CLIENT
      * @return an S3 client appropriate for the region of the named bucket
      */
     S3Client generateSyncClient(String bucketName, S3Client locationClient) {
@@ -168,13 +165,12 @@ public class S3ClientProvider {
      * Generate an async  client for the named bucket using a provided client to
      * determine the location of the named client
      *
-     * @param bucketName the name of the bucket to make the client for
+     * @param bucketName     the name of the bucket to make the client for
      * @param locationClient the client used to determine the location of the
-     *        named bucket, recommend using DEFAULT_CLIENT
-     *
+     *                       named bucket, recommend using DEFAULT_CLIENT
      * @return an S3 client appropriate for the region of the named bucket
      */
-    S3AsyncClient generateAsyncClient (String bucketName, S3Client locationClient) {
+    S3AsyncClient generateAsyncClient(String bucketName, S3Client locationClient) {
         return getClientForBucket(bucketName, locationClient, this::asyncClientForRegion);
     }
 

--- a/src/main/java/software/amazon/nio/spi/s3/S3FileSystem.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3FileSystem.java
@@ -404,10 +404,14 @@ public class S3FileSystem extends FileSystem {
      */
     S3AsyncClient client() {
         if (client == null) {
-            client = clientProvider.generateAsyncClient(bucketName);
+            client = clientProvider.generateAsyncClient(bucketName, true);
         }
 
         return client;
+    }
+
+    S3AsyncClient readClient() {
+        return clientProvider.generateAsyncClient(bucketName, false);
     }
 
     /**

--- a/src/main/java/software/amazon/nio/spi/s3/S3ReadAheadByteChannel.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3ReadAheadByteChannel.java
@@ -169,6 +169,7 @@ class S3ReadAheadByteChannel implements ReadableByteChannel {
         open = false;
         readAheadBuffersCache.invalidateAll();
         readAheadBuffersCache.cleanUp();
+        client.close();
     }
 
     private void clearPriorFragments(int currentFragIndx) {

--- a/src/main/java/software/amazon/nio/spi/s3/S3SeekableByteChannel.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3SeekableByteChannel.java
@@ -62,7 +62,8 @@ class S3SeekableByteChannel implements SeekableByteChannel {
             position = 0L;
         } else if (options.contains(StandardOpenOption.READ) || options.isEmpty()) {
             LOGGER.debug("using S3ReadAheadByteChannel as read delegate for path '{}'", s3Path.toUri());
-            readDelegate = new S3ReadAheadByteChannel(s3Path, config.getMaxFragmentSize(), config.getMaxFragmentNumber(), s3Client, this, timeout, timeUnit);
+            S3AsyncClient readClient = s3Path.getFileSystem().readClient();
+            readDelegate = new S3ReadAheadByteChannel(s3Path, config.getMaxFragmentSize(), config.getMaxFragmentNumber(), readClient, this, timeout, timeUnit);
             writeDelegate = null;
         } else {
             throw new IOException("Invalid channel mode");

--- a/src/main/java/software/amazon/nio/spi/s3/config/S3NioSpiConfiguration.java
+++ b/src/main/java/software/amazon/nio/spi/s3/config/S3NioSpiConfiguration.java
@@ -6,6 +6,7 @@
 package software.amazon.nio.spi.s3.config;
 
 
+import java.net.URI;
 import java.util.HashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -415,5 +416,13 @@ public class S3NioSpiConfiguration extends HashMap<String, Object> {
                     propertyVal, propName, defaultVal);
             return defaultVal;
         }
+    }
+
+    public URI endpointURI() {
+        String endpoint = getEndpoint();
+        if (endpoint.isBlank()) {
+            return null;
+        }
+        return URI.create(String.format("%s://%s", getEndpointProtocol(), getEndpoint()));
     }
 }

--- a/src/test/java/software/amazon/nio/spi/s3/FixedS3ClientProvider.java
+++ b/src/test/java/software/amazon/nio/spi/s3/FixedS3ClientProvider.java
@@ -29,7 +29,7 @@ public class FixedS3ClientProvider extends S3ClientProvider {
     }
 
     @Override
-    protected S3AsyncClient generateAsyncClient(String bucketName) {
+    protected S3AsyncClient generateAsyncClient(String bucketName, boolean crt) {
         return (S3AsyncClient)client;
     }
 

--- a/src/test/java/software/amazon/nio/spi/s3/S3ClientProviderTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3ClientProviderTest.java
@@ -64,7 +64,7 @@ public class S3ClientProviderTest {
     public void testGenerateAsyncClientWithNoErrors() {
         when(mockClient.getBucketLocation(anyConsumer()))
                 .thenReturn(GetBucketLocationResponse.builder().locationConstraint("us-west-2").build());
-        final S3AsyncClient s3Client = provider.generateAsyncClient("test-bucket", mockClient);
+        final S3AsyncClient s3Client = provider.generateAsyncClient("test-bucket", mockClient, true);
         assertNotNull(s3Client);
     }
 
@@ -107,7 +107,7 @@ public class S3ClientProviderTest {
                         .build());
 
         // which should get you a client
-        final S3AsyncClient s3Client = provider.generateAsyncClient("test-bucket", mockClient);
+        final S3AsyncClient s3Client = provider.generateAsyncClient("test-bucket", mockClient, true);
         assertNotNull(s3Client);
 
         final InOrder inOrder = inOrder(mockClient);
@@ -135,7 +135,7 @@ public class S3ClientProviderTest {
         );
 
         // then you should be able to get a client as long as the error response header contains the region
-        final S3AsyncClient s3Client = provider.generateAsyncClient("test-bucket", mockClient);
+        final S3AsyncClient s3Client = provider.generateAsyncClient("test-bucket", mockClient, true);
         assertNotNull(s3Client);
 
         final InOrder inOrder = inOrder(mockClient);
@@ -189,7 +189,7 @@ public class S3ClientProviderTest {
         );
 
         // then you should get a NoSuchElement exception when you try to get the header
-        assertThrows(NoSuchElementException.class, () -> provider.generateAsyncClient("test-bucket", mockClient));
+        assertThrows(NoSuchElementException.class, () -> provider.generateAsyncClient("test-bucket", mockClient, true));
 
         final InOrder inOrder = inOrder(mockClient);
         inOrder.verify(mockClient).getBucketLocation(anyConsumer());
@@ -203,12 +203,12 @@ public class S3ClientProviderTest {
         provider.asyncClientBuilder = BUILDER;
 
         provider.configuration.withEndpoint("endpoint1:1010");
-        provider.generateAsyncClient("bucket1");
+        provider.generateAsyncClient("bucket1", true);
         then(BUILDER.endpointOverride.toString()).isEqualTo("https://endpoint1:1010");
         then(BUILDER.region).isEqualTo(Region.US_EAST_1);  // just a default in the case not provide
 
         provider.configuration.withEndpoint("endpoint2:2020");
-        provider.generateAsyncClient("bucket2");
+        provider.generateAsyncClient("bucket2", true);
         then(BUILDER.endpointOverride.toString()).isEqualTo("https://endpoint2:2020");
         then(BUILDER.region).isEqualTo(Region.US_EAST_1);  // just a default in the case not provide
     }


### PR DESCRIPTION
Issue #236 

*Description of changes:*

As discussed in the issue, a `non-crt` asyncclient will be used for reading files through the `S3ReadAheadByteChannel`. This is the class used when using the nio api via `Files.copy` or `Files.read*`.

Some private methods have been renamed to better reflect the purpose of them.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
