### PR TITLE
fix: use environment configuration when creating a byte channel

### DIFF
--- a/src/main/java/software/amazon/nio/spi/s3/S3ReadAheadByteChannel.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3ReadAheadByteChannel.java
@@ -239,4 +239,12 @@ class S3ReadAheadByteChannel implements ReadableByteChannel {
     Integer fragmentIndexForByteNumber(long byteNumber) {
         return Math.toIntExact(Math.floorDiv(byteNumber, (long) maxFragmentSize));
     }
+
+    public int getMaxFragmentSize() {
+        return maxFragmentSize;
+    }
+
+    public int getMaxNumberFragments() {
+        return maxNumberFragments;
+    }
 }

--- a/src/main/java/software/amazon/nio/spi/s3/S3SeekableByteChannel.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3SeekableByteChannel.java
@@ -21,7 +21,6 @@ import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
-import software.amazon.nio.spi.s3.config.S3NioSpiConfiguration;
 import software.amazon.nio.spi.s3.util.TimeOutUtils;
 
 class S3SeekableByteChannel implements SeekableByteChannel {
@@ -54,9 +53,7 @@ class S3SeekableByteChannel implements SeekableByteChannel {
             throw new IOException("The SYNC/DSYNC options is not supported");
         }
 
-        // later we will add a constructor that allows providing delegates for composition
-
-        var config = new S3NioSpiConfiguration();
+        var config = s3Path.getFileSystem().configuration();
         if (options.contains(StandardOpenOption.WRITE)) {
             LOGGER.debug("using S3WritableByteChannel as write delegate for path '{}'", s3Path.toUri());
             readDelegate = null;


### PR DESCRIPTION
*Issue #, if available:*
#191 
*Description of changes:*
Fixes #191 

Feeds configuration through to the creation of the `S3ByteChannel` and the read ahead delegate. Adds test to demonstrate configuration is used.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
