### PR TITLE
fix: resolves issues when copying or moving objects via`Files` class

### DIFF
--- a/src/examples/java/software/amazon/nio/spi/examples/MoveDirectory.java
+++ b/src/examples/java/software/amazon/nio/spi/examples/MoveDirectory.java
@@ -14,43 +14,36 @@ import java.nio.file.Path;
  * Demonstrates a move operation using the `Files` class
  */
 @SuppressWarnings("CheckStyle")
-public class MoveObject {
+public class MoveDirectory {
 
 
     public static void main(String[] args) throws IOException {
 
         if (args.length != 2) {
-            System.err.println("Usage: java MoveObject <source> <destination>");
+            System.err.println("Usage: java MoveObject <sourceDir> <destinationDir>");
             System.exit(1);
         }
-
-        System.err.printf("Moving %s to %s%n", args[0], args[1]);
 
         final URI source = URI.create(args[0]);
         final URI destination = URI.create(args[1]);
 
         final Path destinationPath = Path.of(destination);
         final Path sourcePath = Path.of(source);
+
+        assert Files.isDirectory(sourcePath);
+        assert Files.isDirectory(destinationPath);
+
         System.err.println("Source path: " + sourcePath);
         System.err.println("Destination path: " + destinationPath);
 
+        System.err.printf("Moving %s to %s%n", args[0], args[1]);
 
-        final long sizeOfSource = Files.size(sourcePath);
         Path movedTo = Files.move(sourcePath, destinationPath);
-        if (Files.isDirectory(movedTo)) {
-            movedTo = movedTo.resolve(sourcePath.getFileName());
-        }
 
         System.err.printf("Moved %s to %s%n", sourcePath, movedTo);
-        final long sizeOfDestination = Files.size(movedTo);
-
-        assert Files.exists(movedTo);
-        assert sizeOfSource == sizeOfDestination;
 
         // move it back
         Files.move(movedTo, sourcePath);
         System.err.printf("Moved %s back to %s%n", movedTo, sourcePath);
-        assert Files.exists(sourcePath);
-        assert sizeOfSource == Files.size(sourcePath);
     }
 }

--- a/src/test/java/software/amazon/nio/spi/s3/S3FileSystemProviderTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3FileSystemProviderTest.java
@@ -338,8 +338,8 @@ public class S3FileSystemProviderTest {
         when(mockClient.copyObject(any(CopyObjectRequest.class))).thenReturn(CompletableFuture.supplyAsync(() ->
                 CopyObjectResponse.builder().build()));
 
-        var dir1 = fs.getPath("/dir1");
-        var dir2 = fs.getPath("/dir2");
+        var dir1 = fs.getPath("/dir1/");
+        var dir2 = fs.getPath("/dir2/");
         assertThrows(FileAlreadyExistsException.class, () -> provider.copy(dir1, dir2));
         provider.copy(dir1, dir2, StandardCopyOption.REPLACE_EXISTING);
 
@@ -370,8 +370,8 @@ public class S3FileSystemProviderTest {
         when(mockClient.deleteObjects(any(DeleteObjectsRequest.class))).thenReturn(CompletableFuture.supplyAsync(() ->
                 DeleteObjectsResponse.builder().build()));
 
-        var dir1 = fs.getPath("/dir1");
-        var dir2 = fs.getPath("/dir2");
+        var dir1 = fs.getPath("/dir1/");
+        var dir2 = fs.getPath("/dir2/");
         assertThrows(FileAlreadyExistsException.class, () -> provider.move(dir1, dir2));
         provider.move(dir1, dir2, StandardCopyOption.REPLACE_EXISTING);
 


### PR DESCRIPTION
*Issue #, if available:*
#430 

*Description of changes:*
Fixes #430 by ensuring that all code considers `/foo/bar/` to be a directory and `/foo/baa` to be an object (file) in accordance with the behavior of S3.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
