### PR TITLE
fix for #293

### DIFF
--- a/src/main/java/software/amazon/nio/spi/s3/S3Path.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3Path.java
@@ -257,10 +257,6 @@ class S3Path implements Path {
         }
 
         var path = String.join(PATH_SEPARATOR, pathRepresentation.elements().subList(beginIndex, endIndex));
-        if (this.isAbsolute() && beginIndex == 0) {
-            path = PATH_SEPARATOR + path;
-        }
-
         if (endIndex == size && !pathRepresentation.hasTrailingSeparator()) {
             return from(path);
         } else {

--- a/src/test/java/software/amazon/nio/spi/s3/S3PathTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3PathTest.java
@@ -336,6 +336,8 @@ public class S3PathTest {
         var bcd = fileSystem.getPath("b/c/d/");
         var bcdObject = fileSystem.getPath("b/c/d/object");
 
+        assertFalse(root.relativize(ab).isAbsolute());
+
         assertEquals(fileSystem.getPath(""), absoluteObject.relativize(absoluteObject));
         assertEquals(fileSystem.getPath("../.."), abcd.relativize(ab));
         assertEquals(fileSystem.getPath("e/"), abcd.relativize(abcde));


### PR DESCRIPTION
*Issue #, if available:*
#293 

*Description of changes:*
The current implementation violates the intended behaviour or relativize when relativizing a path to the root. The correct behaviour should be like:

```
Path root = FileSystems.getDefault().getRootDirectories().iterator().next();
Path path = FileSystems.getDefault().getPath("/a/b");
Path relative = root.relativize(path); // -> a/b, isAbsolute() == false

```

Side note: the use of var is particularly disappointing in `S3Path` where it should be clear if an object is a `Path` or a `S3Path`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
