### PR TITLE
docs(README): Add "how to" reduce library dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,24 @@ For example:
 </dependency>
 ```
 
-`build.gradle`
+`build.gradle(.kts)`
 ```groovy
     implementation("software.amazon.nio.s3:aws-java-nio-spi-for-s3:2.0.0-dev")
 ```
+
+The library heavily relies on the `crt` client from aws. It uses the [`uber`
+version](https://github.com/awslabs/aws-crt-java?tab=readme-ov-file#platform-specific-jars) for simplicity
+and wide range of supported platforms. 
+
+> [!TIP]
+> If **size** is an **issue**, you can **exclude** the `crt` dependency from the library and import the [specific `crt` library](https://github.com/awslabs/aws-crt-java?tab=readme-ov-file#platform-specific-jars)
+> for your platform. For example:
+> ```
+> implementation("software.amazon.nio.s3:aws-java-nio-spi-for-s3:2.0.0-dev") {
+>	exclude group: 'software.amazon.awssdk.crt', module: 'aws-crt'
+> }
+> implementation 'software.amazon.awssdk.crt:aws-crt:0.29.11:linux-x86_64'
+> ```
 
 ### Java compatibility
 | Library version | Java   |


### PR DESCRIPTION
Issue #109 

*Description of changes:*

Add note on README to document how to avoid importing uber jar for `crt` client and importing only a platform-specific jar.

| Content of uber jar | Content of platform-specific jar |
|--------|--------|
| ![Screenshot 2024-03-18 204137](https://github.com/awslabs/aws-java-nio-spi-for-s3/assets/283778/74d24352-63d2-4af6-b9d1-8cb6df4250f5) | ![Screenshot 2024-03-18 204527](https://github.com/awslabs/aws-java-nio-spi-for-s3/assets/283778/6bb3f326-a124-4191-b821-ebe8da44c3f0) |

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
