### PR TITLE
build(ci): Remove `revapiAcceptAllBreaks` on revapi

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -33,10 +33,6 @@ jobs:
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v3
 
-    # Temporary until release of v2
-    - name: Accept breaking changes
-      run: ./gradlew :revapiAcceptAllBreaks --justification 'Changes for v2'
-
     - name: Execute Gradle build
       run: ./gradlew build
     

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,3 @@ target
 
 # MacOS
 .DS_Store
-
-# Palantir Revapi
-.palantir


### PR DESCRIPTION
*Description of changes:*
Now that all breaking changes for v2 are done, there is no need to continue accepting breaking changes in API/ABI.

Reference for [RevApi](https://revapi.org/revapi-java/0.28.1/index.html)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
