### PR TITLE
fix: normalize keeps absolute paths absolute

### DIFF
--- a/src/main/java/software/amazon/nio/spi/s3/S3Path.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3Path.java
@@ -387,6 +387,10 @@ class S3Path implements Path {
         final var elements = pathRepresentation.elements();
         final var realElements = new LinkedList<String>();
 
+        if (this.isAbsolute()) {
+            realElements.add(PATH_SEPARATOR);
+        }
+
         for (var element : elements) {
             if (element.equals(".")) {
                 continue;

--- a/src/test/java/software/amazon/nio/spi/s3/S3PathTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3PathTest.java
@@ -279,6 +279,18 @@ public class S3PathTest {
     }
 
     @Test
+    public void normalizeAndIsAbsolute() {
+        final S3Path pathRelative = S3Path.getPath(fileSystem, "foo/./baa/");
+        final S3Path pathAbsolute = S3Path.getPath(fileSystem, "/foo/./baa/");
+
+        assertFalse(pathRelative.isAbsolute());
+        assertTrue(pathAbsolute.isAbsolute());
+
+        assertFalse(pathRelative.normalize().isAbsolute());
+        assertTrue(pathAbsolute.normalize().isAbsolute());
+    }
+
+    @Test
     public void resolve() {
         assertEquals(absoluteObject, root.resolve(absoluteObject));
         assertEquals(absoluteDirectory, root.resolve(absoluteDirectory));


### PR DESCRIPTION
*Issue #, if available:*
#292 
*Description of changes:*
keeps absolute paths absolute following normalization

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
