### PR TITLE
Prevent concurrent overwrites of an S3 object

### DIFF
--- a/src/integrationTest/java/software/amazon/nio/spi/s3/FileChannelOpenTest.java
+++ b/src/integrationTest/java/software/amazon/nio/spi/s3/FileChannelOpenTest.java
@@ -5,6 +5,7 @@
 
 package software.amazon.nio.spi.s3;
 
+import static java.nio.file.StandardOpenOption.*;
 import static org.assertj.core.api.Assertions.*;
 import static software.amazon.nio.spi.s3.Containers.*;
 
@@ -33,12 +34,24 @@ public class FileChannelOpenTest {
     }
 
     @Test
+    @DisplayName("open/close with If-Match header succeeds")
+    public void newByteChannel_READ_WRITE_preventConcurrentOverwrite_withoutConcurrency() throws IOException {
+        var path = putObject(bucketName, "fc-overwrite-test.txt", "abc");
+
+        try (var channel = FileChannel.open(path, READ, WRITE, S3OpenOption.preventConcurrentOverwrite())) {
+            channel.write(ByteBuffer.wrap("def".getBytes()), 0);
+        }
+
+        assertThat(path).hasContent("def");
+    }
+
+    @Test
     @DisplayName("open with CREATE and WRITE is supported")
     public void open_CREATE_WRITE() throws IOException {
         var path = Paths.get(URI.create(localStackConnectionEndpoint() + "/" + bucketName + "/fc-create-write-test.txt"));
 
         String text = "we test FileChannel#open with CREATE and WRITE options";
-        try (var channel = FileChannel.open(path, StandardOpenOption.CREATE, StandardOpenOption.WRITE)) {
+        try (var channel = FileChannel.open(path, StandardOpenOption.CREATE, WRITE)) {
             channel.write(ByteBuffer.wrap(text.getBytes()));
         }
 
@@ -51,7 +64,7 @@ public class FileChannelOpenTest {
         var path = putObject(bucketName, "fc-read-write-test.txt");
 
         String text = "abcdefhij";
-        try (var channel = FileChannel.open(path, StandardOpenOption.READ, StandardOpenOption.WRITE)) {
+        try (var channel = FileChannel.open(path, READ, WRITE)) {
 
             // write
             channel.write(ByteBuffer.wrap("def".getBytes()), 3);
@@ -67,6 +80,25 @@ public class FileChannelOpenTest {
         }
 
         assertThat(path).hasContent(text);
+    }
+
+    @Test
+    @DisplayName("open/close with If-Match header fails")
+    public void open_READ_WRITE_preventConcurrentOverwrite_withConcurrency() throws IOException {
+        var path = putObject(bucketName, "fc-overwrite-test.txt", "abc");
+
+        var channel1 = FileChannel.open(path, READ, WRITE, S3OpenOption.preventConcurrentOverwrite());
+        channel1.write(ByteBuffer.wrap("def".getBytes()), 0);
+
+        try (var channel2 = FileChannel.open(path, READ, WRITE, S3OpenOption.preventConcurrentOverwrite())) {
+            channel2.write(ByteBuffer.wrap("ghi".getBytes()), 0);
+        }
+
+        assertThatThrownBy(() -> channel1.close())
+            .isInstanceOf(IOException.class)
+            .hasMessage("PutObject => 412; " + path + "; At least one of the pre-conditions you specified did not hold");
+
+        assertThat(path).hasContent("ghi");
     }
 
 }

--- a/src/integrationTest/java/software/amazon/nio/spi/s3/FileChannelOpenTest.java
+++ b/src/integrationTest/java/software/amazon/nio/spi/s3/FileChannelOpenTest.java
@@ -34,12 +34,13 @@ public class FileChannelOpenTest {
     }
 
     @Test
-    @DisplayName("open/close with If-Match header succeeds")
+    @DisplayName("open/force/close with If-Match header succeeds")
     public void newByteChannel_READ_WRITE_preventConcurrentOverwrite_withoutConcurrency() throws IOException {
         var path = putObject(bucketName, "fc-overwrite-test.txt", "abc");
 
         try (var channel = FileChannel.open(path, READ, WRITE, S3OpenOption.preventConcurrentOverwrite())) {
             channel.write(ByteBuffer.wrap("def".getBytes()), 0);
+            channel.force(true);
         }
 
         assertThat(path).hasContent("def");

--- a/src/main/java/software/amazon/nio/spi/s3/S3FileSystem.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3FileSystem.java
@@ -522,13 +522,20 @@ public class S3FileSystem extends FileSystem {
         if (path.isDirectory()) {
             throw new IllegalArgumentException("path must be a file");
         }
+        String filename = path.getFileName().toString();
         if (path.getNameCount() == 1) {
-            Path newPath = temporaryDirectory.resolve(path.getFileName().toString());
+            Path newPath = temporaryDirectory.resolve(filename);
+            newPath = Files.exists(newPath)
+                ? temporaryDirectory.resolve(filename + "-" + System.nanoTime())
+                : newPath;
             return Files.createFile(newPath);
         }
         Path parent = temporaryDirectory.resolve(path.getParent().toString());
         Files.createDirectories(parent);
-        Path newPath = parent.resolve(path.getFileName().toString());
+        Path newPath = parent.resolve(filename);
+        newPath = Files.exists(newPath)
+            ? parent.resolve(filename + "-" + System.nanoTime())
+            : newPath;
         return Files.createFile(newPath);
     }
 

--- a/src/main/java/software/amazon/nio/spi/s3/S3OpenOption.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3OpenOption.java
@@ -18,7 +18,7 @@ import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 public abstract class S3OpenOption implements OpenOption {
 
     /**
-     * Sets an HTTP <code>If-Match</code> header for the {@link PutObjectRequest} with the previously read ETag from the
+     * Sets an HTTP <code>If-Match</code> header for the {@link PutObjectRequest} with a previously read ETag from the
      * {@link GetObjectResponse}.
      *
      * <p>
@@ -36,14 +36,14 @@ public abstract class S3OpenOption implements OpenOption {
     }
 
     /**
-     * Sets a HTTP <code>Range</code> header for a {@link GetObjectRequest}, e.g. <code>Range: bytes=0-100</code>.
+     * Sets an HTTP <code>Range</code> header for a {@link GetObjectRequest}, e.g. <code>Range: bytes=0-100</code>.
      */
     public static S3OpenOption range(int end) {
         return new S3RangeHeader(0, end);
     }
 
     /**
-     * Sets a HTTP <code>Range</code> header for a {@link GetObjectRequest}, e.g. <code>Range: bytes=50-100</code>.
+     * Sets an HTTP <code>Range</code> header for a {@link GetObjectRequest}, e.g. <code>Range: bytes=50-100</code>.
      */
     public static S3OpenOption range(int start, int end) {
         return new S3RangeHeader(start, end);

--- a/src/main/java/software/amazon/nio/spi/s3/S3OpenOption.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3OpenOption.java
@@ -7,18 +7,45 @@ package software.amazon.nio.spi.s3;
 
 import java.nio.file.OpenOption;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 
 /**
  * Represents an S3 client specific {@link OpenOption} that enables the customization of the underlying
  * {@link GetObjectRequest}.
  */
-public interface S3OpenOption extends OpenOption {
+public abstract class S3OpenOption implements OpenOption {
 
-    static S3OpenOption range(int end) {
+    /**
+     * Sets an HTTP <code>If-Match</code> header for the {@link PutObjectRequest} with the previously read ETag from the
+     * {@link GetObjectResponse}.
+     *
+     * <p>
+     * This is meant to be used while opening a {@code FileChannel} or {@code SeekableByteChannel}. When opening the
+     * channel, the ETag is stored. Closing the channel (or while calling <code>FileChannel.force</code>) the stored
+     * ETag is set as <code>If-Match</code> header on the corresponding {@link PutObjectRequest}. This prevents
+     * overwriting of the S3 object between opening and closing the channel.
+     *
+     * <p>
+     * If multiple conditional writes occur for the same object name, the first write operation to finish succeeds.
+     * Amazon S3 then fails subsequent writes with a <code>412 Precondition Failed</code> response.
+     */
+    public static S3OpenOption preventConcurrentOverwrite() {
+        return new S3PreventConcurrentOverwrite();
+    }
+
+    /**
+     * Sets a HTTP <code>Range</code> header for a {@link GetObjectRequest}, e.g. <code>Range: bytes=0-100</code>.
+     */
+    public static S3OpenOption range(int end) {
         return new S3RangeHeader(0, end);
     }
 
-    static S3OpenOption range(int start, int end) {
+    /**
+     * Sets a HTTP <code>Range</code> header for a {@link GetObjectRequest}, e.g. <code>Range: bytes=50-100</code>.
+     */
+    public static S3OpenOption range(int start, int end) {
         return new S3RangeHeader(start, end);
     }
 
@@ -28,5 +55,33 @@ public interface S3OpenOption extends OpenOption {
      * @param getObjectRequest
      *            get object request
      */
-    void apply(GetObjectRequest.Builder getObjectRequest);
+    protected void apply(GetObjectRequest.Builder getObjectRequest) {
+    }
+
+    /**
+     * Adapts the given {@link PutObjectRequest.Builder}.
+     *
+     * @param putObjectRequest
+     *            put object request
+     */
+    protected void apply(PutObjectRequest.Builder putObjectRequest) {
+    }
+
+    /**
+     * Will be called after the {@link GetObjectRequest} succeeded.
+     *
+     * @param getObjectResponse
+     *            get object response
+     */
+    protected void consume(GetObjectResponse getObjectResponse) {
+    }
+
+    /**
+     * Will be called after the {@link PutObjectResponse} succeeded.
+     *
+     * @param putObjectResponse
+     *            put object response
+     */
+    protected void consume(PutObjectResponse putObjectResponse) {
+    }
 }

--- a/src/main/java/software/amazon/nio/spi/s3/S3PreventConcurrentOverwrite.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3PreventConcurrentOverwrite.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.nio.spi.s3;
+
+import software.amazon.awssdk.annotations.NotThreadSafe;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+/**
+ * Sets an HTTP <code>If-Match</code> header for the {@link PutObjectRequest} with the previously read ETag from the
+ * {@link GetObjectResponse}.
+ *
+ * <p>
+ * This is meant to be used while opening a {@code FileChannel} or {@code SeekableByteChannel}. When opening the
+ * channel, the ETag is stored. Closing the channel (or while calling <code>FileChannel.force</code>) the stored ETag is
+ * set as <code>If-Match</code> header on the corresponding {@link PutObjectRequest}. This prevents overwriting of the
+ * S3 object between opening and closing the channel.
+ *
+ * <p>
+ * If multiple conditional writes occur for the same object name, the first write operation to finish succeeds. Amazon
+ * S3 then fails subsequent writes with a <code>412 Precondition Failed</code> response.
+ */
+@NotThreadSafe
+class S3PreventConcurrentOverwrite extends S3OpenOption {
+    private String eTag;
+
+    @Override
+    protected void apply(PutObjectRequest.Builder putObjectRequest) {
+        putObjectRequest.ifMatch(eTag);
+    }
+
+    @Override
+    protected void consume(GetObjectResponse getObjectResponse) {
+        eTag = getObjectResponse.eTag();
+    }
+}

--- a/src/main/java/software/amazon/nio/spi/s3/S3PreventConcurrentOverwrite.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3PreventConcurrentOverwrite.java
@@ -11,7 +11,7 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 
 /**
- * Sets an HTTP <code>If-Match</code> header for the {@link PutObjectRequest} with the previously read ETag from the
+ * Sets an HTTP <code>If-Match</code> header for the {@link PutObjectRequest} with a previously read ETag from the
  * {@link GetObjectResponse}.
  *
  * <p>

--- a/src/main/java/software/amazon/nio/spi/s3/S3PreventConcurrentOverwrite.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3PreventConcurrentOverwrite.java
@@ -8,6 +8,7 @@ package software.amazon.nio.spi.s3;
 import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 
 /**
  * Sets an HTTP <code>If-Match</code> header for the {@link PutObjectRequest} with the previously read ETag from the
@@ -35,5 +36,10 @@ class S3PreventConcurrentOverwrite extends S3OpenOption {
     @Override
     protected void consume(GetObjectResponse getObjectResponse) {
         eTag = getObjectResponse.eTag();
+    }
+
+    @Override
+    protected void consume(PutObjectResponse putObjectResponse) {
+        eTag = putObjectResponse.eTag();
     }
 }

--- a/src/main/java/software/amazon/nio/spi/s3/S3RangeHeader.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3RangeHeader.java
@@ -10,7 +10,7 @@ import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 /**
  * Sets a HTTP <code>Range</code> header for a {@link GetObjectRequest}.
  */
-class S3RangeHeader implements S3OpenOption {
+class S3RangeHeader extends S3OpenOption {
     private final String range;
 
     S3RangeHeader(int start, int end) {

--- a/src/main/java/software/amazon/nio/spi/s3/S3TransferUtil.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3TransferUtil.java
@@ -24,6 +24,7 @@ import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 
 final class S3TransferUtil {
@@ -56,10 +57,14 @@ final class S3TransferUtil {
             var responseTransformer = AsyncResponseTransformer.<GetObjectResponse>toFile(destination, transformerConfig);
             var downloadCompletableFuture = client.getObject(getObjectRequest.build(), responseTransformer);
 
+            GetObjectResponse getObjectResponse;
             if (timeout != null && timeUnit != null) {
-                downloadCompletableFuture.get(timeout, timeUnit);
+                getObjectResponse = downloadCompletableFuture.get(timeout, timeUnit);
             } else {
-                downloadCompletableFuture.join();
+                getObjectResponse = downloadCompletableFuture.join();
+            }
+            for (var option : s3OpenOptions) {
+                option.consume(getObjectResponse);
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
@@ -84,19 +89,31 @@ final class S3TransferUtil {
         }
     }
 
-    void uploadLocalFile(S3Path path, Path localFile) throws IOException {
+    void uploadLocalFile(S3Path path, Path localFile, Set<? extends OpenOption> options) throws IOException {
+        var s3OpenOptions = options.stream()
+            .flatMap(o -> o instanceof S3OpenOption
+                ? Stream.of((S3OpenOption) o)
+                : Stream.empty())
+            .toArray(S3OpenOption[]::new);
         try {
             var putObjectRequest = PutObjectRequest.builder()
                 .bucket(path.bucketName())
                 .key(path.getKey())
                 .contentType(Files.probeContentType(localFile));
             integrityCheck.addChecksumToRequest(localFile, putObjectRequest);
+            for (var option : s3OpenOptions) {
+                option.apply(putObjectRequest);
+            }
             var uploadCompletableFuture = client.putObject(putObjectRequest.build(), AsyncRequestBody.fromFile(localFile));
 
+            PutObjectResponse putObjectResponse;
             if (timeout != null && timeUnit != null) {
-                uploadCompletableFuture.get(timeout, timeUnit);
+                putObjectResponse = uploadCompletableFuture.get(timeout, timeUnit);
             } else {
-                uploadCompletableFuture.join();
+                putObjectResponse = uploadCompletableFuture.join();
+            }
+            for (var option : s3OpenOptions) {
+                option.consume(putObjectResponse);
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
@@ -104,7 +121,14 @@ final class S3TransferUtil {
         } catch (TimeoutException | ExecutionException e) {
             throw new IOException("Could not write to path: " + path, e);
         } catch (CompletionException e) {
-            throw new IOException("Could not write to path: " + path, e);
+            var cause = e.getCause();
+            if (!(cause instanceof S3Exception)) {
+                throw new IOException("Could not write to path: " + path, e);
+            }
+            var s3e = (S3Exception) cause;
+            var code = s3e.statusCode();
+            var message = s3e.awsErrorDetails() == null ? "" : s3e.awsErrorDetails().errorMessage();
+            throw new IOException("PutObject => " + code + "; " + path + "; " + message, e);
         }
     }
 }

--- a/src/main/java/software/amazon/nio/spi/s3/S3WritableByteChannel.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3WritableByteChannel.java
@@ -26,6 +26,7 @@ class S3WritableByteChannel implements SeekableByteChannel {
     private final Path tempFile;
     private final SeekableByteChannel channel;
     private final S3TransferUtil s3TransferUtil;
+    private final Set<? extends OpenOption> options;
 
     private boolean open;
 
@@ -39,6 +40,7 @@ class S3WritableByteChannel implements SeekableByteChannel {
         Objects.requireNonNull(client);
         this.s3TransferUtil = s3TransferUtil;
         this.path = path;
+        this.options = options;
 
         try {
             var fileSystemProvider = (S3FileSystemProvider) path.getFileSystem().provider();
@@ -87,7 +89,7 @@ class S3WritableByteChannel implements SeekableByteChannel {
             return;
         }
 
-        s3TransferUtil.uploadLocalFile(path, tempFile);
+        s3TransferUtil.uploadLocalFile(path, tempFile, options);
         Files.deleteIfExists(tempFile);
 
         open = false;
@@ -102,7 +104,7 @@ class S3WritableByteChannel implements SeekableByteChannel {
         if (!open) {
             throw new ClosedChannelException();
         }
-        s3TransferUtil.uploadLocalFile(path, tempFile);
+        s3TransferUtil.uploadLocalFile(path, tempFile, options);
     }
 
     @Override

--- a/src/test/java/software/amazon/nio/spi/s3/S3PreventConcurrentOverwriteTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3PreventConcurrentOverwriteTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.nio.spi.s3;
+
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.Test;
+
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+class S3PreventConcurrentOverwriteTest {
+
+    @Test
+    void test() {
+        var eTag = "some-etag";
+        var preventConcurrentOverwrite = new S3PreventConcurrentOverwrite();
+
+        var getObjectResponse = mock(GetObjectResponse.class);
+        when(getObjectResponse.eTag()).thenReturn(eTag);
+        preventConcurrentOverwrite.consume(getObjectResponse);
+        verify(getObjectResponse, times(1)).eTag();
+
+        var putObjectRequest = mock(PutObjectRequest.Builder.class);
+        preventConcurrentOverwrite.apply(putObjectRequest);
+        verify(putObjectRequest, times(1)).ifMatch(eTag);
+    }
+
+}

--- a/src/test/java/software/amazon/nio/spi/s3/S3PreventConcurrentOverwriteTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3PreventConcurrentOverwriteTest.java
@@ -11,14 +11,15 @@ import org.junit.jupiter.api.Test;
 
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 
 class S3PreventConcurrentOverwriteTest {
 
     @Test
-    void test() {
-        var eTag = "some-etag";
+    void test_consume_GetObjectResponse() {
         var preventConcurrentOverwrite = new S3PreventConcurrentOverwrite();
 
+        var eTag = "some.etag";
         var getObjectResponse = mock(GetObjectResponse.class);
         when(getObjectResponse.eTag()).thenReturn(eTag);
         preventConcurrentOverwrite.consume(getObjectResponse);
@@ -27,6 +28,23 @@ class S3PreventConcurrentOverwriteTest {
         var putObjectRequest = mock(PutObjectRequest.Builder.class);
         preventConcurrentOverwrite.apply(putObjectRequest);
         verify(putObjectRequest, times(1)).ifMatch(eTag);
+
+    }
+
+    @Test
+    void test_consume_PutObjectResponse() {
+        var preventConcurrentOverwrite = new S3PreventConcurrentOverwrite();
+
+        var eTag = "some-etag";
+        var putObjectResponse = mock(PutObjectResponse.class);
+        when(putObjectResponse.eTag()).thenReturn(eTag);
+        preventConcurrentOverwrite.consume(putObjectResponse);
+        verify(putObjectResponse, times(1)).eTag();
+
+        var putObjectRequest = mock(PutObjectRequest.Builder.class);
+        preventConcurrentOverwrite.apply(putObjectRequest);
+        verify(putObjectRequest, times(1)).ifMatch(eTag);
+
     }
 
 }

--- a/src/test/java/software/amazon/nio/spi/s3/S3WritableByteChannelTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3WritableByteChannelTest.java
@@ -286,7 +286,7 @@ class S3WritableByteChannelTest {
         // this close() call should be a no-op
         channel.close();
 
-        verify(utilMock, times(1)).uploadLocalFile(any(), any());
+        verify(utilMock, times(1)).uploadLocalFile(any(), any(), any());
     }
 
     private long countTemporaryFiles(Path tempDir) throws IOException {


### PR DESCRIPTION
We want to prevent overwrites if the S3 object has changed in the meantime. For this we utilize an `OpenOption` that captures the `ETag` on `GetObject` and sets the `If-Match` header on `PutObject`. When opening a `FileChannel` or `SeekableByteChannel`, the ETag is stored in a field and when closing the channel (or while calling `FileChannel.force`) the stored ETag is set as `If-Match` header on the corresponding `PutObjectRequest`. This prevents overwriting of the S3 object between opening and closing the channel.

Additionally, this change fixes the ability to open multiple channels on the same S3 object.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
