### PR TITLE
Improve exception handling on download/upload

### DIFF
--- a/src/main/java/software/amazon/nio/spi/s3/S3TransferUtil.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3TransferUtil.java
@@ -7,18 +7,24 @@ package software.amazon.nio.spi.s3;
 
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.OpenOption;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Set;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.stream.Stream;
 import software.amazon.awssdk.core.FileTransformerConfiguration;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
-import software.amazon.awssdk.transfer.s3.S3TransferManager;
-import software.amazon.awssdk.transfer.s3.model.UploadFileRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 
 final class S3TransferUtil {
     private final S3ObjectIntegrityCheck integrityCheck;
@@ -33,39 +39,59 @@ final class S3TransferUtil {
         this.integrityCheck = integrityCheck;
     }
 
-    void downloadToLocalFile(S3Path path, Path destination, S3OpenOption... options)
-            throws InterruptedException, ExecutionException, TimeoutException {
-        var getObjectRequest = GetObjectRequest.builder()
-            .bucket(path.bucketName())
-            .key(path.getKey());
-        for (var option : options) {
-            option.apply(getObjectRequest);
-        }
-        var transformerConfig = FileTransformerConfiguration.defaultCreateOrReplaceExisting();
-        var responseTransformer = AsyncResponseTransformer.<GetObjectResponse>toFile(destination, transformerConfig);
-        var downloadCompletableFuture = client.getObject(getObjectRequest.build(), responseTransformer)
-            .toCompletableFuture();
+    void downloadToLocalFile(S3Path path, Path destination, Set<? extends OpenOption> options) throws IOException {
+        var s3OpenOptions = options.stream()
+            .flatMap(o -> o instanceof S3OpenOption
+                ? Stream.of((S3OpenOption) o)
+                : Stream.empty())
+            .toArray(S3OpenOption[]::new);
+        try {
+            var getObjectRequest = GetObjectRequest.builder()
+                .bucket(path.bucketName())
+                .key(path.getKey());
+            for (var option : s3OpenOptions) {
+                option.apply(getObjectRequest);
+            }
+            var transformerConfig = FileTransformerConfiguration.defaultCreateOrReplaceExisting();
+            var responseTransformer = AsyncResponseTransformer.<GetObjectResponse>toFile(destination, transformerConfig);
+            var downloadCompletableFuture = client.getObject(getObjectRequest.build(), responseTransformer);
 
-        if (timeout != null && timeUnit != null) {
-            downloadCompletableFuture.get(timeout, timeUnit);
-        } else {
-            downloadCompletableFuture.join();
+            if (timeout != null && timeUnit != null) {
+                downloadCompletableFuture.get(timeout, timeUnit);
+            } else {
+                downloadCompletableFuture.join();
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Could not read from path: " + path, e);
+        } catch (TimeoutException | ExecutionException e) {
+            throw new IOException("Could not read from path: " + path, e);
+        } catch (CompletionException e) {
+            // This complicated download handling is the result of omitting an existence check
+            // with a head object request, instead we look for a 404 status code if available.
+            var cause = e.getCause();
+            if (!(cause instanceof S3Exception)) {
+                throw new IOException("Could not read from path: " + path, e);
+            }
+            var s3e = (S3Exception) cause;
+            if (s3e.statusCode() != 404) {
+                throw new IOException("Could not read from path: " + path, e);
+            }
+            if (!options.contains(StandardOpenOption.CREATE)) {
+                throw new NoSuchFileException(path.toString());
+            }
+            // gracefully handle the file creation
         }
     }
 
     void uploadLocalFile(S3Path path, Path localFile) throws IOException {
-        try (var s3TransferManager = S3TransferManager.builder().s3Client(client).build()) {
+        try {
             var putObjectRequest = PutObjectRequest.builder()
                 .bucket(path.bucketName())
                 .key(path.getKey())
                 .contentType(Files.probeContentType(localFile));
             integrityCheck.addChecksumToRequest(localFile, putObjectRequest);
-            var uploadCompletableFuture = s3TransferManager.uploadFile(
-                UploadFileRequest.builder()
-                    .putObjectRequest(putObjectRequest.build())
-                    .source(localFile)
-                    .build()
-            ).completionFuture();
+            var uploadCompletableFuture = client.putObject(putObjectRequest.build(), AsyncRequestBody.fromFile(localFile));
 
             if (timeout != null && timeUnit != null) {
                 uploadCompletableFuture.get(timeout, timeUnit);
@@ -74,9 +100,11 @@ final class S3TransferUtil {
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new IOException("Could not write to path:" + path, e);
+            throw new IOException("Could not write to path: " + path, e);
         } catch (TimeoutException | ExecutionException e) {
-            throw new IOException("Could not write to path:" + path, e);
+            throw new IOException("Could not write to path: " + path, e);
+        } catch (CompletionException e) {
+            throw new IOException("Could not write to path: " + path, e);
         }
     }
 }

--- a/src/main/java/software/amazon/nio/spi/s3/S3WritableByteChannel.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3WritableByteChannel.java
@@ -11,20 +11,15 @@ import java.nio.channels.ClosedChannelException;
 import java.nio.channels.SeekableByteChannel;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
-import java.nio.file.NoSuchFileException;
 import java.nio.file.OpenOption;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.CompletionException;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
-import software.amazon.awssdk.services.s3.model.S3Exception;
 
 class S3WritableByteChannel implements SeekableByteChannel {
     private final S3Path path;
@@ -54,44 +49,17 @@ class S3WritableByteChannel implements SeekableByteChannel {
 
             tempFile = path.getFileSystem().createTempFile(path);
             if (!options.contains(StandardOpenOption.CREATE_NEW)) {
-                downloadToLocalFile(path, s3TransferUtil, options);
+                s3TransferUtil.downloadToLocalFile(path, tempFile, options);
             }
 
             channel = Files.newByteChannel(this.tempFile, removeCreateNew(options));
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new IOException("Could not open the path:" + path, e);
-        } catch (TimeoutException | ExecutionException e) {
+        } catch (TimeoutException e) {
             throw new IOException("Could not open the path:" + path, e);
         }
         this.open = true;
-    }
-
-    private void downloadToLocalFile(S3Path path, S3TransferUtil s3TransferUtil, Set<? extends OpenOption> options)
-            throws InterruptedException, ExecutionException, TimeoutException, NoSuchFileException {
-        // this complicated download handling is the result of
-        // avoiding an existence check with a head-object request
-        try {
-            var s3OpenOptions = options.stream()
-                .flatMap(o -> o instanceof S3OpenOption
-                    ? Stream.of((S3OpenOption) o)
-                    : Stream.empty())
-                .toArray(S3OpenOption[]::new);
-            s3TransferUtil.downloadToLocalFile(path, tempFile, s3OpenOptions);
-        } catch (CompletionException e) {
-            var cause = e.getCause();
-            if (!(cause instanceof S3Exception)) {
-                throw e;
-            }
-            var s3e = (S3Exception) cause;
-            if (s3e.statusCode() != 404) {
-                throw e;
-            }
-            if (!options.contains(StandardOpenOption.CREATE)) {
-                throw new NoSuchFileException("File at path " + path + " does not exist yet");
-            }
-            // gracefully handle the file creation
-        }
     }
 
     private @NonNull Set<? extends OpenOption> removeCreateNew(Set<? extends OpenOption> options) {

--- a/src/test/java/software/amazon/nio/spi/s3/S3TransferUtilTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3TransferUtilTest.java
@@ -5,6 +5,7 @@
 
 package software.amazon.nio.spi.s3;
 
+import static java.nio.file.StandardOpenOption.*;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -16,8 +17,10 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.nio.file.Files;
-import java.time.Duration;
+import java.nio.file.NoSuchFileException;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.junit.jupiter.api.DisplayName;
@@ -29,17 +32,48 @@ import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 
 @DisplayName("S3TransferUtil")
 @SuppressWarnings("unchecked")
 class S3TransferUtilTest {
 
     @Test
-    @DisplayName("download should succeed")
-    void downloadFileCompletesSuccessfully() throws IOException {
-        S3Path file = mock();
-        when(file.bucketName()).thenReturn("a");
-        when(file.getKey()).thenReturn("a");
+    @DisplayName("download should succeed (with open options)")
+    void downloadFileCompletesSuccessfully_withOpenOption() throws IOException {
+        var file = mock(S3Path.class);
+
+        var client = mock(S3AsyncClient.class);
+        var responseFuture = completedFuture(GetObjectResponse.builder().build());
+        when(client.getObject(any(GetObjectRequest.class), any(AsyncResponseTransformer.class))).thenReturn(responseFuture);
+
+        var util = new S3TransferUtil(client, null, null, DisabledFileIntegrityCheck.INSTANCE);
+        var tmpFile = Files.createTempFile(null, null);
+        var option1 = mock(S3OpenOption.class);
+        var option2 = mock(S3OpenOption.class);
+        assertThatCode(() -> util.downloadToLocalFile(file, tmpFile, Set.of(option1, option2))).doesNotThrowAnyException();
+        verify(option1, times(1)).apply(any(GetObjectRequest.Builder.class));
+        verify(option2, times(1)).apply(any(GetObjectRequest.Builder.class));
+    }
+
+    @Test
+    @DisplayName("download should succeed (without timeout)")
+    void downloadFileCompletesSuccessfully_withoutTimeout() throws IOException {
+        var file = mock(S3Path.class);
+
+        var client = mock(S3AsyncClient.class);
+        var responseFuture = completedFuture(GetObjectResponse.builder().build());
+        when(client.getObject(any(GetObjectRequest.class), any(AsyncResponseTransformer.class))).thenReturn(responseFuture);
+
+        var util = new S3TransferUtil(client, null, null, DisabledFileIntegrityCheck.INSTANCE);
+        var tmpFile = Files.createTempFile(null, null);
+        assertThatCode(() -> util.downloadToLocalFile(file, tmpFile, Set.of())).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("download should succeed (with timeout)")
+    void downloadFileCompletesSuccessfully_withTimeout() throws IOException {
+        var file = mock(S3Path.class);
 
         var client = mock(S3AsyncClient.class);
         var responseFuture = completedFuture(GetObjectResponse.builder().build());
@@ -47,16 +81,134 @@ class S3TransferUtilTest {
 
         var util = new S3TransferUtil(client, 1L, TimeUnit.MINUTES, DisabledFileIntegrityCheck.INSTANCE);
         var tmpFile = Files.createTempFile(null, null);
-        var option1 = mock(S3OpenOption.class);
-        var option2 = mock(S3OpenOption.class);
-        assertThatCode(() -> util.downloadToLocalFile(file, tmpFile, option1, option2)).doesNotThrowAnyException();
-        verify(option1, times(1)).apply(any(GetObjectRequest.Builder.class));
-        verify(option2, times(1)).apply(any(GetObjectRequest.Builder.class));
+        assertThatCode(() -> util.downloadToLocalFile(file, tmpFile, Set.of())).doesNotThrowAnyException();
     }
 
     @Test
-    @DisplayName("upload should succeed")
-    void uploadFileCompletesSuccessfully() throws IOException {
+    @DisplayName("IOException is thrown when download failed for unknown reason")
+    void downloadFileFailsDueForUnknownReason() throws IOException {
+        var file = mock(S3Path.class);
+        when(file.toString()).thenReturn("somefile");
+
+        var client = mock(S3AsyncClient.class);
+        var exception = new CompletionException(new RuntimeException("unknown error"));
+        when(client.getObject(any(GetObjectRequest.class), any(AsyncResponseTransformer.class))).thenThrow(exception);
+
+        var util = new S3TransferUtil(client, null, null, DisabledFileIntegrityCheck.INSTANCE);
+        var tmpFile = Files.createTempFile(null, null);
+        assertThatCode(() -> util.downloadToLocalFile(file, tmpFile, Set.of()))
+            .isInstanceOf(IOException.class)
+            .hasMessage("Could not read from path: somefile")
+            .hasCause(exception);
+    }
+
+    @Test
+    @DisplayName("IOException is thrown when download failed with 400")
+    void downloadFileFailsDueTo400() throws IOException {
+        var file = mock(S3Path.class);
+        when(file.toString()).thenReturn("somefile");
+
+        var client = mock(S3AsyncClient.class);
+        var exception = new CompletionException(S3Exception.builder().statusCode(400).build());
+        when(client.getObject(any(GetObjectRequest.class), any(AsyncResponseTransformer.class))).thenThrow(exception);
+
+        var util = new S3TransferUtil(client, null, null, DisabledFileIntegrityCheck.INSTANCE);
+        var tmpFile = Files.createTempFile(null, null);
+        assertThatCode(() -> util.downloadToLocalFile(file, tmpFile, Set.of()))
+            .isInstanceOf(IOException.class)
+            .hasMessage("Could not read from path: somefile")
+            .hasCause(exception);
+    }
+
+    @Test
+    @DisplayName("IOException is thrown when download failed with 404")
+    void downloadFileFailsDueTo404() throws IOException {
+        var file = mock(S3Path.class);
+        when(file.toString()).thenReturn("somefile");
+
+        var client = mock(S3AsyncClient.class);
+        var exception = new CompletionException(S3Exception.builder().statusCode(404).build());
+        when(client.getObject(any(GetObjectRequest.class), any(AsyncResponseTransformer.class))).thenThrow(exception);
+
+        var util = new S3TransferUtil(client, null, null, DisabledFileIntegrityCheck.INSTANCE);
+        var tmpFile = Files.createTempFile(null, null);
+        assertThatCode(() -> util.downloadToLocalFile(file, tmpFile, Set.of()))
+            .isInstanceOf(NoSuchFileException.class)
+            .hasMessage("somefile");
+    }
+
+    @Test
+    @DisplayName("when CREATE open option is present, a failed download with a 404 status code is gracefully handled")
+    void downloadFileFailsDueTo404ButCreateOption() throws IOException {
+        var file = mock(S3Path.class);
+
+        var client = mock(S3AsyncClient.class);
+        var exception = new CompletionException(S3Exception.builder().statusCode(404).build());
+        when(client.getObject(any(GetObjectRequest.class), any(AsyncResponseTransformer.class))).thenThrow(exception);
+
+        var util = new S3TransferUtil(client, null, null, DisabledFileIntegrityCheck.INSTANCE);
+        var tmpFile = Files.createTempFile(null, null);
+        assertThatCode(() -> util.downloadToLocalFile(file, tmpFile, Set.of(CREATE))).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("IOException is thrown when timeout happens while downloading")
+    void downloadFileFailsDueToTimeout() throws Exception {
+        var file = mock(S3Path.class);
+        when(file.toString()).thenReturn("somefile");
+
+        var client = mock(S3AsyncClient.class);
+        var exception = new TimeoutException("test timeout");
+        var responseFuture = mock(CompletableFuture.class);
+        when(responseFuture.get(1L, TimeUnit.MINUTES)).thenThrow(exception);
+        when(client.getObject(any(GetObjectRequest.class), any(AsyncResponseTransformer.class))).thenReturn(responseFuture);
+
+        var util = new S3TransferUtil(client, 1L, TimeUnit.MINUTES, DisabledFileIntegrityCheck.INSTANCE);
+        var tmpFile = Files.createTempFile(null, null);
+        assertThatCode(() -> util.downloadToLocalFile(file, tmpFile, Set.of()))
+            .isInstanceOf(IOException.class)
+            .hasMessage("Could not read from path: somefile")
+            .hasCause(exception);
+    }
+
+    @Test
+    @DisplayName("IOException is thrown when interrupted while downloading")
+    void downloadFileInterrupted() throws Exception {
+        var file = mock(S3Path.class);
+        when(file.toString()).thenReturn("somefile");
+
+        var client = mock(S3AsyncClient.class);
+        var exception = new InterruptedException("test interruption");
+        var responseFuture = mock(CompletableFuture.class);
+        when(responseFuture.get(1L, TimeUnit.MINUTES)).thenThrow(exception);
+        when(client.getObject(any(GetObjectRequest.class), any(AsyncResponseTransformer.class))).thenReturn(responseFuture);
+
+        var util = new S3TransferUtil(client, 1L, TimeUnit.MINUTES, DisabledFileIntegrityCheck.INSTANCE);
+        var tmpFile = Files.createTempFile(null, null);
+        assertThatCode(() -> util.downloadToLocalFile(file, tmpFile, Set.of()))
+            .isInstanceOf(IOException.class)
+            .hasMessage("Could not read from path: somefile")
+            .hasCause(exception);
+    }
+
+    @Test
+    @DisplayName("upload should succeed (without timeout spec)")
+    void uploadFileCompletesSuccessfully_withoutTimeout() throws IOException {
+        S3Path file = mock();
+        when(file.bucketName()).thenReturn("a");
+        when(file.getKey()).thenReturn("a");
+
+        final S3AsyncClient client = mock();
+        when(client.putObject(any(PutObjectRequest.class), any(AsyncRequestBody.class))).thenReturn(completedFuture(PutObjectResponse.builder().build()));
+
+        var util = new S3TransferUtil(client, null, null, DisabledFileIntegrityCheck.INSTANCE);
+        var tmpFile = Files.createTempFile(null, null);
+        assertThatCode(() -> util.uploadLocalFile(file, tmpFile)).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("upload should succeed (with timeout spec)")
+    void uploadFileCompletesSuccessfully_withTimeout() throws IOException {
         S3Path file = mock();
         when(file.bucketName()).thenReturn("a");
         when(file.getKey()).thenReturn("a");
@@ -70,29 +222,62 @@ class S3TransferUtilTest {
     }
 
     @Test
+    @DisplayName("IOException is thrown when interrupted while uploading")
+    void uploadFileFailedDueTo400() throws Exception {
+        var file = mock(S3Path.class);
+        when(file.toString()).thenReturn("somefile");
+
+        var client = mock(S3AsyncClient.class);
+        var exception = new CompletionException(S3Exception.builder().statusCode(400).build());
+        var responseFuture = mock(CompletableFuture.class);
+        when(responseFuture.get(1L, TimeUnit.SECONDS)).thenThrow(exception);
+        when(client.putObject(any(PutObjectRequest.class), any(AsyncRequestBody.class))).thenReturn(responseFuture);
+
+        var util = new S3TransferUtil(client, 1L, TimeUnit.SECONDS, DisabledFileIntegrityCheck.INSTANCE);
+        var tmpFile = Files.createTempFile(null, null);
+        assertThatCode(() -> util.uploadLocalFile(file, tmpFile))
+            .isInstanceOf(IOException.class)
+            .hasMessage("Could not write to path: somefile")
+            .hasCause(exception);
+    }
+
+    @Test
+    @DisplayName("IOException is thrown when interrupted while uploading")
+    void uploadFileInterrupted() throws Exception {
+        var file = mock(S3Path.class);
+        when(file.toString()).thenReturn("somefile");
+
+        var client = mock(S3AsyncClient.class);
+        var exception = new InterruptedException("test interruption");
+        var responseFuture = mock(CompletableFuture.class);
+        when(responseFuture.get(1L, TimeUnit.SECONDS)).thenThrow(exception);
+        when(client.putObject(any(PutObjectRequest.class), any(AsyncRequestBody.class))).thenReturn(responseFuture);
+
+        var util = new S3TransferUtil(client, 1L, TimeUnit.SECONDS, DisabledFileIntegrityCheck.INSTANCE);
+        var tmpFile = Files.createTempFile(null, null);
+        assertThatCode(() -> util.uploadLocalFile(file, tmpFile))
+            .isInstanceOf(IOException.class)
+            .hasMessage("Could not write to path: somefile")
+            .hasCause(exception);
+    }
+
+    @Test
     @DisplayName("IOException is thrown when timeout happens while uploading")
-    void uploadTimeoutYieldsIOException() throws IOException {
+    void uploadTimeoutYieldsIOException() throws Exception {
         S3Path file = mock();
         when(file.bucketName()).thenReturn("a");
         when(file.getKey()).thenReturn("a");
 
-        final S3AsyncClient client = mock();
-        when(client.putObject(any(PutObjectRequest.class), any(AsyncRequestBody.class))).thenReturn(
-            CompletableFuture.supplyAsync(() -> {
-                try {
-                    Thread.sleep(Duration.ofMinutes(1).toMillis());
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    throw new RuntimeException(e);
-                }
-                return PutObjectResponse.builder().build();
-            })
-        );
+        var client = mock(S3AsyncClient.class);
+        var exception = new TimeoutException("test timeout");
+        var responseFuture = mock(CompletableFuture.class);
+        when(responseFuture.get(1L, TimeUnit.MILLISECONDS)).thenThrow(exception);
+        when(client.putObject(any(PutObjectRequest.class), any(AsyncRequestBody.class))).thenReturn(responseFuture);
 
         var util = new S3TransferUtil(client, 1L, TimeUnit.MILLISECONDS, DisabledFileIntegrityCheck.INSTANCE);
         var tmpFile = Files.createTempFile(null, null);
         assertThatThrownBy(() -> util.uploadLocalFile(file, tmpFile))
-                .isInstanceOf(IOException.class)
-                .hasCauseInstanceOf(TimeoutException.class);
+            .isInstanceOf(IOException.class)
+            .hasCauseInstanceOf(TimeoutException.class);
     }
 }


### PR DESCRIPTION
An exception while downloading from S3 or uploading to S3 is not traceable to the caller, because it is created in another thread. To make it traceable, we need to propagate the exception from the the caller side (e.g. `S3TransferUtil`).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
