### PR TITLE
chore: ignores directory used to check for breaking API changes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ target
 
 # MacOS
 .DS_Store
+
+# directory used for API break checks
+/.palantir/


### PR DESCRIPTION
*Description of changes:*
Adds `.palantir` directory to gitignore

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
