### PR TITLE
fix: fixes refreshing expired credentials by preventing DefaultCredentialsProvider from being autoclosed

### DIFF
--- a/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
@@ -384,8 +384,8 @@ public class S3FileSystemProvider extends FileSystemProvider {
         var timeOut = TIMEOUT_TIME_LENGTH_1;
         final var unit = MINUTES;
 
-        try (S3AsyncClient client = s3Directory.getFileSystem().client()) {
-            client.putObject(
+        try {
+            s3Directory.getFileSystem().client().putObject(
                 PutObjectRequest.builder()
                     .bucket(s3Directory.bucketName())
                     .key(directoryKey)


### PR DESCRIPTION
Fixes #494

Pulls the client instantiation out of the `try-with-resource` block to stop it being closed and therefore not usable when refreshing expired credentials.