### PR TITLE
Use a temporary directory per file system and preserve the directory structure locally

### DIFF
--- a/src/main/java/software/amazon/nio/spi/s3/S3WritableByteChannel.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3WritableByteChannel.java
@@ -51,7 +51,7 @@ class S3WritableByteChannel implements SeekableByteChannel {
                 throw new FileAlreadyExistsException("File at path:" + path + " already exists");
             }
 
-            tempFile = Files.createTempFile("aws-s3-nio-", ".tmp");
+            tempFile = path.getFileSystem().createTempFile(path);
             // this complicated download handling is the result of
             // avoiding an existence check with a head-object request
             if (!options.contains(StandardOpenOption.CREATE_NEW)) {


### PR DESCRIPTION
To be able to better understand which file I'm messing around with while debugging locally, I find it really helpful when the directory structure is preserved as it exists on S3. Therefore, I suggest to have a temporary directory per `S3FileSystem` instance and locally cached S3 files are mirrored there with their key in correspondence to the bucket location.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
