### PR TITLE
fix: adds causal exception

### DIFF
--- a/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
@@ -186,7 +186,8 @@ public class S3FileSystemProvider extends FileSystemProvider {
         } catch (ExecutionException e) {
             if (e.getCause() instanceof BucketAlreadyOwnedByYouException ||
                     e.getCause() instanceof BucketAlreadyExistsException) {
-                throw new FileSystemAlreadyExistsException(e.getCause().getMessage());
+                throw (FileSystemAlreadyExistsException) new FileSystemAlreadyExistsException(e.getCause().getMessage())
+                        .initCause(e.getCause());
             } else {
                 throw new IOException(e.getMessage(), e.getCause());
             }


### PR DESCRIPTION
*Issue #, if available:*
461
*Description of changes:*
Improves previous fix by adding the causal exception so that users can better distinguish between bucket exists and already owned by the user vs. bucket already exists (owned by someone else).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
