### PR TITLE
fix: Let getFileAttributeView() return null for unsupported view class.

### DIFF
--- a/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
@@ -715,7 +715,8 @@ public class S3FileSystemProvider extends FileSystemProvider {
             @SuppressWarnings("unchecked") final var v = (V) new S3BasicFileAttributeView(s3Path);
             return v;
         } else {
-            throw new IllegalArgumentException("type must be BasicFileAttributeView.class");
+            // if the type is not supported, return null, to be compliant with the method contract
+            return null;
         }
     }
 

--- a/src/test/java/software/amazon/nio/spi/s3/S3FileSystemProviderTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3FileSystemProviderTest.java
@@ -466,9 +466,10 @@ public class S3FileSystemProviderTest {
     }
 
     @Test
-    public void getFileAttributeViewIllegalArg() {
+    public void getFileAttributeViewUnsupportedView() {
         var foo = fs.getPath("/foo");
-        assertThrows(IllegalArgumentException.class, () -> provider.getFileAttributeView(foo, FileAttributeView.class));
+        final var unsupportedView = provider.getFileAttributeView(foo, FileAttributeView.class);
+        assertNull(unsupportedView);
     }
 
     @Test


### PR DESCRIPTION
*Issue #, if available:*
No issue created this time. If needed, I can create one later.

*Description of changes:*
Observed when trying to use JDK's `Files.move()` method. This method uses the `java.nio.file.CopyMoveHelper#copyToForeignTarget` method. The implementation tries to get the `PosixFileAttributeView` (in line 109). This fails for the S3 implementation with an `UnsupportedOperationException`, which is not caught by JDK's code, resulting in the move operation to fail.

Having read the method description, I'm of the opinion that the method should return `null` in case of an unsupported view type. This would at least be compliant with the method comment in the `copyToForeignTarget` method (line 108):

> // retrieve source posix view, null if unsupported

I've adapted the test accordingly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
