### PR TITLE
Provide a dedicated `IOException` to handle expected failures

### DIFF
--- a/src/integrationTest/java/software/amazon/nio/spi/s3/FileChannelOpenTest.java
+++ b/src/integrationTest/java/software/amazon/nio/spi/s3/FileChannelOpenTest.java
@@ -96,8 +96,14 @@ public class FileChannelOpenTest {
         }
 
         assertThatThrownBy(() -> channel1.close())
-            .isInstanceOf(IOException.class)
-            .hasMessage("PutObject => 412; " + path + "; At least one of the pre-conditions you specified did not hold");
+            .isInstanceOf(S3TransferException.class)
+            .hasMessage("PutObject => 412; " + path + "; At least one of the pre-conditions you specified did not hold")
+            .extracting(e -> (S3TransferException) e)
+            .satisfiesAnyOf(e -> {
+                assertThat(e.errorCode()).isEqualTo("PreconditionFailed");
+                assertThat(e.errorMessage()).isEqualTo("At least one of the pre-conditions you specified did not hold");
+                assertThat(e.statusCode()).isEqualTo(412);
+            });
 
         assertThat(path).hasContent("ghi");
     }

--- a/src/integrationTest/java/software/amazon/nio/spi/s3/FilesNewByteChannelTest.java
+++ b/src/integrationTest/java/software/amazon/nio/spi/s3/FilesNewByteChannelTest.java
@@ -132,7 +132,7 @@ public class FilesNewByteChannelTest {
     @Test
     @DisplayName("newByteChannel with RANGE header to partially fetch object")
     public void newByteChannel_useRangeHeader_partiallyGet() throws IOException {
-        String content = "abcdef";
+        String content = "abcdefghi";
         var path = putObject(bucketName, "bc-range-test.txt", content);
         assertThat(Containers.getLoggedS3HttpRequests()).containsExactly("PutObject => 200");
 

--- a/src/main/java/software/amazon/nio/spi/s3/S3OpenOption.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3OpenOption.java
@@ -30,6 +30,8 @@ public abstract class S3OpenOption implements OpenOption {
      * <p>
      * If multiple conditional writes occur for the same object name, the first write operation to finish succeeds.
      * Amazon S3 then fails subsequent writes with a <code>412 Precondition Failed</code> response.
+     *
+     * @return new instance
      */
     public static S3OpenOption preventConcurrentOverwrite() {
         return new S3PreventConcurrentOverwrite();
@@ -37,6 +39,10 @@ public abstract class S3OpenOption implements OpenOption {
 
     /**
      * Sets an HTTP <code>Range</code> header for a {@link GetObjectRequest}, e.g. <code>Range: bytes=0-100</code>.
+     *
+     * @param end
+     *            exclusive end
+     * @return new instance
      */
     public static S3OpenOption range(int end) {
         return new S3RangeHeader(0, end);
@@ -44,6 +50,12 @@ public abstract class S3OpenOption implements OpenOption {
 
     /**
      * Sets an HTTP <code>Range</code> header for a {@link GetObjectRequest}, e.g. <code>Range: bytes=50-100</code>.
+     *
+     * @param start
+     *            first position (offset)
+     * @param end
+     *            last position (exclusive)
+     * @return new instance
      */
     public static S3OpenOption range(int start, int end) {
         return new S3RangeHeader(start, end);

--- a/src/main/java/software/amazon/nio/spi/s3/S3TransferException.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3TransferException.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.nio.spi.s3;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+
+public class S3TransferException extends IOException {
+    private static final long serialVersionUID = 1L;
+
+    private final String errorCode;
+    private final String errorMessage;
+    private final Integer numAttempts;
+    private final String requestId;
+    private final int statusCode;
+
+    public S3TransferException(String method, Path path, AwsServiceException cause) {
+        this(
+            errorCode(cause),
+            errorMessage(cause),
+            cause.requestId(),
+            cause.statusCode(),
+            cause.numAttempts(),
+            message(method, path, cause),
+            cause);
+    }
+
+    private S3TransferException(
+        String errorCode,
+        String errorMessage,
+        String requestId,
+        int statusCode,
+        Integer numAttempts,
+        String message,
+        Throwable cause) {
+        super(message, cause);
+        this.errorCode = errorCode;
+        this.errorMessage = errorMessage;
+        this.requestId = requestId;
+        this.statusCode = statusCode;
+        this.numAttempts = numAttempts;
+    }
+
+    private static String errorCode(AwsServiceException cause) {
+        return cause.awsErrorDetails() == null ? "" : cause.awsErrorDetails().errorCode();
+    }
+
+    private static String errorMessage(AwsServiceException cause) {
+        return cause.awsErrorDetails() == null ? "" : cause.awsErrorDetails().errorMessage();
+    }
+
+    private static String message(String method, Path path, AwsServiceException cause) {
+        String errorMessage = errorMessage(cause);
+        errorMessage = errorMessage.isEmpty() ? "" : "; " + errorMessage;
+        return method + " => " + cause.statusCode() + "; " + path + errorMessage;
+    }
+
+    public String errorCode() {
+        return errorCode;
+    }
+
+    public String errorMessage() {
+        return errorMessage;
+    }
+
+    public Integer numAttempts() {
+        return numAttempts;
+    }
+
+    public String requestId() {
+        return requestId;
+    }
+
+    public int statusCode() {
+        return statusCode;
+    }
+}

--- a/src/main/java/software/amazon/nio/spi/s3/S3TransferException.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3TransferException.java
@@ -9,6 +9,21 @@ import java.io.IOException;
 import java.nio.file.Path;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 
+/**
+ * Represents an error which is caused by an S3 action and enables a caller to react based on the {@link #errorCode()}
+ * or {@link #statusCode()}.
+ *
+ * <p>
+ * It is meant to be used, to re-apply changes on a <code>FileChannel</code> or <code>SeekableByteChannel</code> when
+ * the upload fails due to an expected failure like a failing precondition (caused by a conditional request). The caller
+ * would catch the {@link S3TransferException} and checks for the {@link #errorCode()} or {@link #statusCode()}.
+ * 
+ * <p>
+ * For example, when opening a FileChannel with the option {@link S3OpenOption#preventConcurrentOverwrite()} and the
+ * upload fails while closing the channel due to a non-matching ETag, the caller catches the
+ * {@link S3TransferException}, checks for the {@link #statusCode()} being equal to <code>412</code> performs the same
+ * procedure again from the beginning.
+ */
 public class S3TransferException extends IOException {
     private static final long serialVersionUID = 1L;
 

--- a/src/test/java/software/amazon/nio/spi/s3/S3TransferExceptionTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3TransferExceptionTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.nio.spi.s3;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.nio.file.spi.FileSystemProvider;
+
+import org.junit.jupiter.api.Test;
+
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+class S3TransferExceptionTest {
+
+    @Test
+    void test_cause() {
+        var fs = mock(S3FileSystem.class);
+        var provider = mock(FileSystemProvider.class);
+        when(fs.provider()).thenReturn(provider);
+        when(provider.getScheme()).thenReturn("s3");
+        var path = S3Path.getPath(fs, "somefile");
+        var cause = S3Exception.builder()
+            .awsErrorDetails(AwsErrorDetails.builder()
+                .errorCode("PreconditionFailed")
+                .errorMessage("At least one of the pre-conditions you specified did not hold")
+                .build())
+            .numAttempts(1)
+            .requestId("some-request")
+            .statusCode(412)
+            .build();
+        var exception = new S3TransferException("HeadObject", path, cause);
+        assertThat(exception).hasMessage("HeadObject => 412; somefile; At least one of the pre-conditions you specified did not hold");
+        assertThat(exception.errorCode()).isEqualTo("PreconditionFailed");
+        assertThat(exception.errorMessage()).isEqualTo("At least one of the pre-conditions you specified did not hold");
+        assertThat(exception.numAttempts()).isEqualTo(1);
+        assertThat(exception.requestId()).isEqualTo("some-request");
+        assertThat(exception.statusCode()).isEqualTo(412);
+    }
+
+    @Test
+    void test_emptyCause() {
+        var fs = mock(S3FileSystem.class);
+        var provider = mock(FileSystemProvider.class);
+        when(fs.provider()).thenReturn(provider);
+        when(provider.getScheme()).thenReturn("s3");
+        var path = S3Path.getPath(fs, "somefile");
+        var cause = S3Exception.builder().build();
+        var exception = new S3TransferException("HeadObject", path, cause);
+        assertThat(exception).hasMessage("HeadObject => 0; somefile");
+        assertThat(exception.errorCode()).isEmpty();
+        assertThat(exception.errorMessage()).isEmpty();
+        assertThat(exception.numAttempts()).isNull();
+        assertThat(exception.requestId()).isNull();
+        assertThat(exception.statusCode()).isEqualTo(0);
+    }
+}

--- a/src/test/java/software/amazon/nio/spi/s3/S3TransferUtilTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3TransferUtilTest.java
@@ -117,9 +117,9 @@ class S3TransferUtilTest {
         var util = new S3TransferUtil(client, null, null, DisabledFileIntegrityCheck.INSTANCE);
         var tmpFile = Files.createTempFile(null, null);
         assertThatCode(() -> util.downloadToLocalFile(file, tmpFile, Set.of()))
-            .isInstanceOf(IOException.class)
-            .hasMessage("Could not read from path: somefile")
-            .hasCause(exception);
+            .isInstanceOf(S3TransferException.class)
+            .hasMessage("GetObject => 400; somefile")
+            .hasCause(exception.getCause());
     }
 
     @Test
@@ -260,9 +260,9 @@ class S3TransferUtilTest {
         var util = new S3TransferUtil(client, 1L, TimeUnit.SECONDS, DisabledFileIntegrityCheck.INSTANCE);
         var tmpFile = Files.createTempFile(null, null);
         assertThatCode(() -> util.uploadLocalFile(file, tmpFile, Set.of()))
-            .isInstanceOf(IOException.class)
-            .hasMessage("PutObject => 400; somefile; ")
-            .hasCause(exception);
+            .isInstanceOf(S3TransferException.class)
+            .hasMessage("PutObject => 400; somefile")
+            .hasCause(exception.getCause());
     }
 
     @Test

--- a/src/test/java/software/amazon/nio/spi/s3/S3WritableByteChannelTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3WritableByteChannelTest.java
@@ -152,9 +152,9 @@ class S3WritableByteChannelTest {
         doThrow(exception).when(s3Client).getObject(any(GetObjectRequest.class), any(AsyncResponseTransformer.class));
 
         assertThatThrownBy(() -> new S3WritableByteChannel(file, s3Client, transferManager, emptySet()))
-            .isInstanceOf(IOException.class)
-            .hasMessage("Could not read from path: somefile")
-            .hasCause(exception);
+            .isInstanceOf(S3TransferException.class)
+            .hasMessage("GetObject => 400; somefile")
+            .hasCause(exception.getCause());
     }
 
     @Test


### PR DESCRIPTION
If we want to re-apply changes on a `FileChannel` or `SeekableByteChannel` that failed to upload due to failing preconditions, we need to figure out if the resulting failure was a `PreconditionFailed`. To figure this out, we would need to parse the stacktrace, the causes and their message. To avoid that, we need a custom `IOException` that enable us to check the status code or error code from the causing `AwsServiceException`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
