### PR TITLE
no longer throw exception on set times

### DIFF
--- a/src/examples/java/software/amazon/nio/spi/examples/MoveObject.java
+++ b/src/examples/java/software/amazon/nio/spi/examples/MoveObject.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.nio.spi.examples;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Demonstrates a move operation using the `Files` class
+ */
+public class MoveObject {
+
+    private static final Logger logger = LoggerFactory.getLogger(MoveObject.class.getName());
+
+    public static void main(String[] args) throws IOException {
+
+        if (args.length != 2) {
+            logger.error("Usage: java MoveObject <source> <destination>");
+            System.exit(1);
+        }
+
+        logger.info("Moving {} to {}", args[0], args[1]);
+
+        URI source = URI.create(args[0]);
+        URI destination = URI.create(args[1]);
+        Files.move(Path.of(source), Path.of(destination));
+    }
+}

--- a/src/main/java/software/amazon/nio/spi/s3/S3BasicFileAttributeView.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3BasicFileAttributeView.java
@@ -10,9 +10,13 @@ import java.nio.file.attribute.BasicFileAttributeView;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileTime;
 import java.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import software.amazon.nio.spi.s3.util.TimeOutUtils;
 
 class S3BasicFileAttributeView implements BasicFileAttributeView {
+
+    private final Logger logger = LoggerFactory.getLogger("S3BasicFileAttributeView");
 
     private final S3Path path;
 
@@ -22,7 +26,7 @@ class S3BasicFileAttributeView implements BasicFileAttributeView {
 
     /**
      * Returns the name of the attribute view. Attribute views of this type
-     * have the name {@code "basic"}.
+     * have the name {@code "s3"}.
      */
     @Override
     public String name() {
@@ -43,12 +47,15 @@ class S3BasicFileAttributeView implements BasicFileAttributeView {
     }
 
     /**
-     * Unsupported operation, write operations are not supported.
+     * S3 doesn't support setting of file times other than by writing the file. Therefore, this operation does
+     * nothing (no-op). To support {@code Files.copy()} and {@code Files.move()} operations which call this method,
+     * we don't throw an exception. The time set during those operations will be determined by S3.
      */
     @Override
     public void setTimes(FileTime lastModifiedTime, FileTime lastAccessTime, FileTime createTime) {
-        throw new UnsupportedOperationException(
-            "write operations are not supported, please submitted a feature request explaining your use case");
+        // intentional no-op. S3 doesn't support setting of file times other than by writing the file.
+        logger.warn("S3 doesn't support setting of file times other than by writing the file. " +
+                "The time set during those operations will be determined by S3. This method call will be ignored");
     }
 
 }

--- a/src/test/java/software/amazon/nio/spi/s3/S3BasicFileAttributeViewTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3BasicFileAttributeViewTest.java
@@ -1,0 +1,4 @@
+import static org.junit.jupiter.api.Assertions.*;
+class S3BasicFileAttributeViewTest {
+  
+}

--- a/src/test/java/software/amazon/nio/spi/s3/S3BasicFileAttributeViewTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3BasicFileAttributeViewTest.java
@@ -1,4 +1,30 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.nio.spi.s3;
+
 import static org.junit.jupiter.api.Assertions.*;
+
+import java.net.URI;
+import org.junit.jupiter.api.Test;
+
 class S3BasicFileAttributeViewTest {
-  
+    final String uriString = "s3://mybucket";
+    final S3FileSystemProvider provider = new S3FileSystemProvider();
+
+    S3FileSystem fileSystem = provider.getFileSystem(URI.create(uriString), true);
+    S3Path path = S3Path.getPath(fileSystem, uriString);
+    S3BasicFileAttributeView view = new S3BasicFileAttributeView(path);
+
+    @Test
+    void setTimes() {
+        assertDoesNotThrow(() -> view.setTimes(null, null, null));
+    }
+
+    @Test
+    void name() {
+        assertEquals("s3", view.name());
+    }
 }


### PR DESCRIPTION
*Issue #, if available:*
#339 

*Description of changes:*
Remove exception when attempting to set times. Times are not modified because this isn't supported on S3.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
