### PR TITLE
refactor(S3BasicFileAttributes): Extract and reuse `getObjectMetadata` method

### DIFF
--- a/src/main/java/software/amazon/nio/spi/s3/S3BasicFileAttributes.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3BasicFileAttributes.java
@@ -165,7 +165,7 @@ class S3BasicFileAttributes implements BasicFileAttributes {
      * @throws RuntimeException if the S3Clients {@code RetryConditions} configuration was not able to handle the exception.
      */
     @Override
-    public long size() throws RuntimeException{
+    public long size() {
         if(isDirectory()) return 0;
 
         try {

--- a/src/test/java/software/amazon/nio/spi/s3/S3BasicFileAttributesTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3BasicFileAttributesTest.java
@@ -1,8 +1,6 @@
 package software.amazon.nio.spi.s3;
 
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import software.amazon.nio.spi.s3.config.S3NioSpiConfiguration;
 
 import java.nio.file.attribute.FileTime;
@@ -14,15 +12,16 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @DisplayName("S3BasicFileAttributes")
-class S3BasicFileAttributesTest {
+public class S3BasicFileAttributesTest {
 
     @Nested
     @DisplayName("directory")
     class Directories {
 
-        @Test
-        @DisplayName("lastModifiedTime() should return epoch")
-        void lastModifiedTime() {
+        private S3BasicFileAttributes directoryAttributes;
+
+        @BeforeEach
+        void configureDirectory(){
             S3FileSystem fs = mock();
             FileSystemProvider provider = mock();
             when(fs.provider()).thenReturn(provider);
@@ -30,8 +29,20 @@ class S3BasicFileAttributesTest {
             when(provider.getScheme()).thenReturn("s3");
 
             S3Path directory = S3Path.getPath(fs, "s3://somebucket/somedirectory/");
-            S3BasicFileAttributes s3BasicFileAttributes = new S3BasicFileAttributes(directory);
-            assertThat(s3BasicFileAttributes.lastModifiedTime()).isEqualTo(FileTime.from(Instant.EPOCH));
+            directoryAttributes = new S3BasicFileAttributes(directory);
         }
+
+        @Test
+        @DisplayName("lastModifiedTime() should return epoch")
+        void lastModifiedTime() {
+            assertThat(directoryAttributes.lastModifiedTime()).isEqualTo(FileTime.from(Instant.EPOCH));
+        }
+
+        @Test
+        @DisplayName("lastAccessTime() should return epoch")
+        void lastAccessTime() {
+            assertThat(directoryAttributes.lastAccessTime()).isEqualTo(FileTime.from(Instant.EPOCH));
+        }
+
     }
 }

--- a/src/test/java/software/amazon/nio/spi/s3/S3BasicFileAttributesTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3BasicFileAttributesTest.java
@@ -185,6 +185,12 @@ public class S3BasicFileAttributesTest {
             assertThat(attributes.isSymbolicLink()).isFalse();
         }
 
+        @Test
+        @DisplayName("isOther() should return false")
+        void isOther() {
+            assertThat(attributes.isOther()).isFalse();
+        }
+
         private Stream<Arguments> dateGetters() {
             final Function<S3BasicFileAttributes, FileTime> lastModifiedTimeGetter = S3BasicFileAttributes::lastModifiedTime;
             final Function<S3BasicFileAttributes, FileTime> creationTimeGetter = S3BasicFileAttributes::creationTime;

--- a/src/test/java/software/amazon/nio/spi/s3/S3BasicFileAttributesTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3BasicFileAttributesTest.java
@@ -44,5 +44,11 @@ public class S3BasicFileAttributesTest {
             assertThat(directoryAttributes.lastAccessTime()).isEqualTo(FileTime.from(Instant.EPOCH));
         }
 
+        @Test
+        @DisplayName("creationTime() should return epoch")
+        void creationTime() {
+            assertThat(directoryAttributes.creationTime()).isEqualTo(FileTime.from(Instant.EPOCH));
+        }
+
     }
 }

--- a/src/test/java/software/amazon/nio/spi/s3/S3BasicFileAttributesTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3BasicFileAttributesTest.java
@@ -154,7 +154,19 @@ public class S3BasicFileAttributesTest {
 
             assertThat(attributes.size()).isEqualTo(100L);
         }
-        
+
+        @Test
+        @DisplayName("fileKey() should return the etag from head response")
+        void fileKey() {
+            when(mockClient.headObject(anyConsumer())).thenReturn(
+                    CompletableFuture.supplyAsync(() ->
+                            HeadObjectResponse.builder().eTag("someEtag").build()
+                    )
+            );
+
+            assertThat(attributes.fileKey()).isEqualTo("someEtag");
+        }
+
         private Stream<Arguments> dateGetters() {
             final Function<S3BasicFileAttributes, FileTime> lastModifiedTimeGetter = S3BasicFileAttributes::lastModifiedTime;
             final Function<S3BasicFileAttributes, FileTime> creationTimeGetter = S3BasicFileAttributes::creationTime;

--- a/src/test/java/software/amazon/nio/spi/s3/S3BasicFileAttributesTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3BasicFileAttributesTest.java
@@ -14,6 +14,8 @@ import static org.mockito.Mockito.when;
 @DisplayName("S3BasicFileAttributes")
 public class S3BasicFileAttributesTest {
 
+    private static final FileTime EPOCH_FILE_TIME = FileTime.from(Instant.EPOCH);
+
     @Nested
     @DisplayName("directory")
     class Directories {
@@ -35,19 +37,19 @@ public class S3BasicFileAttributesTest {
         @Test
         @DisplayName("lastModifiedTime() should return epoch")
         void lastModifiedTime() {
-            assertThat(directoryAttributes.lastModifiedTime()).isEqualTo(FileTime.from(Instant.EPOCH));
+            assertThat(directoryAttributes.lastModifiedTime()).isEqualTo(EPOCH_FILE_TIME);
         }
 
         @Test
         @DisplayName("lastAccessTime() should return epoch")
         void lastAccessTime() {
-            assertThat(directoryAttributes.lastAccessTime()).isEqualTo(FileTime.from(Instant.EPOCH));
+            assertThat(directoryAttributes.lastAccessTime()).isEqualTo(EPOCH_FILE_TIME);
         }
 
         @Test
         @DisplayName("creationTime() should return epoch")
         void creationTime() {
-            assertThat(directoryAttributes.creationTime()).isEqualTo(FileTime.from(Instant.EPOCH));
+            assertThat(directoryAttributes.creationTime()).isEqualTo(EPOCH_FILE_TIME);
         }
 
     }

--- a/src/test/java/software/amazon/nio/spi/s3/S3BasicFileAttributesTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3BasicFileAttributesTest.java
@@ -52,5 +52,12 @@ public class S3BasicFileAttributesTest {
             assertThat(directoryAttributes.creationTime()).isEqualTo(EPOCH_FILE_TIME);
         }
 
+        @Test
+        @DisplayName("size() should return 0")
+        void size() {
+            assertThat(directoryAttributes.size()).isZero();
+        }
+
+
     }
 }

--- a/src/test/java/software/amazon/nio/spi/s3/S3BasicFileAttributesTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3BasicFileAttributesTest.java
@@ -1,0 +1,37 @@
+package software.amazon.nio.spi.s3;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import software.amazon.nio.spi.s3.config.S3NioSpiConfiguration;
+
+import java.nio.file.attribute.FileTime;
+import java.nio.file.spi.FileSystemProvider;
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@DisplayName("S3BasicFileAttributes")
+class S3BasicFileAttributesTest {
+
+    @Nested
+    @DisplayName("directory")
+    class Directories {
+
+        @Test
+        @DisplayName("lastModifiedTime() should return epoch")
+        void lastModifiedTime() {
+            S3FileSystem fs = mock();
+            FileSystemProvider provider = mock();
+            when(fs.provider()).thenReturn(provider);
+            when(fs.configuration()).thenReturn(new S3NioSpiConfiguration());
+            when(provider.getScheme()).thenReturn("s3");
+
+            S3Path directory = S3Path.getPath(fs, "s3://somebucket/somedirectory/");
+            S3BasicFileAttributes s3BasicFileAttributes = new S3BasicFileAttributes(directory);
+            assertThat(s3BasicFileAttributes.lastModifiedTime()).isEqualTo(FileTime.from(Instant.EPOCH));
+        }
+    }
+}

--- a/src/test/java/software/amazon/nio/spi/s3/S3BasicFileAttributesTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3BasicFileAttributesTest.java
@@ -167,6 +167,12 @@ public class S3BasicFileAttributesTest {
             assertThat(attributes.fileKey()).isEqualTo("someEtag");
         }
 
+        @Test
+        @DisplayName("isDirectory() should return false")
+        void isDirectory() {
+            assertThat(attributes.isDirectory()).isFalse();
+        }
+
         private Stream<Arguments> dateGetters() {
             final Function<S3BasicFileAttributes, FileTime> lastModifiedTimeGetter = S3BasicFileAttributes::lastModifiedTime;
             final Function<S3BasicFileAttributes, FileTime> creationTimeGetter = S3BasicFileAttributes::creationTime;

--- a/src/test/java/software/amazon/nio/spi/s3/S3BasicFileAttributesTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3BasicFileAttributesTest.java
@@ -1,6 +1,9 @@
 package software.amazon.nio.spi.s3;
 
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import software.amazon.nio.spi.s3.config.S3NioSpiConfiguration;
 
 import java.nio.file.attribute.FileTime;
@@ -64,6 +67,11 @@ public class S3BasicFileAttributesTest {
             assertThat(directoryAttributes.fileKey()).isNull();
         }
 
+        @Test
+        @DisplayName("isDirectory() should return true")
+        void isDirectory() {
+            assertThat(directoryAttributes.isDirectory()).isTrue();
+        }
 
     }
 }

--- a/src/test/java/software/amazon/nio/spi/s3/S3BasicFileAttributesTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3BasicFileAttributesTest.java
@@ -1,5 +1,6 @@
 package software.amazon.nio.spi.s3;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Named;
@@ -33,11 +34,12 @@ public class S3BasicFileAttributesTest {
 
     @Nested
     @DisplayName("directory")
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     class Directories {
 
         private S3BasicFileAttributes directoryAttributes;
 
-        @BeforeEach
+        @BeforeAll
         void configureDirectory(){
             S3FileSystem fs = mock();
             FileSystemProvider provider = mock();
@@ -112,7 +114,7 @@ public class S3BasicFileAttributesTest {
         private S3BasicFileAttributes attributes;
         private final S3AsyncClient mockClient = mock();
 
-        @BeforeEach
+        @BeforeAll
         void configureRegularFile() {
             S3FileSystem fs = mock();
 
@@ -126,6 +128,10 @@ public class S3BasicFileAttributesTest {
 
             S3Path file = S3Path.getPath(fs, "s3://somebucket/somefile");
             attributes = new S3BasicFileAttributes(file);
+        }
+
+        @BeforeEach
+        void resetMockClient() {
             reset(mockClient);
         }
 

--- a/src/test/java/software/amazon/nio/spi/s3/S3BasicFileAttributesTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3BasicFileAttributesTest.java
@@ -73,5 +73,11 @@ public class S3BasicFileAttributesTest {
             assertThat(directoryAttributes.isDirectory()).isTrue();
         }
 
+        @Test
+        @DisplayName("isRegularFile() should return false")
+        void isRegularFile() {
+            assertThat(directoryAttributes.isRegularFile()).isFalse();
+        }
+
     }
 }

--- a/src/test/java/software/amazon/nio/spi/s3/S3BasicFileAttributesTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3BasicFileAttributesTest.java
@@ -58,6 +58,12 @@ public class S3BasicFileAttributesTest {
             assertThat(directoryAttributes.size()).isZero();
         }
 
+        @Test
+        @DisplayName("fileKey() should return null")
+        void fileKey() {
+            assertThat(directoryAttributes.fileKey()).isNull();
+        }
+
 
     }
 }

--- a/src/test/java/software/amazon/nio/spi/s3/S3BasicFileAttributesTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3BasicFileAttributesTest.java
@@ -85,5 +85,11 @@ public class S3BasicFileAttributesTest {
             assertThat(directoryAttributes.isSymbolicLink()).isFalse();
         }
 
+        @Test
+        @DisplayName("isOther() should return false")
+        void isOther() {
+            assertThat(directoryAttributes.isOther()).isFalse();
+        }
+
     }
 }

--- a/src/test/java/software/amazon/nio/spi/s3/S3BasicFileAttributesTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3BasicFileAttributesTest.java
@@ -173,6 +173,12 @@ public class S3BasicFileAttributesTest {
             assertThat(attributes.isDirectory()).isFalse();
         }
 
+        @Test
+        @DisplayName("isRegularFile() should return true")
+        void isRegularFile() {
+            assertThat(attributes.isRegularFile()).isTrue();
+        }
+
         private Stream<Arguments> dateGetters() {
             final Function<S3BasicFileAttributes, FileTime> lastModifiedTimeGetter = S3BasicFileAttributes::lastModifiedTime;
             final Function<S3BasicFileAttributes, FileTime> creationTimeGetter = S3BasicFileAttributes::creationTime;

--- a/src/test/java/software/amazon/nio/spi/s3/S3BasicFileAttributesTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3BasicFileAttributesTest.java
@@ -79,5 +79,11 @@ public class S3BasicFileAttributesTest {
             assertThat(directoryAttributes.isRegularFile()).isFalse();
         }
 
+        @Test
+        @DisplayName("isSymbolicLink() should return false")
+        void isSymbolicLink() {
+            assertThat(directoryAttributes.isSymbolicLink()).isFalse();
+        }
+
     }
 }

--- a/src/test/java/software/amazon/nio/spi/s3/S3BasicFileAttributesTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3BasicFileAttributesTest.java
@@ -179,6 +179,12 @@ public class S3BasicFileAttributesTest {
             assertThat(attributes.isRegularFile()).isTrue();
         }
 
+        @Test
+        @DisplayName("isSymbolicLink() should return false")
+        void isSymbolicLink() {
+            assertThat(attributes.isSymbolicLink()).isFalse();
+        }
+
         private Stream<Arguments> dateGetters() {
             final Function<S3BasicFileAttributes, FileTime> lastModifiedTimeGetter = S3BasicFileAttributes::lastModifiedTime;
             final Function<S3BasicFileAttributes, FileTime> creationTimeGetter = S3BasicFileAttributes::creationTime;

--- a/src/test/java/software/amazon/nio/spi/s3/S3BasicFileAttributesTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3BasicFileAttributesTest.java
@@ -143,6 +143,18 @@ public class S3BasicFileAttributesTest {
             assertThat(dateGetter.apply(attributes)).isEqualTo(expectedFileTime);
         }
 
+        @Test
+        @DisplayName("size() should return the contentLength from head response")
+        void size() {
+            when(mockClient.headObject(anyConsumer())).thenReturn(
+                    CompletableFuture.supplyAsync(() ->
+                            HeadObjectResponse.builder().contentLength(100L).build()
+                    )
+            );
+
+            assertThat(attributes.size()).isEqualTo(100L);
+        }
+        
         private Stream<Arguments> dateGetters() {
             final Function<S3BasicFileAttributes, FileTime> lastModifiedTimeGetter = S3BasicFileAttributes::lastModifiedTime;
             final Function<S3BasicFileAttributes, FileTime> creationTimeGetter = S3BasicFileAttributes::creationTime;
@@ -154,6 +166,5 @@ public class S3BasicFileAttributesTest {
             );
         }
     }
-
 
 }


### PR DESCRIPTION
*Description of changes:*

A new `getObjectMetadata` method has been extracted from `S3BasicFileAttributes` in order to reuse it in `lastModifiedTime()`, `size()`, and `fileKey()`. Unit tests for the class have also been added for the cases when the path is a regular file or a directory.

Previous coverage:
![Screenshot 2023-11-07 110946](https://github.com/awslabs/aws-java-nio-spi-for-s3/assets/283778/530faf84-41c5-4ab6-98df-047feeca57cf)

Current coverage:
![Screenshot 2023-11-07 110053](https://github.com/awslabs/aws-java-nio-spi-for-s3/assets/283778/88bd832c-f6e1-46fa-8780-b0f1b636f62d)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
