### PR TITLE
feature: adds experimental support for creating a bucket.

### DIFF
--- a/src/examples/java/software/amazon/nio/spi/examples/CreateBucket.java
+++ b/src/examples/java/software/amazon/nio/spi/examples/CreateBucket.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.nio.spi.examples;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.FileSystems;
+import java.util.Map;
+
+public class CreateBucket {
+    public static void main(String[] args) throws IOException {
+        try (var fs = FileSystems.newFileSystem(URI.create(args[0]),
+                Map.of("locationConstraint", "us-east-1"))) {
+            System.out.println(fs.toString());
+        }
+    }
+}


### PR DESCRIPTION
adds experimental support for creating a bucket via the `FileSystems.newFileSystem(URI, Map)` method.

*Issue #, if available:*
#243

*Description of changes:*
Implements `public FileSystem newFileSystem(URI uri, Map<String, ?> env)`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
