### PR TITLE
chore(S3BasicFileAttributes): Do IO in methods that throw `IOException`

### DIFF
--- a/src/main/java/software/amazon/nio/spi/s3/S3BasicFileAttributeView.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3BasicFileAttributeView.java
@@ -5,6 +5,7 @@
 
 package software.amazon.nio.spi.s3;
 
+import java.io.IOException;
 import java.nio.file.attribute.BasicFileAttributeView;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileTime;
@@ -37,8 +38,8 @@ class S3BasicFileAttributeView implements BasicFileAttributeView {
      * @return the file attributes
      */
     @Override
-    public BasicFileAttributes readAttributes() {
-        return new S3BasicFileAttributes(path, Duration.ofMinutes(TimeOutUtils.TIMEOUT_TIME_LENGTH_1));
+    public BasicFileAttributes readAttributes() throws IOException {
+        return S3BasicFileAttributes.get(path, Duration.ofMinutes(TimeOutUtils.TIMEOUT_TIME_LENGTH_1));
     }
 
     /**

--- a/src/main/java/software/amazon/nio/spi/s3/S3BasicFileAttributes.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3BasicFileAttributes.java
@@ -80,7 +80,6 @@ class S3BasicFileAttributes implements BasicFileAttributes {
      *
      * @return a {@code FileTime} representing the time the file was last
      * modified.
-     * @throws RuntimeException if the S3Clients {@code RetryConditions} configuration was not able to handle the exception.
      */
     @Override
     public FileTime lastModifiedTime() {
@@ -162,7 +161,6 @@ class S3BasicFileAttributes implements BasicFileAttributes {
      * therefore unspecified.
      *
      * @return the file size, in bytes
-     * @throws RuntimeException if the S3Clients {@code RetryConditions} configuration was not able to handle the exception.
      */
     @Override
     public long size() {
@@ -173,7 +171,6 @@ class S3BasicFileAttributes implements BasicFileAttributes {
      * Returns the S3 etag for the object
      *
      * @return the etag for an object, or {@code null} for a "directory"
-     * @throws RuntimeException if the S3Clients {@code RetryConditions} configuration was not able to handle the exception.
      * @see Files#walkFileTree
      */
     @Override
@@ -211,8 +208,8 @@ class S3BasicFileAttributes implements BasicFileAttributes {
     /**
      * @param path        the path to represent the attributes of
      * @param readTimeout timeout for requests to get attributes
-     * @return
-     * @throws IOException
+     * @return path BasicFileAttributes
+     * @throws IOException Errors getting the metadata of the object represented by the path are wrapped in IOException
      */
     static S3BasicFileAttributes get(S3Path path, Duration readTimeout) throws IOException {
         if (path.isDirectory()) {

--- a/src/main/java/software/amazon/nio/spi/s3/S3BasicFileAttributes.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3BasicFileAttributes.java
@@ -7,7 +7,9 @@ package software.amazon.nio.spi.s3;
 
 import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static software.amazon.nio.spi.s3.util.TimeOutUtils.createAndLogTimeOutMessage;
 
+import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.file.Files;
@@ -24,36 +26,49 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
-import software.amazon.nio.spi.s3.util.TimeOutUtils;
 
 /**
  * Representation of {@link BasicFileAttributes} for an S3 object
  */
 class S3BasicFileAttributes implements BasicFileAttributes {
 
+    private static final FileTime EPOCH_FILE_TIME = FileTime.from(Instant.EPOCH);
+
+    private static final S3BasicFileAttributes DIRECTORY_ATTRIBUTES = new S3BasicFileAttributes(
+        EPOCH_FILE_TIME,
+        0L,
+        null,
+        true,
+        false
+    );
+
     private static final Set<String> METHOD_NAMES_TO_FILTER_OUT =
         Set.of("wait", "toString", "hashCode", "getClass", "notify", "notifyAll");
 
     private static final Logger logger = LoggerFactory.getLogger(S3BasicFileAttributes.class.getName());
 
-    private final S3Path path;
-    private final S3AsyncClient client;
-    private final String bucketName;
-    private final Duration timeout;
+
+    private final FileTime lastModifiedTime;
+    private final Long size;
+    private final Object eTag;
+    private final boolean isDirectory;
+    private final boolean isRegularFile;
 
     /**
      * Constructor for the attributes of a path
-     *
-     * @param path    the path to represent the attributes of
-     * @param timeout timeout for requests to get attributes
      */
-    S3BasicFileAttributes(S3Path path, Duration timeout) {
-        this.path = path;
-        this.client = path.getFileSystem().client();
-        this.bucketName = path.bucketName();
-        this.timeout = timeout;
+    private S3BasicFileAttributes(FileTime lastModifiedTime,
+                                 Long size,
+                                 Object eTag,
+                                 boolean isDirectory,
+                                 boolean isRegularFile
+    ) {
+        this.lastModifiedTime = lastModifiedTime;
+        this.size = size;
+        this.eTag = eTag;
+        this.isDirectory = isDirectory;
+        this.isRegularFile = isRegularFile;
     }
 
     /**
@@ -69,11 +84,7 @@ class S3BasicFileAttributes implements BasicFileAttributes {
      */
     @Override
     public FileTime lastModifiedTime() {
-        if (path.isDirectory()) {
-            return FileTime.from(Instant.EPOCH);
-        }
-
-        return FileTime.from(getObjectMetadata("lastModifiedTime()").lastModified());
+        return lastModifiedTime;
     }
 
     /**
@@ -109,7 +120,7 @@ class S3BasicFileAttributes implements BasicFileAttributes {
      */
     @Override
     public boolean isRegularFile() {
-        return !path.isDirectory();
+        return isRegularFile;
     }
 
     /**
@@ -119,7 +130,7 @@ class S3BasicFileAttributes implements BasicFileAttributes {
      */
     @Override
     public boolean isDirectory() {
-        return path.isDirectory();
+        return isDirectory;
     }
 
     /**
@@ -155,10 +166,7 @@ class S3BasicFileAttributes implements BasicFileAttributes {
      */
     @Override
     public long size() {
-        if (isDirectory()) {
-            return 0;
-        }
-        return getObjectMetadata("size()").contentLength();
+        return size;
     }
 
     /**
@@ -170,31 +178,7 @@ class S3BasicFileAttributes implements BasicFileAttributes {
      */
     @Override
     public Object fileKey() {
-        if (path.isDirectory()) {
-            return null;
-        }
-        return getObjectMetadata("fileKey()").eTag();
-    }
-
-    private HeadObjectResponse getObjectMetadata(String forOperation) {
-        try {
-            return client.headObject(req -> req
-                .bucket(bucketName)
-                .key(path.getKey())
-            ).get(timeout.toMillis(), MILLISECONDS);
-        } catch (ExecutionException e) {
-            var errMsg = format(
-                "an '%s' error occurred while obtaining the metadata (for operation %s) of '%s'" +
-                    "that was not handled successfully by the S3Client's configured RetryConditions",
-                e.getCause().toString(), forOperation, path.toUri());
-            logger.error(errMsg);
-            throw new RuntimeException(errMsg, e);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new RuntimeException(e);
-        } catch (TimeoutException e) {
-            throw TimeOutUtils.logAndGenerateExceptionOnTimeOut(logger, forOperation, timeout.toMillis(), MILLISECONDS);
-        }
+        return eTag;
     }
 
     /**
@@ -214,13 +198,62 @@ class S3BasicFileAttributes implements BasicFileAttributes {
                     return method.invoke(this);
                 } catch (IllegalAccessException | InvocationTargetException e) {
                     // should not ever happen as these are all public no arg methods
-                    var errorMsg = format(
-                        "an exception has occurred during a reflection operation on the methods of the file attributes" +
-                            "of '%s', check if your Java SecurityManager is configured to allow reflection.",
-                        path.toUri());
+                    var errorMsg =
+                        "an exception has occurred during a reflection operation on the methods of file attributes," +
+                            "check if your Java SecurityManager is configured to allow reflection."
+                        ;
                     logger.error("{}, caused by {}", errorMsg, e.getCause().getMessage());
                     throw new RuntimeException(errorMsg, e);
                 }
             })));
     }
+
+    /**
+     * @param path        the path to represent the attributes of
+     * @param readTimeout timeout for requests to get attributes
+     * @return
+     * @throws IOException
+     */
+    static S3BasicFileAttributes get(S3Path path, Duration readTimeout) throws IOException {
+        if (path.isDirectory()) {
+            return DIRECTORY_ATTRIBUTES;
+        }
+
+        var headResponse = getObjectMetadata(path, readTimeout);
+        return new S3BasicFileAttributes(
+            FileTime.from(headResponse.lastModified()),
+            headResponse.contentLength(),
+            headResponse.eTag(),
+            false,
+            true
+        );
+    }
+
+    private static HeadObjectResponse getObjectMetadata(
+        S3Path path,
+        Duration timeout
+    ) throws IOException {
+        var client = path.getFileSystem().client();
+        var bucketName = path.bucketName();
+        try {
+            return client.headObject(req -> req
+                .bucket(bucketName)
+                .key(path.getKey())
+            ).get(timeout.toMillis(), MILLISECONDS);
+        } catch (ExecutionException e) {
+            var errMsg = format(
+                "an '%s' error occurred while obtaining the metadata (for operation getFileAttributes) of '%s'" +
+                    "that was not handled successfully by the S3Client's configured RetryConditions",
+                e.getCause().toString(), path.toUri());
+            logger.error(errMsg);
+            throw new IOException(errMsg, e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException(e);
+        } catch (TimeoutException e) {
+            var msg = createAndLogTimeOutMessage(logger, "getFileAttributes", timeout.toMillis(), MILLISECONDS);
+            throw new IOException(msg, e);
+        }
+    }
+
 }

--- a/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
@@ -626,13 +626,13 @@ public class S3FileSystemProvider extends FileSystemProvider {
      * @return the file attributes or {@code null} if {@code path} is inferred to be a directory.
      */
     @Override
-    public <A extends BasicFileAttributes> A readAttributes(Path path, Class<A> type, LinkOption... options) {
+    public <A extends BasicFileAttributes> A readAttributes(Path path, Class<A> type, LinkOption... options) throws IOException {
         Objects.requireNonNull(type);
         var s3Path = checkPath(path);
 
         if (type.equals(BasicFileAttributes.class)) {
             @SuppressWarnings("unchecked")
-            var a = (A) new S3BasicFileAttributes(s3Path, Duration.ofMinutes(TimeOutUtils.TIMEOUT_TIME_LENGTH_1));
+            var a = (A) S3BasicFileAttributes.get(s3Path, Duration.ofMinutes(TimeOutUtils.TIMEOUT_TIME_LENGTH_1));
             return a;
         } else {
             throw new UnsupportedOperationException("cannot read attributes of type: " + type);
@@ -660,7 +660,7 @@ public class S3FileSystemProvider extends FileSystemProvider {
      *                                       may be invoked to check for additional permissions.
      */
     @Override
-    public Map<String, Object> readAttributes(Path path, String attributes, LinkOption... options) {
+    public Map<String, Object> readAttributes(Path path, String attributes, LinkOption... options) throws IOException {
         Objects.requireNonNull(attributes);
         var s3Path = checkPath(path);
 
@@ -669,7 +669,7 @@ public class S3FileSystemProvider extends FileSystemProvider {
         }
 
         var attributesFilter = attributesFilterFor(attributes);
-        return new S3BasicFileAttributes(s3Path, Duration.ofMinutes(TimeOutUtils.TIMEOUT_TIME_LENGTH_1)).asMap(attributesFilter);
+        return S3BasicFileAttributes.get(s3Path, Duration.ofMinutes(TimeOutUtils.TIMEOUT_TIME_LENGTH_1)).asMap(attributesFilter);
     }
 
     /**

--- a/src/main/java/software/amazon/nio/spi/s3/S3SeekableByteChannel.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3SeekableByteChannel.java
@@ -201,9 +201,9 @@ class S3SeekableByteChannel implements SeekableByteChannel {
         return this.size;
     }
 
-    private void fetchSize() {
+    private void fetchSize() throws IOException {
         synchronized (this) {
-            this.size = new S3BasicFileAttributes(path, Duration.ofMinutes(TimeOutUtils.TIMEOUT_TIME_LENGTH_1)).size();
+            this.size = S3BasicFileAttributes.get(path, Duration.ofMinutes(TimeOutUtils.TIMEOUT_TIME_LENGTH_1)).size();
             LOGGER.debug("size of '{}' is '{}'", path.toUri(), this.size);
         }
     }

--- a/src/test/java/software/amazon/nio/spi/s3/S3FileSystemProviderTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3FileSystemProviderTest.java
@@ -162,6 +162,11 @@ public class S3FileSystemProviderTest {
 
     @Test
     public void newByteChannel() throws Exception {
+        when(mockClient.headObject(anyConsumer())).thenReturn(
+            CompletableFuture.completedFuture(
+                HeadObjectResponse.builder().lastModified(Instant.now()).contentLength(1L).build()
+            )
+        );
         final var channel = provider.newByteChannel(Paths.get(URI.create(pathUri)), Collections.singleton(StandardOpenOption.READ));
         assertNotNull(channel);
         assertThat(channel).isInstanceOf(S3SeekableByteChannel.class);
@@ -428,15 +433,21 @@ public class S3FileSystemProviderTest {
     }
 
     @Test
-    public void readAttributes() {
+    public void readAttributes() throws IOException {
         var foo = fs.getPath("/foo");
+        when(mockClient.headObject(anyConsumer())).thenReturn(completedFuture(
+            HeadObjectResponse.builder()
+                .lastModified(Instant.EPOCH)
+                .contentLength(100L)
+                .eTag("abcdef")
+                .build()));
         final var basicFileAttributes = provider.readAttributes(foo, BasicFileAttributes.class);
         assertNotNull(basicFileAttributes);
         assertThat(basicFileAttributes).isInstanceOf(S3BasicFileAttributes.class);
     }
 
     @Test
-    public void testReadAttributes() {
+    public void testReadAttributes() throws IOException {
         var foo = fs.getPath("/foo");
         var fooDir = fs.getPath("/foo/");
 

--- a/src/test/java/software/amazon/nio/spi/s3/S3SeekableByteChannelTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3SeekableByteChannelTest.java
@@ -5,6 +5,7 @@
 
 package software.amazon.nio.spi.s3;
 
+import java.time.Instant;
 import org.mockito.Mock;
 import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
@@ -53,7 +54,10 @@ public class S3SeekableByteChannelTest {
         // forward to the method that uses the HeadObjectRequest parameter
         lenient().when(mockClient.headObject(anyConsumer())).thenCallRealMethod();
         lenient().when(mockClient.headObject(any(HeadObjectRequest.class))).thenReturn(
-                CompletableFuture.supplyAsync(() -> HeadObjectResponse.builder().contentLength(100L).build()));
+                CompletableFuture.completedFuture(
+                    HeadObjectResponse.builder().contentLength(100L).lastModified(Instant.now()).build()
+                )
+        );
         lenient().when(mockClient.getObject(anyConsumer(), any(AsyncResponseTransformer.class))).thenCallRealMethod();
         lenient().when(mockClient.getObject(any(GetObjectRequest.class), any(AsyncResponseTransformer.class))).thenReturn(
                 CompletableFuture.supplyAsync(() -> ResponseBytes.fromByteArray(


### PR DESCRIPTION
*Description of changes:*

The implementation of S3BasicFileAttributes does IO whenever `size()`, `lastModified()` or `fileKey()` are invoked. When there are network problems, `RuntimeException`s are thrown, since the `BasicFileAttributes` *nio* interface does not declare any expected exceptions to be thrown when calling these methods.

In order to conform better with the contract specified by the *nio* interfaces, the IO done in `size()`, `lastModified()` and `fileKey()` methods is now done before constructing the attributes: when `readAttributes` from the *provider* or the *attributeview* is called. `readAttributes` in those interfaces specify that it can throw `IOException` and therefore seems a better place where to do the IO to get the object metadata.

As a side effect, requests to S3 are **reduced** whenever a user of a library needs **more than 1 attribute** of a file; for example `size` and `lastModified`.

## References:
* [BasicFileAttributes javadoc](https://docs.oracle.com/javase/8/docs/api/java/nio/file/attribute/BasicFileAttributes.html)
* [BasicFileAttributeView.readAttributes javadoc](https://docs.oracle.com/javase/8/docs/api/java/nio/file/attribute/BasicFileAttributeView.html#readAttributes--)
* [FileSystemProvider.readAttributes javadoc](https://docs.oracle.com/javase/8/docs/api/java/nio/file/spi/FileSystemProvider.html#readAttributes-java.nio.file.Path-java.lang.Class-java.nio.file.LinkOption...-)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
