### PR TITLE
rewrite(S3FileSystemProvider): instantiate S3FileAttributes once

### DIFF
--- a/src/main/java/software/amazon/nio/spi/s3/S3BasicFileAttributes.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3BasicFileAttributes.java
@@ -192,14 +192,6 @@ class S3BasicFileAttributes implements BasicFileAttributes {
     }
 
     /**
-     * Construct a <code>Map</code> representation of this object
-     * @return a map
-     */
-    protected Map<String, Object> asMap(){
-        return asMap(x -> true);
-    }
-
-    /**
      * Construct a <code>Map</code> representation of this object with properties filtered
      * @param attributeFilter a filter to include properties in the resulting Map
      * @return a map filtered to only contain keys that pass the attributeFilter


### PR DESCRIPTION
*Description of changes:*

The rewrite unifies the `return`s from `readAttributes` taking advantage of the filter option. As a consequence, `asMap()` method from `S3BasicFileAttributes` is not used anymore, so it has been cleaned up.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
