### PR TITLE
chore: Remove unused apache client dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,8 +56,12 @@ dependencies {
 
     implementation platform('software.amazon.awssdk:bom:2.25.6')
 
-    implementation 'software.amazon.awssdk:s3'
-    implementation 'software.amazon.awssdk:s3-transfer-manager'
+    implementation('software.amazon.awssdk:s3') {
+        exclude group: 'software.amazon.awssdk', module: 'apache-client'
+    }
+    implementation('software.amazon.awssdk:s3-transfer-manager') {
+        exclude group: 'software.amazon.awssdk', module: 'apache-client'
+    }
     implementation 'software.amazon.awssdk.crt:aws-crt:0.29.11'
     implementation 'org.slf4j:slf4j-api:2.0.12'
     implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'


### PR DESCRIPTION
*Issue #109 

*Description of changes:*
`s3` and `s3-transfer-manager` depend on `apache-client` dependency. Given that there is no use of a synchronous s3 client currently in the project, this dependency is not necessary at the moment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
