### PR TITLE
Avoid unnecessary head-object request

### DIFF
--- a/src/main/java/software/amazon/nio/spi/s3/S3WritableByteChannel.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3WritableByteChannel.java
@@ -18,10 +18,12 @@ import java.nio.file.StandardOpenOption;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 
 class S3WritableByteChannel implements SeekableByteChannel {
     private final S3Path path;
@@ -44,18 +46,31 @@ class S3WritableByteChannel implements SeekableByteChannel {
 
         try {
             var fileSystemProvider = (S3FileSystemProvider) path.getFileSystem().provider();
-            var exists = fileSystemProvider.exists(client, path);
 
-            if (exists && options.contains(StandardOpenOption.CREATE_NEW)) {
+            if (options.contains(StandardOpenOption.CREATE_NEW) && fileSystemProvider.exists(client, path)) {
                 throw new FileAlreadyExistsException("File at path:" + path + " already exists");
-            }
-            if (!exists && !options.contains(StandardOpenOption.CREATE_NEW) && !options.contains(StandardOpenOption.CREATE)) {
-                throw new NoSuchFileException("File at path:" + path + " does not exist yet");
             }
 
             tempFile = Files.createTempFile("aws-s3-nio-", ".tmp");
-            if (exists) {
-                s3TransferUtil.downloadToLocalFile(path, tempFile);
+            // this complicated download handling is the result of
+            // avoiding an existence check with a head-object request
+            if (!options.contains(StandardOpenOption.CREATE_NEW)) {
+                try {
+                    s3TransferUtil.downloadToLocalFile(path, tempFile);
+                } catch (CompletionException e) {
+                    var cause = e.getCause();
+                    if (!(cause instanceof S3Exception)) {
+                        throw e;
+                    }
+                    var s3e = (S3Exception) cause;
+                    if (s3e.statusCode() != 404) {
+                        throw e;
+                    }
+                    if (!options.contains(StandardOpenOption.CREATE)) {
+                        throw new NoSuchFileException("File at path " + path + " does not exist yet");
+                    }
+                    // gracefully handle the file creation
+                }
             }
 
             channel = Files.newByteChannel(this.tempFile, removeCreateNew(options));

--- a/src/test/java/software/amazon/nio/spi/s3/S3SeekableByteChannelTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3SeekableByteChannelTest.java
@@ -42,9 +42,9 @@ import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
-import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings("unchecked")
@@ -102,7 +102,8 @@ public class S3SeekableByteChannelTest {
 
     @Test
     public void write() throws IOException {
-        when(mockClient.headObject(any(HeadObjectRequest.class))).thenThrow(NoSuchKeyException.class);
+        var exception = S3Exception.builder().statusCode(404).build();
+        when(mockClient.getObject(any(GetObjectRequest.class), any(AsyncResponseTransformer.class))).thenThrow(exception);
         when(mockClient.putObject(any(PutObjectRequest.class), any(AsyncRequestBody.class))).thenReturn(CompletableFuture.supplyAsync(() ->
                 PutObjectResponse.builder().build()));
         try(var channel = new S3SeekableByteChannel(path, mockClient, Set.<OpenOption>of(CREATE, WRITE), DisabledFileIntegrityCheck.INSTANCE)){


### PR DESCRIPTION
We want to avoid an additional head-request to S3 when we know the file exists. This reduces the latency and cost when opening a `SeekableByteChannel` or `FileChannel` with the open option `WRITE`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.