### PR TITLE
Transport system properties to S3 NIO configuration

### DIFF
--- a/src/main/java/software/amazon/nio/spi/s3/config/S3NioSpiConfiguration.java
+++ b/src/main/java/software/amazon/nio/spi/s3/config/S3NioSpiConfiguration.java
@@ -110,7 +110,18 @@ public class S3NioSpiConfiguration extends HashMap<String, Object> {
      * Create a new, empty configuration
      */
     public S3NioSpiConfiguration() {
-        this(new HashMap<>());
+        this(systemProperties());
+    }
+
+    private static Map<String, ?> systemProperties() {
+        var map = new HashMap<String, Object>();
+        var properties = System.getProperties();
+        for (var name : properties.stringPropertyNames()) {
+            if (name.startsWith("aws.") || name.startsWith("s3.")) {
+                map.put(name, properties.getProperty(name));
+            }
+        }
+        return map;
     }
 
     /**


### PR DESCRIPTION
According to documentation the endpoint protocol can be configured via system properties, which is not working at the moment. This change makes this possible.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
