### PR TITLE
fix: deprecated the configuration field and setter

### DIFF
--- a/src/main/java/software/amazon/nio/spi/s3/S3FileSystem.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3FileSystem.java
@@ -67,7 +67,16 @@ public class S3FileSystem extends FileSystem {
         configuration = (config == null) ? new S3NioSpiConfiguration() : config;
         bucketName = configuration.getBucketName();
 
+        // This is quite questionable and may be removed in future versions:
         provider.setConfiguration(config);
+        // The configuration field in {@code S3FileSystemProvider} is used for certain tasks
+        // that are implemented there.
+        // But those tasks are in service of {@code S3FileSystem} instances.
+        // So if there are multiple ones with different configurations, the provider will use
+        // the one that has been set by the last created filesystem, overriding potentially
+        // different values in older {@code S3FileSystem} instances.
+        //
+        // See https://github.com/awslabs/aws-java-nio-spi-for-s3/issues/597
 
         logger.debug("creating FileSystem for '{}://{}'", provider.getScheme(), bucketName);
 

--- a/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
@@ -98,6 +98,15 @@ public class S3FileSystemProvider extends FileSystemProvider {
     static final String SCHEME = "s3";
     private static final Map<String, S3FileSystem> FS_CACHE = new ConcurrentHashMap<>();
 
+    /**
+     * This variable holds the configuration for the S3 NIO Service Provider Interface (SPI).
+     * It is used to manage and handle the configuration details required for interaction
+     * with S3 NIO services.
+     *
+     * @deprecated This variable is deprecated and may be removed in future versions.
+     *             Consider using updated configuration mechanisms if available.
+     */
+    @Deprecated
     protected S3NioSpiConfiguration configuration = new S3NioSpiConfiguration();
 
     private final Logger logger = LoggerFactory.getLogger(this.getClass().getName());
@@ -802,10 +811,14 @@ public class S3FileSystemProvider extends FileSystemProvider {
     }
 
     /**
-     * Set custom configuration. This configuration is referred to for API timeouts
+     * Set custom configuration. This configuration is referred to for API timeouts.
      *
      * @param configuration    The new configuration containing the timeout info
+     *
+     * @deprecated This method is deprecated and may be removed in future versions.
+     *
      */
+    @Deprecated
     public void setConfiguration(S3NioSpiConfiguration configuration) {
         this.configuration = configuration;
     }


### PR DESCRIPTION
This is an intermediate 'fix' for issue #597 until API breaking changes are possible.