### PR TITLE
rewrite(S3SeekableByteChannel): Use `S3BasicFileAttributes` to get "file"size of path

### DIFF
--- a/src/main/java/software/amazon/nio/spi/s3/S3SeekableByteChannel.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3SeekableByteChannel.java
@@ -8,9 +8,7 @@ package software.amazon.nio.spi.s3;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
-import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import software.amazon.nio.spi.s3.config.S3NioSpiConfiguration;
-import software.amazon.nio.spi.s3.util.TimeOutUtils;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -23,16 +21,13 @@ import java.nio.channels.WritableByteChannel;
 import java.nio.file.OpenOption;
 import java.nio.file.StandardOpenOption;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 class S3SeekableByteChannel implements SeekableByteChannel {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(S3SeekableByteChannel.class);
 
     private long position;
-    private final S3AsyncClient s3Client;
     private final S3Path path;
     private final ReadableByteChannel readDelegate;
     private final S3WritableByteChannel writeDelegate;
@@ -48,7 +43,6 @@ class S3SeekableByteChannel implements SeekableByteChannel {
         position = startAt;
         path = s3Path;
         closed = false;
-        this.s3Client = s3Client;
         s3Path.getFileSystem().registerOpenChannel(this);
 
         if (options.contains(StandardOpenOption.WRITE) && options.contains(StandardOpenOption.READ)) {

--- a/src/main/java/software/amazon/nio/spi/s3/S3SeekableByteChannel.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3SeekableByteChannel.java
@@ -200,28 +200,10 @@ class S3SeekableByteChannel implements SeekableByteChannel {
         return this.size;
     }
 
-    private void fetchSize() throws IOException {
-        long timeOut = TimeOutUtils.TIMEOUT_TIME_LENGTH_1;
-        TimeUnit unit = TimeUnit.MINUTES;
-
-        LOGGER.debug("requesting size of '{}'", path.toUri());
+    private void fetchSize() {
         synchronized (this) {
-            final HeadObjectResponse headObjectResponse;
-            try {
-                headObjectResponse = s3Client.headObject(builder -> builder
-                        .bucket(path.bucketName())
-                        .key(path.getKey())).get(timeOut, unit);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                throw new RuntimeException(e);
-            } catch (ExecutionException e) {
-                throw new IOException(e);
-            } catch (TimeoutException e) {
-                throw TimeOutUtils.logAndGenerateExceptionOnTimeOut(LOGGER, "size", timeOut, unit);
-            }
-
-            LOGGER.debug("size of '{}' is '{}'", path.toUri(), headObjectResponse.contentLength());
-            this.size = headObjectResponse.contentLength();
+            this.size = new S3BasicFileAttributes(path).size();
+            LOGGER.debug("size of '{}' is '{}'", path.toUri(), this.size);
         }
     }
 


### PR DESCRIPTION
*Description of changes:*

The call to get the "file" size in `S3SeekableByteChannel` is replaced with `S3BasicFileAttributes.size()` since it already provides a way to get a "file" size.

_Package Coverage_ (Before / After)
![Screenshot 2023-11-03 095239](https://github.com/awslabs/aws-java-nio-spi-for-s3/assets/283778/a1c24233-d64e-4ef8-84c0-b7d7444c1d15)

_Class Coverage_ (Before / After)
![Screenshot 2023-11-03 095256](https://github.com/awslabs/aws-java-nio-spi-for-s3/assets/283778/e3f131c9-96b9-45ff-b9c1-9392b4222107)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
