### PR TITLE
[#353] leave region empty if none is provided

### DIFF
--- a/src/main/java/software/amazon/nio/spi/s3/S3ClientProvider.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3ClientProvider.java
@@ -253,11 +253,14 @@ public class S3ClientProvider {
         S3AsyncClientBuilder builder
     ) {
         var region = getRegionFromRegionName(regionName);
-        logger.debug("bucket region is: '{}'", region.id());
+        // no region provided => leave it to the provider chain to figure it out (e.g. env var AWS_REGION)
+        if (region != null) {
+            logger.debug("bucket region is: '{}'", region.id());
+            asyncClientBuilder.region(region);
+        }
 
         builder
             .forcePathStyle(configuration.getForcePathStyle())
-            .region(region)
             .overrideConfiguration(
                 conf -> conf.retryPolicy(
                     configBuilder -> configBuilder.retryCondition(retryCondition).backoffStrategy(backoffStrategy)
@@ -279,7 +282,11 @@ public class S3ClientProvider {
 
     private S3AsyncClient configureCrtClientForRegion(String regionName) {
         var region = getRegionFromRegionName(regionName);
-        logger.debug("bucket region is: '{}'", region.id());
+        // no region provided => leave it to the provider chain to figure it out (e.g. env var AWS_REGION)
+        if (region != null) {
+            logger.debug("bucket region is: '{}'", region.id());
+            asyncClientBuilder.region(region);
+        }
 
         var endpointUri = configuration.endpointUri();
         if (endpointUri != null) {
@@ -292,12 +299,11 @@ public class S3ClientProvider {
         }
 
         return asyncClientBuilder.forcePathStyle(configuration.getForcePathStyle())
-                .region(region)
                 .build();
     }
 
     private static Region getRegionFromRegionName(String regionName) {
-        return (regionName == null || regionName.isBlank()) ? Region.US_EAST_1 : Region.of(regionName);
+        return (regionName == null || regionName.isBlank()) ? null : Region.of(regionName);
     }
 
 }

--- a/src/test/java/software/amazon/nio/spi/s3/S3ClientProviderTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3ClientProviderTest.java
@@ -156,11 +156,11 @@ public class S3ClientProviderTest {
         provider.configuration.withEndpoint("endpoint1:1010");
         provider.generateClient("bucket1", true);
         then(BUILDER.endpointOverride.toString()).isEqualTo("https://endpoint1:1010");
-        then(BUILDER.region).isEqualTo(Region.US_EAST_1);  // just a default in the case not provide
+        then(BUILDER.region).isNull();  // no default => leave it to the provider chain
 
         provider.configuration.withEndpoint("endpoint2:2020");
         provider.generateClient("bucket2", true);
         then(BUILDER.endpointOverride.toString()).isEqualTo("https://endpoint2:2020");
-        then(BUILDER.region).isEqualTo(Region.US_EAST_1);  // just a default in the case not provide
+        then(BUILDER.region).isNull();  // no default => leave it to the provider chain
     }
 }


### PR DESCRIPTION
...and as such leave the decision to the provider chain (e.g. env var AWS_REGION)

*Issue #, if available:*

cannot change region in any way

*Description of changes:*

if no region is provided then the decision will be made by the provider chain


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
