### PR TITLE
Provide S3 specific `OpenOption` to add a HTTP `Range` header

### DIFF
--- a/src/main/java/software/amazon/nio/spi/s3/S3OpenOption.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3OpenOption.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.nio.spi.s3;
+
+import java.nio.file.OpenOption;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+
+/**
+ * Represents an S3 client specific {@link OpenOption} that enables the customization of the underlying
+ * {@link GetObjectRequest}.
+ */
+public interface S3OpenOption extends OpenOption {
+
+    static S3OpenOption range(int end) {
+        return new S3RangeHeader(0, end);
+    }
+
+    static S3OpenOption range(int start, int end) {
+        return new S3RangeHeader(start, end);
+    }
+
+    /**
+     * Adapts the given {@link GetObjectRequest.Builder}.
+     *
+     * @param getObjectRequest
+     *            get object request
+     */
+    void apply(GetObjectRequest.Builder getObjectRequest);
+}

--- a/src/main/java/software/amazon/nio/spi/s3/S3RangeHeader.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3RangeHeader.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.nio.spi.s3;
+
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+
+/**
+ * Sets a HTTP <code>Range</code> header for a {@link GetObjectRequest}.
+ */
+class S3RangeHeader implements S3OpenOption {
+    private final String range;
+
+    S3RangeHeader(int start, int end) {
+        if (start < 0) {
+            throw new IllegalArgumentException("start must be nonnegative");
+        }
+        if (end < 0) {
+            throw new IllegalArgumentException("end must be nonnegative");
+        }
+        range = "bytes=" + start + "-" + end;
+    }
+
+    @Override
+    public void apply(GetObjectRequest.Builder builder) {
+        builder.range(range);
+    }
+}


### PR DESCRIPTION
I want to partially get an S3 object when opening a `SeekableByteChannel` or `FileChannel`. When a HTTP `Range` header is specified the HEAD object request is omitted.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
