### PR TITLE
test(S3BasicFileAttributes): When a timeout happens getting attributes of a regular file, an Exception should be thrown

### DIFF
--- a/src/main/java/software/amazon/nio/spi/s3/S3BasicFileAttributeView.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3BasicFileAttributeView.java
@@ -5,9 +5,12 @@
 
 package software.amazon.nio.spi.s3;
 
+import software.amazon.nio.spi.s3.util.TimeOutUtils;
+
 import java.nio.file.attribute.BasicFileAttributeView;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileTime;
+import java.time.Duration;
 
 class S3BasicFileAttributeView implements BasicFileAttributeView {
 
@@ -35,7 +38,7 @@ class S3BasicFileAttributeView implements BasicFileAttributeView {
      */
     @Override
     public BasicFileAttributes readAttributes() {
-        return new S3BasicFileAttributes(path);
+        return new S3BasicFileAttributes(path, Duration.ofMinutes(TimeOutUtils.TIMEOUT_TIME_LENGTH_1));
     }
 
     /**

--- a/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
@@ -38,6 +38,7 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileAttribute;
 import java.nio.file.attribute.FileAttributeView;
 import java.nio.file.spi.FileSystemProvider;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -645,7 +646,7 @@ public class S3FileSystemProvider extends FileSystemProvider {
 
         if (type.equals(BasicFileAttributes.class)) {
             @SuppressWarnings("unchecked")
-            A a = (A) new S3BasicFileAttributes(s3Path);
+            A a = (A) new S3BasicFileAttributes(s3Path, Duration.ofMinutes(TimeOutUtils.TIMEOUT_TIME_LENGTH_1));
             return a;
         } else {
             throw new UnsupportedOperationException("cannot read attributes of type: " + type);
@@ -680,7 +681,7 @@ public class S3FileSystemProvider extends FileSystemProvider {
             return Collections.emptyMap();
 
         if (attributes.equals("*") || attributes.equals("s3"))
-            return new S3BasicFileAttributes(s3Path).asMap();
+            return new S3BasicFileAttributes(s3Path, Duration.ofMinutes(TimeOutUtils.TIMEOUT_TIME_LENGTH_1)).asMap();
 
         final Set<String> attrSet = Arrays.stream(attributes.split(","))
                 .map(attr -> attr.replaceAll("^s3:", ""))

--- a/src/main/java/software/amazon/nio/spi/s3/S3SeekableByteChannel.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3SeekableByteChannel.java
@@ -9,6 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.nio.spi.s3.config.S3NioSpiConfiguration;
+import software.amazon.nio.spi.s3.util.TimeOutUtils;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -20,6 +21,7 @@ import java.nio.channels.SeekableByteChannel;
 import java.nio.channels.WritableByteChannel;
 import java.nio.file.OpenOption;
 import java.nio.file.StandardOpenOption;
+import java.time.Duration;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
@@ -197,7 +199,7 @@ class S3SeekableByteChannel implements SeekableByteChannel {
 
     private void fetchSize() {
         synchronized (this) {
-            this.size = new S3BasicFileAttributes(path).size();
+            this.size = new S3BasicFileAttributes(path, Duration.ofMinutes(TimeOutUtils.TIMEOUT_TIME_LENGTH_1)).size();
             LOGGER.debug("size of '{}' is '{}'", path.toUri(), this.size);
         }
     }

--- a/src/test/java/software/amazon/nio/spi/s3/S3BasicFileAttributesTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3BasicFileAttributesTest.java
@@ -47,7 +47,7 @@ public class S3BasicFileAttributesTest {
             when(fs.configuration()).thenReturn(new S3NioSpiConfiguration());
             when(provider.getScheme()).thenReturn("s3");
 
-            S3Path directory = S3Path.getPath(fs, "s3://somebucket/somedirectory/");
+            S3Path directory = S3Path.getPath(fs, "/somedirectory/");
             directoryAttributes = new S3BasicFileAttributes(directory);
         }
 
@@ -126,7 +126,7 @@ public class S3BasicFileAttributesTest {
 
             when(fs.client()).thenReturn(mockClient);
 
-            S3Path file = S3Path.getPath(fs, "s3://somebucket/somefile");
+            S3Path file = S3Path.getPath(fs, "somefile");
             attributes = new S3BasicFileAttributes(file);
         }
 

--- a/src/test/java/software/amazon/nio/spi/s3/S3BasicFileAttributesTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3BasicFileAttributesTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import software.amazon.nio.spi.s3.config.S3NioSpiConfiguration;
+import software.amazon.nio.spi.s3.util.TimeOutUtils;
 
 import java.nio.file.attribute.FileTime;
 import java.nio.file.spi.FileSystemProvider;
@@ -50,7 +51,7 @@ public class S3BasicFileAttributesTest {
             when(provider.getScheme()).thenReturn("s3");
 
             S3Path directory = S3Path.getPath(fs, "/somedirectory/");
-            directoryAttributes = new S3BasicFileAttributes(directory);
+            directoryAttributes = new S3BasicFileAttributes(directory, Duration.ofMinutes(TimeOutUtils.TIMEOUT_TIME_LENGTH_1));
         }
 
         @Test
@@ -129,7 +130,7 @@ public class S3BasicFileAttributesTest {
             when(fs.client()).thenReturn(mockClient);
 
             S3Path file = S3Path.getPath(fs, "somefile");
-            attributes = new S3BasicFileAttributes(file);
+            attributes = new S3BasicFileAttributes(file, Duration.ofMinutes(TimeOutUtils.TIMEOUT_TIME_LENGTH_1));
         }
 
         @BeforeEach
@@ -224,12 +225,12 @@ public class S3BasicFileAttributesTest {
         S3AsyncClient mockClient = mock();
         when(fs.client()).thenReturn(mockClient);
 
-        var attributes = new S3BasicFileAttributes(S3Path.getPath(fs, "somefile"));
+        var attributes = new S3BasicFileAttributes(S3Path.getPath(fs, "somefile"), Duration.ofMillis(1));
 
         when(mockClient.headObject(anyConsumer())).thenReturn(
             CompletableFuture.supplyAsync(() -> {
                 try {
-                    Thread.sleep(Duration.ofMillis(100).toMillis());
+                    Thread.sleep(Duration.ofMinutes(1).toMillis());
                 } catch (InterruptedException e) {
                     throw new RuntimeException(e);
                 }


### PR DESCRIPTION
*Description of changes:*

The PR introduces a test for `S3BasicFileAttributes`, _when a timeout happens getting attributes of a regular file, an Exception should be thrown_. In order to achieve this, and avoid having to wait 1 minute( the _current_ default ) for the test to fail, the timeout is now configurable.

Coverage:
![Screenshot 2023-11-08 130844](https://github.com/awslabs/aws-java-nio-spi-for-s3/assets/283778/f3c4c92a-ecf2-4ec6-839d-40c7b1f53cab)

By the way, isn't 1 minute to high for a timeout? I imagine a user waiting up to 1 minute to get the size of a file would be too much and a bad user experience. I was thinking maybe 10 seconds would be a more sensible default. What are your thoughts @markjschreiber ?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
