### PR TITLE
Update JUnit Jupiter to 5.11.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -137,7 +137,7 @@ testing {
             }
         }
         withType(JvmTestSuite).configureEach {
-            useJUnitJupiter('5.10.0')
+            useJUnitJupiter('5.11.4')
             targets {
                 all {
                     testTask.configure {
@@ -150,7 +150,7 @@ testing {
                 implementation 'org.mockito:mockito-core:5.16.0'
                 implementation 'org.mockito:mockito-junit-jupiter:5.16.0'
                 implementation 'com.github.stefanbirkner:system-lambda:1.2.1'
-                implementation 'ch.qos.logback:logback-classic:1.5.17'
+                runtimeOnly 'ch.qos.logback:logback-classic:1.5.17'
             }
         }
     }


### PR DESCRIPTION
To match the JUnit Jupiter version used by `mockito-junit-jupiter` we should set the JUnit Jupiter of this project to `5.11.4`. Additionally, the logging implementation `logback-classic` is set to `runtimeOnly` scope (for tests), because no one should use the code directly while writing tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
