### PR TITLE
Correctly handle copy and delete operations on single objects

### DIFF
--- a/src/test/java/software/amazon/nio/spi/s3/S3FileSystemProviderTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3FileSystemProviderTest.java
@@ -306,7 +306,7 @@ public class S3FileSystemProviderTest {
         when(mockClient.deleteObjects(any(DeleteObjectsRequest.class))).thenReturn(CompletableFuture.supplyAsync(() ->
                 DeleteObjectsResponse.builder().build()));
 
-        provider.delete(fs.getPath("/dir"));
+        provider.delete(fs.getPath("/dir/"));
 
         var argumentCaptor = ArgumentCaptor.forClass(DeleteObjectsRequest.class);
         verify(mockClient, times(1)).deleteObjects(argumentCaptor.capture());


### PR DESCRIPTION
Fixes #497

The copy and delete code was currently treating `/foo/` and `/foo` as a directory, which in the S3 context is incorrect (as perfectly summed up [here](https://github.com/awslabs/aws-java-nio-spi-for-s3/blob/01542979007859a51adfcc0aef9338e8a4fa4ade/src/main/java/software/amazon/nio/spi/s3/PosixLikePathRepresentation.java#L146)). If the given path is not a directory, it should not be listing objects from S3 and returning all those that match the prefix. Rather, it should just be performing the copy/delete operation on that given object. This change adds a check for whether the given source is a directory and acts accordingly.