### PR TITLE
log(S3FileSystem): Use scheme of the provider instead of `s3`

### DIFF
--- a/src/main/java/software/amazon/nio/spi/s3/S3FileSystem.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3FileSystem.java
@@ -58,7 +58,7 @@ public class S3FileSystem extends FileSystem {
         configuration = (config == null) ? new S3NioSpiConfiguration() : config;
         bucketName = configuration.getBucketName();
 
-        logger.debug("creating FileSystem for 's3://{}'", bucketName);
+        logger.debug("creating FileSystem for '{}://{}'", provider.getScheme(), bucketName);
 
         clientProvider = new S3ClientProvider(configuration);
         this.provider = provider;


### PR DESCRIPTION
*Description of changes:*

Since there are two schemes `s3` and `s3x`, it is convenient that the logs reflect the proper scheme.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
