### PR TITLE
fix: close() call on already closed S3WritableByteChannel (awslabs#453)

### DIFF
--- a/src/main/java/software/amazon/nio/spi/s3/S3WritableByteChannel.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3WritableByteChannel.java
@@ -87,6 +87,10 @@ class S3WritableByteChannel implements WritableByteChannel {
     @Override
     public void close() throws IOException {
         channel.close();
+        if (!open) {
+            // channel has already been closed -> close() should have no effect
+            return;
+        }
 
         s3TransferUtil.uploadLocalFile(path, tempFile);
         Files.deleteIfExists(tempFile);


### PR DESCRIPTION
*Issue #, if available:* #453

*Description of changes:*
Added a check in the `S3WritableByteChannel#close` method to prevent another upload attempt.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
