### PR TITLE
fix: made S3FileSystemProvider#newFileSystem better match its documentation

### DIFF
--- a/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3FileSystemProvider.java
@@ -165,7 +165,7 @@ public class S3FileSystemProvider extends FileSystemProvider {
         }
 
         @SuppressWarnings("unchecked")
-        var envMap = (Map<String, Object>) env;
+        var envMap = (env != null) ? (Map<String, Object>) env : Collections.<String, Object>emptyMap();
 
         var info = fileSystemInfo(uri);
         var config = new S3NioSpiConfiguration().withEndpoint(info.endpoint()).withBucketName(info.bucket());

--- a/src/test/java/software/amazon/nio/spi/s3/S3FileSystemProviderTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3FileSystemProviderTest.java
@@ -113,6 +113,20 @@ public class S3FileSystemProviderTest {
     }
 
     @Test
+    public void newFileSystemUri() {
+        final var uri = URI.create(pathUri);
+        final var env = Collections.<String, Object>emptyMap();
+
+        assertThatThrownBy(
+                () -> provider.newFileSystem(uri, null)
+        ).isInstanceOf(IOException.class);
+
+        assertThatThrownBy(
+                () -> provider.newFileSystem(uri, env)
+        ).isInstanceOf(IOException.class);
+    }
+
+    @Test
     public void getFileSystem() {
         assertThatCode(() -> provider.getFileSystem(null))
                 .as("missing argument check!")

--- a/src/test/java/software/amazon/nio/spi/s3/S3FileSystemProviderTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3FileSystemProviderTest.java
@@ -117,13 +117,11 @@ public class S3FileSystemProviderTest {
         final var uri = URI.create(pathUri);
         final var env = Collections.<String, Object>emptyMap();
 
-        assertThatThrownBy(
-                () -> provider.newFileSystem(uri, null)
-        ).isInstanceOf(IOException.class);
+        assertThatCode(() -> provider.newFileSystem(uri, null))
+                .doesNotThrowAnyExceptionExcept(IOException.class);
 
-        assertThatThrownBy(
-                () -> provider.newFileSystem(uri, env)
-        ).isInstanceOf(IOException.class);
+        assertThatCode(() -> provider.newFileSystem(uri, env))
+                .doesNotThrowAnyExceptionExcept(IOException.class);
     }
 
     @Test


### PR DESCRIPTION
The documentation states "May be null or empty." but that was clearly not the case.

Added a test for the fix which expects call to not fail with anything but an `IOException`.
