### PR TITLE
fix: rethrows `BucketAlreadyExists` and `BucketAlreadyOwned` 

### DIFF
--- a/src/examples/java/software/amazon/nio/spi/examples/CreateBucket.java
+++ b/src/examples/java/software/amazon/nio/spi/examples/CreateBucket.java
@@ -7,14 +7,27 @@ package software.amazon.nio.spi.examples;
 
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.FileSystemAlreadyExistsException;
 import java.nio.file.FileSystems;
 import java.util.Map;
 
 public class CreateBucket {
     public static void main(String[] args) throws IOException {
+
+        if (args.length != 1) {
+            throw new IllegalArgumentException("Usage: CreateBucket <bucket-uri>");
+        }
+
+        if (!args[0].startsWith("s3://")) {
+            throw new IllegalArgumentException("Bucket URI must start with s3://");
+        }
+
+        System.out.println("Creating bucket " + args[0]);
         try (var fs = FileSystems.newFileSystem(URI.create(args[0]),
-                Map.of("locationConstraint", "us-east-1"))) {
+                Map.of("locationConstraint", "us-west-2"))) {
             System.out.println(fs.toString());
+        } catch (FileSystemAlreadyExistsException e) {
+            System.err.printf("Bucket already exists: %s\n", e.getMessage());
         }
     }
 }


### PR DESCRIPTION
exceptions as `FileSystemAlreadyExists` exception

*Issue #, if available:*
#461
*Description of changes:*
Fixes #461 by rethrowing `BucketAlreadyExistsException` and `BucketAlreadyOwnedException` as `FileSystemAlreadyExists` exception.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
