### PR TITLE
Use the 'S3TransferManager' by default, but allow users to disable it

### DIFF
--- a/src/integrationTest/java/software/amazon/nio/spi/s3/FileChannelOpenTest.java
+++ b/src/integrationTest/java/software/amazon/nio/spi/s3/FileChannelOpenTest.java
@@ -210,4 +210,23 @@ public class FileChannelOpenTest {
         assertThat(path).hasContent("ghi");
     }
 
+    @Test
+    @DisplayName("open with `UseTransferManager` option")
+    public void open_useTransferManager() throws IOException {
+        String content = "abcdefgh";
+        var path = putObject(bucketName, "fc-use-tm-test.txt", content);
+        assertThat(Containers.getLoggedS3HttpRequests()).contains("PutObject => 200");
+
+        try (var channel = FileChannel.open(path, READ, WRITE, S3OpenOption.useTransferManager())) {
+            assertThat(Containers.getLoggedS3HttpRequests()).containsExactly("HeadObject => 200", "GetObject => 206");
+            ByteBuffer buffer = ByteBuffer.allocate(content.length());
+            channel.read(buffer);
+            assertThat(buffer.array()).isEqualTo(content.getBytes());
+
+            channel.write(ByteBuffer.wrap("xyz".getBytes()), 3);
+        }
+        assertThat(Containers.getLoggedS3HttpRequests()).containsExactly("PutObject => 200");
+        assertThat(path).hasContent("abcxyzgh");
+    }
+
 }

--- a/src/main/java/software/amazon/nio/spi/s3/Crc32FileIntegrityCheck.java
+++ b/src/main/java/software/amazon/nio/spi/s3/Crc32FileIntegrityCheck.java
@@ -24,7 +24,7 @@ class Crc32FileIntegrityCheck extends S3ObjectIntegrityCheck {
     }
 
     @Override
-    public S3OpenOption newInstance() {
+    public S3OpenOption copy() {
         return new Crc32FileIntegrityCheck();
     }
 }

--- a/src/main/java/software/amazon/nio/spi/s3/Crc32FileIntegrityCheck.java
+++ b/src/main/java/software/amazon/nio/spi/s3/Crc32FileIntegrityCheck.java
@@ -22,4 +22,9 @@ class Crc32FileIntegrityCheck extends S3ObjectIntegrityCheck {
         int checksum = (int) calculateChecksum(file);
         putObjectRequest.checksumCRC32(checksumToBase64String(checksum));
     }
+
+    @Override
+    public S3OpenOption newInstance() {
+        return new Crc32FileIntegrityCheck();
+    }
 }

--- a/src/main/java/software/amazon/nio/spi/s3/Crc32cFileIntegrityCheck.java
+++ b/src/main/java/software/amazon/nio/spi/s3/Crc32cFileIntegrityCheck.java
@@ -24,7 +24,7 @@ class Crc32cFileIntegrityCheck extends S3ObjectIntegrityCheck {
     }
 
     @Override
-    public S3OpenOption newInstance() {
+    public S3OpenOption copy() {
         return new Crc32cFileIntegrityCheck();
     }
 }

--- a/src/main/java/software/amazon/nio/spi/s3/Crc32cFileIntegrityCheck.java
+++ b/src/main/java/software/amazon/nio/spi/s3/Crc32cFileIntegrityCheck.java
@@ -22,4 +22,9 @@ class Crc32cFileIntegrityCheck extends S3ObjectIntegrityCheck {
         int checksum = (int) calculateChecksum(file);
         putObjectRequest.checksumCRC32C(checksumToBase64String(checksum));
     }
+
+    @Override
+    public S3OpenOption newInstance() {
+        return new Crc32cFileIntegrityCheck();
+    }
 }

--- a/src/main/java/software/amazon/nio/spi/s3/Crc64nvmeFileIntegrityCheck.java
+++ b/src/main/java/software/amazon/nio/spi/s3/Crc64nvmeFileIntegrityCheck.java
@@ -22,4 +22,9 @@ class Crc64nvmeFileIntegrityCheck extends S3ObjectIntegrityCheck {
         long checksum = calculateChecksum(file);
         putObjectRequest.checksumCRC64NVME(checksumToBase64String(checksum));
     }
+
+    @Override
+    public S3OpenOption newInstance() {
+        return new Crc64nvmeFileIntegrityCheck();
+    }
 }

--- a/src/main/java/software/amazon/nio/spi/s3/Crc64nvmeFileIntegrityCheck.java
+++ b/src/main/java/software/amazon/nio/spi/s3/Crc64nvmeFileIntegrityCheck.java
@@ -24,7 +24,7 @@ class Crc64nvmeFileIntegrityCheck extends S3ObjectIntegrityCheck {
     }
 
     @Override
-    public S3OpenOption newInstance() {
+    public S3OpenOption copy() {
         return new Crc64nvmeFileIntegrityCheck();
     }
 }

--- a/src/main/java/software/amazon/nio/spi/s3/S3FileSystem.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3FileSystem.java
@@ -155,6 +155,7 @@ public class S3FileSystem extends FileSystem {
     Set<? extends OpenOption> appendConfiguredOpenOptions(Set<? extends OpenOption> options) {
         var newOptions = new HashSet<OpenOption>(options);
         integrityCheck().ifPresent(newOptions::add);
+        configuration.getOpenOptions().forEach(newOptions::add);
         return newOptions;
     }
 

--- a/src/main/java/software/amazon/nio/spi/s3/S3OpenOption.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3OpenOption.java
@@ -193,7 +193,7 @@ public abstract class S3OpenOption implements OpenOption {
      * 
      * @return new instance
      */
-    public abstract S3OpenOption newInstance();
+    public abstract S3OpenOption copy();
 
     /**
      * Whether the {@link PutObjectRequest} should not be made.

--- a/src/main/java/software/amazon/nio/spi/s3/S3OpenOption.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3OpenOption.java
@@ -9,6 +9,7 @@ import java.nio.file.OpenOption;
 import java.nio.file.Path;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
@@ -19,19 +20,6 @@ import software.amazon.awssdk.services.s3.model.PutObjectResponse;
  * {@link GetObjectRequest}.
  */
 public abstract class S3OpenOption implements OpenOption {
-
-    /**
-     * Removes all {@link S3OpenOption}s from the given set.
-     *
-     * @param options
-     *            options that may contain {@link S3OpenOption}s
-     * @return new set of filtered options
-     */
-    static Set<? extends OpenOption> exclude(Set<? extends OpenOption> options) {
-        return options.stream()
-            .filter(o -> !(o instanceof S3OpenOption))
-            .collect(Collectors.toSet());
-    }
 
     /**
      * Sets an HTTP <code>If-Match</code> header for the {@link PutObjectRequest} with a previously read ETag from the
@@ -63,12 +51,10 @@ public abstract class S3OpenOption implements OpenOption {
      * <code>FileChannel.force</code>) a checksum is calculated again and compared to the previously stored one. If the
      * checksum matches, no {@link PutObjectRequest} is performed.
      *
-     * @param checksumAlgorithm
-     *            the algorithm to calculate a checksum
      * @return new instance
      */
-    public static S3OpenOption putOnlyIfModified(S3ObjectIntegrityCheck checksumAlgorithm) {
-        return new S3PutOnlyIfModified(checksumAlgorithm);
+    public static S3OpenOption putOnlyIfModified() {
+        return new S3PutOnlyIfModified(new Crc32FileIntegrityCheck());
     }
 
     /**
@@ -81,10 +67,12 @@ public abstract class S3OpenOption implements OpenOption {
      * <code>FileChannel.force</code>) a checksum is calculated again and compared to the previously stored one. If the
      * checksum matches, no {@link PutObjectRequest} is performed.
      *
+     * @param checksumAlgorithm
+     *            the algorithm to calculate a checksum
      * @return new instance
      */
-    public static S3OpenOption putOnlyIfModified() {
-        return new S3PutOnlyIfModified(new Crc32FileIntegrityCheck());
+    public static S3OpenOption putOnlyIfModified(S3ObjectIntegrityCheck checksumAlgorithm) {
+        return new S3PutOnlyIfModified(checksumAlgorithm);
     }
 
     /**
@@ -109,6 +97,53 @@ public abstract class S3OpenOption implements OpenOption {
      */
     public static S3OpenOption range(int start, int end) {
         return new S3RangeHeader(start, end);
+    }
+
+    /**
+     * Removes all {@link S3OpenOption}s from the given set.
+     *
+     * @param options
+     *            options that may contain {@link S3OpenOption}s
+     * @return new set of filtered options
+     */
+    static Set<OpenOption> removeAll(Set<? extends OpenOption> options) {
+        return options.stream()
+            .filter(o -> !(o instanceof S3OpenOption))
+            .collect(Collectors.toSet());
+    }
+
+    /**
+     * Retains all {@link S3OpenOption}s from the given set.
+     *
+     * @param options
+     *            options that may contain {@link S3OpenOption}s
+     * @return new set of filtered options
+     */
+    static Set<S3OpenOption> retainAll(Set<? extends OpenOption> options) {
+        return options.stream()
+            .flatMap(o -> o instanceof S3OpenOption
+                ? Stream.of((S3OpenOption) o)
+                : Stream.empty())
+            .collect(Collectors.toSet());
+    }
+
+    /**
+     * Enables the usage of the {@code S3TransferManager}.
+     *
+     * <p>
+     * This open options tells the implementation to use the {@code S3TransferManager} for {@code GetObjectRequest} or
+     * {@code PutObjectRequest} requests if applicable. It is meant to be used while opening a {@code FileChannel} or
+     * {@code SeekableByteChannel} on large S3 objects. For small objects (typically smaller than 8 MiB) the
+     * {@code GetObjectRequest} or {@code PutObjectRequest} operations are sufficient.
+     *
+     * <p>
+     * The {@code S3TransferManager} allows you to transfer a single object with enhanced throughput by leveraging
+     * multi-part upload and byte-range fetches to perform transfers in parallel.
+     *
+     * @return same instance
+     */
+    public static S3OpenOption useTransferManager() {
+        return S3UseTransferManager.INSTANCE;
     }
 
     /**
@@ -152,6 +187,13 @@ public abstract class S3OpenOption implements OpenOption {
      */
     protected void consume(PutObjectResponse putObjectResponse, Path file) {
     }
+
+    /**
+     * Creates a new instance unless it is thread-safe.
+     * 
+     * @return new instance
+     */
+    public abstract S3OpenOption newInstance();
 
     /**
      * Whether the {@link PutObjectRequest} should not be made.

--- a/src/main/java/software/amazon/nio/spi/s3/S3PreventConcurrentOverwrite.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3PreventConcurrentOverwrite.java
@@ -43,4 +43,9 @@ class S3PreventConcurrentOverwrite extends S3OpenOption {
     protected void consume(PutObjectResponse putObjectResponse, Path file) {
         eTag = putObjectResponse.eTag();
     }
+
+    @Override
+    public S3OpenOption newInstance() {
+        return new S3PreventConcurrentOverwrite();
+    }
 }

--- a/src/main/java/software/amazon/nio/spi/s3/S3PreventConcurrentOverwrite.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3PreventConcurrentOverwrite.java
@@ -45,7 +45,7 @@ class S3PreventConcurrentOverwrite extends S3OpenOption {
     }
 
     @Override
-    public S3OpenOption newInstance() {
+    public S3OpenOption copy() {
         return new S3PreventConcurrentOverwrite();
     }
 }

--- a/src/main/java/software/amazon/nio/spi/s3/S3PutOnlyIfModified.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3PutOnlyIfModified.java
@@ -41,7 +41,7 @@ class S3PutOnlyIfModified extends S3OpenOption {
     }
 
     @Override
-    public S3OpenOption newInstance() {
+    public S3OpenOption copy() {
         return new S3PutOnlyIfModified(algorithm);
     }
 

--- a/src/main/java/software/amazon/nio/spi/s3/S3PutOnlyIfModified.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3PutOnlyIfModified.java
@@ -41,6 +41,11 @@ class S3PutOnlyIfModified extends S3OpenOption {
     }
 
     @Override
+    public S3OpenOption newInstance() {
+        return new S3PutOnlyIfModified(algorithm);
+    }
+
+    @Override
     protected boolean preventPutObjectRequest(Path file) {
         return checksum == algorithm.calculateChecksum(file);
     }

--- a/src/main/java/software/amazon/nio/spi/s3/S3RangeHeader.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3RangeHeader.java
@@ -33,7 +33,7 @@ class S3RangeHeader extends S3OpenOption {
     }
 
     @Override
-    public S3OpenOption newInstance() {
+    public S3OpenOption copy() {
         return new S3RangeHeader(range);
     }
 }

--- a/src/main/java/software/amazon/nio/spi/s3/S3RangeHeader.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3RangeHeader.java
@@ -14,17 +14,26 @@ class S3RangeHeader extends S3OpenOption {
     private final String range;
 
     S3RangeHeader(int start, int end) {
+        this("bytes=" + start + "-" + end);
         if (start < 0) {
             throw new IllegalArgumentException("start must be non-negative");
         }
         if (end < 0) {
             throw new IllegalArgumentException("end must be non-negative");
         }
-        range = "bytes=" + start + "-" + end;
+    }
+
+    private S3RangeHeader(String range) {
+        this.range = range;
     }
 
     @Override
     public void apply(GetObjectRequest.Builder builder) {
         builder.range(range);
+    }
+
+    @Override
+    public S3OpenOption newInstance() {
+        return new S3RangeHeader(range);
     }
 }

--- a/src/main/java/software/amazon/nio/spi/s3/S3SeekableByteChannel.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3SeekableByteChannel.java
@@ -69,7 +69,7 @@ class S3SeekableByteChannel implements SeekableByteChannel {
             var transferUtil = new S3TransferUtil(s3Client, timeout, timeUnit);
             writeDelegate = new S3WritableByteChannel(s3Path, s3Client, transferUtil, options);
             position = 0L;
-        } else if (options.contains(StandardOpenOption.READ) || S3OpenOption.exclude(options).isEmpty()) {
+        } else if (options.contains(StandardOpenOption.READ) || S3OpenOption.removeAll(options).isEmpty()) {
             LOGGER.debug("using S3ReadAheadByteChannel as read delegate for path '{}'", s3Path.toUri());
             readDelegate =
                 new S3ReadAheadByteChannel(s3Path, config.getMaxFragmentSize(), config.getMaxFragmentNumber(), s3Client, this,

--- a/src/main/java/software/amazon/nio/spi/s3/S3TransferUtil.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3TransferUtil.java
@@ -16,7 +16,6 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.stream.Stream;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.core.FileTransformerConfiguration;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
@@ -26,6 +25,11 @@ import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.transfer.s3.S3TransferManager;
+import software.amazon.awssdk.transfer.s3.model.CompletedFileDownload;
+import software.amazon.awssdk.transfer.s3.model.CompletedFileUpload;
+import software.amazon.awssdk.transfer.s3.model.DownloadFileRequest;
+import software.amazon.awssdk.transfer.s3.model.UploadFileRequest;
 
 final class S3TransferUtil {
     private final S3AsyncClient client;
@@ -39,37 +43,19 @@ final class S3TransferUtil {
     }
 
     void downloadToLocalFile(S3Path path, Path destination, Set<? extends OpenOption> options) throws IOException {
-        var s3OpenOptions = options.stream()
-            .flatMap(o -> o instanceof S3OpenOption
-                ? Stream.of((S3OpenOption) o)
-                : Stream.empty())
-            .toArray(S3OpenOption[]::new);
+        var s3OpenOptions = S3OpenOption.retainAll(options);
         try {
-            var getObjectRequest = GetObjectRequest.builder()
-                .bucket(path.bucketName())
-                .key(path.getKey());
-            for (var option : s3OpenOptions) {
-                option.apply(getObjectRequest);
-            }
-            var transformerConfig = FileTransformerConfiguration.defaultCreateOrReplaceExisting();
-            var responseTransformer = AsyncResponseTransformer.<GetObjectResponse>toFile(destination, transformerConfig);
-            var downloadCompletableFuture = client.getObject(getObjectRequest.build(), responseTransformer);
-
-            GetObjectResponse getObjectResponse;
-            if (timeout != null && timeUnit != null) {
-                getObjectResponse = downloadCompletableFuture.get(timeout, timeUnit);
+            if (s3OpenOptions.contains(S3UseTransferManager.INSTANCE)) {
+                downloadWithTransferManager(path, destination, s3OpenOptions);
             } else {
-                getObjectResponse = downloadCompletableFuture.join();
-            }
-            for (var option : s3OpenOptions) {
-                option.consume(getObjectResponse, destination);
+                downloadWithGetObject(path, destination, s3OpenOptions);
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new IOException("Could not read from path: " + path, e);
-        } catch (TimeoutException | ExecutionException e) {
+        } catch (TimeoutException e) {
             throw new IOException("Could not read from path: " + path, e);
-        } catch (CompletionException e) {
+        } catch (CompletionException | ExecutionException e) {
             // This complicated download handling is the result of omitting an existence check
             // with a head object request, instead we look for a 404 status code if available.
             var cause = e.getCause();
@@ -87,48 +73,131 @@ final class S3TransferUtil {
         }
     }
 
+    private void downloadWithGetObject(S3Path path, Path destination, Set<S3OpenOption> options)
+            throws InterruptedException, ExecutionException, TimeoutException {
+        var getObjectRequest = GetObjectRequest.builder()
+            .bucket(path.bucketName())
+            .key(path.getKey());
+        for (var option : options) {
+            option.apply(getObjectRequest);
+        }
+        var transformerConfig = FileTransformerConfiguration.defaultCreateOrReplaceExisting();
+        var responseTransformer = AsyncResponseTransformer.<GetObjectResponse>toFile(destination, transformerConfig);
+        var downloadCompletableFuture = client.getObject(getObjectRequest.build(), responseTransformer);
+
+        GetObjectResponse getObjectResponse;
+        if (timeout != null && timeUnit != null) {
+            getObjectResponse = downloadCompletableFuture.get(timeout, timeUnit);
+        } else {
+            getObjectResponse = downloadCompletableFuture.join();
+        }
+        for (var option : options) {
+            option.consume(getObjectResponse, destination);
+        }
+    }
+
+    private void downloadWithTransferManager(S3Path path, Path destination, Set<S3OpenOption> options)
+            throws InterruptedException, ExecutionException, TimeoutException {
+        try (var transferManager = S3TransferManager.builder().s3Client(client).build();) {
+            var getObjectRequest = GetObjectRequest.builder()
+                .bucket(path.bucketName())
+                .key(path.getKey());
+            for (var option : options) {
+                option.apply(getObjectRequest);
+            }
+            var downloadRequest = DownloadFileRequest.builder()
+                .getObjectRequest(getObjectRequest.build())
+                .destination(destination)
+                .build();
+            var future = transferManager.downloadFile(downloadRequest)
+                .completionFuture();
+            CompletedFileDownload completedFileDownload;
+            if (timeout != null && timeUnit != null) {
+                completedFileDownload = future.get(timeout, timeUnit);
+            } else {
+                completedFileDownload = future.join();
+            }
+            for (var option : options) {
+                option.consume(completedFileDownload.response(), destination);
+            }
+        }
+    }
+
     void uploadLocalFile(S3Path path, Path localFile, Set<? extends OpenOption> options) throws IOException {
-        var s3OpenOptions = options.stream()
-            .flatMap(o -> o instanceof S3OpenOption
-                ? Stream.of((S3OpenOption) o)
-                : Stream.empty())
-            .toArray(S3OpenOption[]::new);
+        var s3OpenOptions = S3OpenOption.retainAll(options);
         for (var option : s3OpenOptions) {
             if (option.preventPutObjectRequest(localFile)) {
                 return;
             }
         }
         try {
-            var putObjectRequest = PutObjectRequest.builder()
-                .bucket(path.bucketName())
-                .key(path.getKey())
-                .contentType(Files.probeContentType(localFile));
-            for (var option : s3OpenOptions) {
-                option.apply(putObjectRequest, localFile);
-            }
-            var uploadCompletableFuture = client.putObject(putObjectRequest.build(), AsyncRequestBody.fromFile(localFile));
-
-            PutObjectResponse putObjectResponse;
-            if (timeout != null && timeUnit != null) {
-                putObjectResponse = uploadCompletableFuture.get(timeout, timeUnit);
+            if (s3OpenOptions.contains(S3UseTransferManager.INSTANCE)) {
+                uploadWithTransferManager(path, localFile, s3OpenOptions);
             } else {
-                putObjectResponse = uploadCompletableFuture.join();
-            }
-            for (var option : s3OpenOptions) {
-                option.consume(putObjectResponse, localFile);
+                uploadWithPutObject(path, localFile, s3OpenOptions);
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new IOException("Could not write to path: " + path, e);
-        } catch (TimeoutException | ExecutionException e) {
+        } catch (TimeoutException e) {
             throw new IOException("Could not write to path: " + path, e);
-        } catch (CompletionException e) {
+        } catch (CompletionException | ExecutionException e) {
             var cause = e.getCause();
             if (!(cause instanceof AwsServiceException)) {
                 throw new IOException("Could not write to path: " + path, e);
             }
             var s3e = (AwsServiceException) cause;
             throw new S3TransferException("PutObject", path, s3e);
+        }
+    }
+
+    private void uploadWithPutObject(S3Path path, Path localFile, Set<S3OpenOption> options)
+            throws IOException, InterruptedException, ExecutionException, TimeoutException {
+        var putObjectRequest = PutObjectRequest.builder()
+            .bucket(path.bucketName())
+            .key(path.getKey())
+            .contentType(Files.probeContentType(localFile));
+        for (var option : options) {
+            option.apply(putObjectRequest, localFile);
+        }
+        var uploadCompletableFuture = client.putObject(putObjectRequest.build(), AsyncRequestBody.fromFile(localFile));
+
+        PutObjectResponse putObjectResponse;
+        if (timeout != null && timeUnit != null) {
+            putObjectResponse = uploadCompletableFuture.get(timeout, timeUnit);
+        } else {
+            putObjectResponse = uploadCompletableFuture.join();
+        }
+        for (var option : options) {
+            option.consume(putObjectResponse, localFile);
+        }
+    }
+
+    private void uploadWithTransferManager(S3Path path, Path localFile, Set<S3OpenOption> options)
+            throws IOException, InterruptedException, ExecutionException, TimeoutException {
+        try (var transferManager = S3TransferManager.builder().s3Client(client).build()) {
+            var putObjectRequest = PutObjectRequest.builder()
+                .bucket(path.bucketName())
+                .key(path.getKey())
+                .contentType(Files.probeContentType(localFile));
+            for (var option : options) {
+                option.apply(putObjectRequest, localFile);
+            }
+            var uploadCompletableFuture = transferManager.uploadFile(UploadFileRequest.builder()
+                .putObjectRequest(putObjectRequest.build())
+                .source(localFile)
+                .build())
+                .completionFuture();
+
+            CompletedFileUpload putObjectResponse;
+            if (timeout != null && timeUnit != null) {
+                putObjectResponse = uploadCompletableFuture.get(timeout, timeUnit);
+            } else {
+                putObjectResponse = uploadCompletableFuture.join();
+            }
+            for (var option : options) {
+                option.consume(putObjectResponse.response(), localFile);
+            }
         }
     }
 }

--- a/src/main/java/software/amazon/nio/spi/s3/S3UseTransferManager.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3UseTransferManager.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.nio.spi.s3;
+
+/**
+ * This open options tells the implementation to use the {@code S3TransferManager} for {@code GetObjectRequest} or
+ * {@code PutObjectRequest} requests if applicable. The {@code S3TransferManager} allows you to transfer a single object
+ * with enhanced throughput by leveraging multi-part upload and byte-range fetches to perform transfers in parallel.
+ *
+ * <p>
+ * This is meant to be used while opening a {@code FileChannel} or {@code SeekableByteChannel} on large S3 objects. For
+ * small objects (typically smaller than 8 MiB) the {@code GetObjectRequest} or {@code PutObjectRequest} operations are
+ * sufficient.
+ */
+class S3UseTransferManager extends S3OpenOption {
+    static final S3UseTransferManager INSTANCE = new S3UseTransferManager();
+
+    private S3UseTransferManager() {
+        // use INSTANCE
+    }
+
+    @Override
+    public S3OpenOption newInstance() {
+        return INSTANCE;
+    }
+}

--- a/src/main/java/software/amazon/nio/spi/s3/S3UseTransferManager.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3UseTransferManager.java
@@ -23,7 +23,7 @@ class S3UseTransferManager extends S3OpenOption {
     }
 
     @Override
-    public S3OpenOption newInstance() {
+    public S3OpenOption copy() {
         return INSTANCE;
     }
 }

--- a/src/main/java/software/amazon/nio/spi/s3/S3WritableByteChannel.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3WritableByteChannel.java
@@ -52,7 +52,7 @@ class S3WritableByteChannel implements SeekableByteChannel {
                 s3TransferUtil.downloadToLocalFile(path, tempFile, options);
             }
 
-            var localOptions = S3OpenOption.exclude(options);
+            var localOptions = S3OpenOption.removeAll(options);
             localOptions.remove(StandardOpenOption.CREATE_NEW);
             channel = Files.newByteChannel(this.tempFile, localOptions);
         } catch (InterruptedException e) {

--- a/src/main/java/software/amazon/nio/spi/s3/config/S3NioSpiConfiguration.java
+++ b/src/main/java/software/amazon/nio/spi/s3/config/S3NioSpiConfiguration.java
@@ -6,6 +6,7 @@
 package software.amazon.nio.spi.s3.config;
 
 import java.net.URI;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -432,10 +433,12 @@ public class S3NioSpiConfiguration extends HashMap<String, Object> {
      *            the new value; can be null
      * @return this instance
      */
-    public S3NioSpiConfiguration withOpenOptions(Set<S3OpenOption> options) {
+    public S3NioSpiConfiguration withOpenOptions(Collection<S3OpenOption> options) {
         if (options == null) {
             put(S3_OPEN_OPTIONS_PROPERTY, null);
         } else {
+            // verify an open option type appears only once
+            options.stream().collect(Collectors.toMap(o -> o.getClass().getName(), o -> o));
             put(S3_OPEN_OPTIONS_PROPERTY, Set.copyOf(options));
         }
         return this;
@@ -593,7 +596,7 @@ public class S3NioSpiConfiguration extends HashMap<String, Object> {
         @SuppressWarnings("unchecked")
         var options = (Set<S3OpenOption>) getOrDefault(S3_OPEN_OPTIONS_PROPERTY, Set.of());
         // make a defensive copy to ensure that the thread-safetyness is ensured for the consumers
-        return options.stream().map(S3OpenOption::newInstance).collect(Collectors.toSet());
+        return options.stream().map(S3OpenOption::copy).collect(Collectors.toSet());
     }
 
     private void validateIntegrityAlgorithm(String algorithm) {

--- a/src/main/java/software/amazon/nio/spi/s3/config/S3NioSpiConfiguration.java
+++ b/src/main/java/software/amazon/nio/spi/s3/config/S3NioSpiConfiguration.java
@@ -14,12 +14,14 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.services.s3.internal.BucketUtils;
 import software.amazon.awssdk.utils.Pair;
+import software.amazon.nio.spi.s3.S3OpenOption;
 import software.amazon.nio.spi.s3.util.TimeOutUtils;
 
 /**
@@ -113,6 +115,11 @@ public class S3NioSpiConfiguration extends HashMap<String, Object> {
     public static final Set<String> S3_INTEGRITY_CHECK_ALGORITHM_ALLOWED = Set.of(
         "CRC32", "CRC32C", "CRC64NVME", S3_INTEGRITY_CHECK_ALGORITHM_DEFAULT.toUpperCase());
 
+    /**
+     * This configuration is not meant to be configured via System Properties, but to be set programmatically.
+     */
+    static final String S3_OPEN_OPTIONS_PROPERTY = "s3.open-options";
+
     private static final Pattern ENDPOINT_REGEXP = Pattern.compile("(\\w[\\w\\-\\.]*)?(:(\\d+))?");
 
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
@@ -146,6 +153,7 @@ public class S3NioSpiConfiguration extends HashMap<String, Object> {
         put(S3_SPI_TIMEOUT_MEDIUM_PROPERTY, String.valueOf(S3_SPI_TIMEOUT_MEDIUM_DEFAULT));
         put(S3_SPI_TIMEOUT_HIGH_PROPERTY, String.valueOf(S3_SPI_TIMEOUT_HIGH_DEFAULT));
         put(S3_INTEGRITY_CHECK_ALGORITHM_PROPERTY, S3_INTEGRITY_CHECK_ALGORITHM_DEFAULT);
+        put(S3_OPEN_OPTIONS_PROPERTY, Set.of(S3OpenOption.useTransferManager()));
 
         //
         // With the below we pick existing environment variables and system
@@ -398,7 +406,7 @@ public class S3NioSpiConfiguration extends HashMap<String, Object> {
     }
 
     /**
-     * Get the value of the Integrity Check Algorithm
+     * Set the value of the Integrity Check Algorithm
      *
      * @param algorithm the new value; can be null
      * @return this instance
@@ -411,6 +419,25 @@ public class S3NioSpiConfiguration extends HashMap<String, Object> {
         }
         validateIntegrityAlgorithm(algorithm);
 
+        return this;
+    }
+
+    /**
+     * Set the default open options to be used when opening a {@code FileChannel} or {@code SeekableByteChannel}.
+     *
+     * <p>
+     * This configuration is not meant to be configured via System Properties, but to be set programmatically.
+     *
+     * @param options
+     *            the new value; can be null
+     * @return this instance
+     */
+    public S3NioSpiConfiguration withOpenOptions(Set<S3OpenOption> options) {
+        if (options == null) {
+            put(S3_OPEN_OPTIONS_PROPERTY, null);
+        } else {
+            put(S3_OPEN_OPTIONS_PROPERTY, Set.copyOf(options));
+        }
         return this;
     }
 
@@ -552,6 +579,21 @@ public class S3NioSpiConfiguration extends HashMap<String, Object> {
         String algorithm = (String) getOrDefault(S3_INTEGRITY_CHECK_ALGORITHM_PROPERTY, S3_INTEGRITY_CHECK_ALGORITHM_DEFAULT);
         validateIntegrityAlgorithm(algorithm);
         return algorithm;
+    }
+
+    /**
+     * Get default open options to be used when opening a {@code FileChannel} or {@code SeekableByteChannel}.
+     *
+     * <p>
+     * This configuration is not meant to be configured via System Properties, but to be set programmatically.
+     *
+     * @return the open options
+     */
+    public Set<S3OpenOption> getOpenOptions() {
+        @SuppressWarnings("unchecked")
+        var options = (Set<S3OpenOption>) getOrDefault(S3_OPEN_OPTIONS_PROPERTY, Set.of());
+        // make a defensive copy to ensure that the thread-safetyness is ensured for the consumers
+        return options.stream().map(S3OpenOption::newInstance).collect(Collectors.toSet());
     }
 
     private void validateIntegrityAlgorithm(String algorithm) {

--- a/src/test/java/software/amazon/nio/spi/s3/S3OpenOptionTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3OpenOptionTest.java
@@ -13,8 +13,11 @@ import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 
 import java.nio.file.OpenOption;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.BDDAssertions.*;
 import static org.mockito.Mockito.*;
 
 class S3OpenOptionTest {
@@ -85,6 +88,32 @@ class S3OpenOptionTest {
     }
 
     @Test
+    void retainAll() {
+        // When
+        var option1 = StandardOpenOption.CREATE;
+        var option2 = S3OpenOption.preventConcurrentOverwrite();
+        var option3 = StandardOpenOption.WRITE;
+        var option4 = S3OpenOption.putOnlyIfModified();
+        var options = Set.of(option1, option2, option3, option4);
+
+        // Then
+        then(S3OpenOption.retainAll(options)).containsExactlyInAnyOrder(option2, option4);
+    }
+
+    @Test
+    void removeAll() {
+        // When
+        var option1 = StandardOpenOption.CREATE;
+        var option2 = S3OpenOption.preventConcurrentOverwrite();
+        var option3 = StandardOpenOption.WRITE;
+        var option4 = S3OpenOption.putOnlyIfModified();
+        var options = Set.of(option1, option2, option3, option4);
+
+        // Then
+        then(S3OpenOption.removeAll(options)).containsExactlyInAnyOrder(option1, option3);
+    }
+
+    @Test
     void apply_GetObjectRequest_DoesNotModifyByDefault() {
         // Given
         S3OpenOption option = new TestS3OpenOption();
@@ -144,6 +173,11 @@ class S3OpenOptionTest {
 
     // Test implementation of S3OpenOption
     private static class TestS3OpenOption extends S3OpenOption {
-        // Empty implementation for testing default behaviors
+        // implementation for testing default behaviors
+
+        @Override
+        public S3OpenOption newInstance() {
+            throw new UnsupportedOperationException();
+        }
     }
 }

--- a/src/test/java/software/amazon/nio/spi/s3/S3OpenOptionTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3OpenOptionTest.java
@@ -176,7 +176,7 @@ class S3OpenOptionTest {
         // implementation for testing default behaviors
 
         @Override
-        public S3OpenOption newInstance() {
+        public S3OpenOption copy() {
             throw new UnsupportedOperationException();
         }
     }

--- a/src/test/java/software/amazon/nio/spi/s3/S3TransferUtilTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3TransferUtilTest.java
@@ -39,6 +39,36 @@ import software.amazon.awssdk.services.s3.model.S3Exception;
 class S3TransferUtilTest {
 
     @Test
+    @DisplayName("download should succeed (with S3TransferManager but without timeout)")
+    void downloadFileCompletesSuccessfully_useTransferManager_withoutTimeout() throws IOException {
+        var file = mock(S3Path.class);
+
+        var client = mock(S3AsyncClient.class);
+        var responseFuture = completedFuture(GetObjectResponse.builder().build());
+        when(client.getObject(any(GetObjectRequest.class), any(AsyncResponseTransformer.class))).thenReturn(responseFuture);
+
+        var util = new S3TransferUtil(client, null, null);
+        var tmpFile = Files.createTempFile(null, null);
+        var option = S3OpenOption.useTransferManager();
+        assertThatCode(() -> util.downloadToLocalFile(file, tmpFile, Set.of(option))).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("download should succeed (with S3TransferManager and timeout)")
+    void downloadFileCompletesSuccessfully_useTransferManager_withTimeout() throws IOException {
+        var file = mock(S3Path.class);
+
+        var client = mock(S3AsyncClient.class);
+        var responseFuture = completedFuture(GetObjectResponse.builder().build());
+        when(client.getObject(any(GetObjectRequest.class), any(AsyncResponseTransformer.class))).thenReturn(responseFuture);
+
+        var util = new S3TransferUtil(client, 1L, TimeUnit.MINUTES);
+        var tmpFile = Files.createTempFile(null, null);
+        var option = S3OpenOption.useTransferManager();
+        assertThatCode(() -> util.downloadToLocalFile(file, tmpFile, Set.of(option))).doesNotThrowAnyException();
+    }
+
+    @Test
     @DisplayName("download should succeed (with open options)")
     void downloadFileCompletesSuccessfully_withOpenOption() throws IOException {
         var file = mock(S3Path.class);
@@ -191,6 +221,40 @@ class S3TransferUtilTest {
             .isInstanceOf(IOException.class)
             .hasMessage("Could not read from path: somefile")
             .hasCause(exception);
+    }
+
+    @Test
+    @DisplayName("upload should succeed (with S3TransferManager but without timeout)")
+    void uploadFileCompletesSuccessfully_useTransferManager_withoutTimeout() throws IOException {
+        var file = mock(S3Path.class);
+        when(file.bucketName()).thenReturn("a");
+        when(file.getKey()).thenReturn("a");
+
+        var client = mock(S3AsyncClient.class);
+        when(client.putObject(any(PutObjectRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(completedFuture(PutObjectResponse.builder().build()));
+
+        var util = new S3TransferUtil(client, null, null);
+        var tmpFile = Files.createTempFile(null, null);
+        var option = S3OpenOption.useTransferManager();
+        assertThatCode(() -> util.uploadLocalFile(file, tmpFile, Set.of(option))).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("upload should succeed (with S3TransferManager and timeout)")
+    void uploadFileCompletesSuccessfully_useTransferManager_withTimeout() throws IOException {
+        var file = mock(S3Path.class);
+        when(file.bucketName()).thenReturn("a");
+        when(file.getKey()).thenReturn("a");
+
+        var client = mock(S3AsyncClient.class);
+        when(client.putObject(any(PutObjectRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(completedFuture(PutObjectResponse.builder().build()));
+
+        var util = new S3TransferUtil(client, 1L, TimeUnit.MINUTES);
+        var tmpFile = Files.createTempFile(null, null);
+        var option = S3OpenOption.useTransferManager();
+        assertThatCode(() -> util.uploadLocalFile(file, tmpFile, Set.of(option))).doesNotThrowAnyException();
     }
 
     @Test

--- a/src/test/java/software/amazon/nio/spi/s3/config/S3NioSpiConfigurationTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/config/S3NioSpiConfigurationTest.java
@@ -10,6 +10,7 @@ import static com.github.stefanbirkner.systemlambda.SystemLambda.withEnvironment
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.BDDAssertions.entry;
@@ -22,6 +23,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.nio.spi.s3.S3OpenOption;
 
 import static software.amazon.nio.spi.s3.config.S3NioSpiConfiguration.*;
 
@@ -309,6 +311,29 @@ public class S3NioSpiConfigurationTest {
             .execute(() -> then(new S3NioSpiConfiguration().getIntegrityCheckAlgorithm()).isEqualTo("CRC64NVME"));
 
         then(new S3NioSpiConfiguration(Map.of(S3_INTEGRITY_CHECK_ALGORITHM_PROPERTY, "CRC32")).getIntegrityCheckAlgorithm()).isEqualTo("CRC32");
+    }
+
+    @Test
+    public void withAndGetOpenOptions() {
+        // by default `useTransferManager` is set
+        then(config).contains(entry(S3_OPEN_OPTIONS_PROPERTY, Set.of(S3OpenOption.useTransferManager())));
+        then(config.getOpenOptions()).containsExactly(S3OpenOption.useTransferManager());
+
+        // clear all default open options
+        then(config.withOpenOptions(Set.of())).isSameAs(config);
+        then(config).contains(entry(S3_OPEN_OPTIONS_PROPERTY, Set.of()));
+        then(config.getOpenOptions()).isEmpty();
+
+        // set `preventConcurrentOverwrite`
+        var option1 = S3OpenOption.preventConcurrentOverwrite();
+        var option2 = S3OpenOption.putOnlyIfModified();
+        var newOptions = Set.of(option1, option2);
+        then(config.withOpenOptions(newOptions)).isSameAs(config);
+        then(config.getOpenOptions()).hasSize(2);
+        config.getOpenOptions().forEach(o -> {
+            then(o).isInstanceOfAny(option1.getClass(), option2.getClass());
+            then(o).isNotInstanceOf(S3OpenOption.useTransferManager().getClass());
+        });
     }
 
 }

--- a/src/test/java/software/amazon/nio/spi/s3/config/S3NioSpiConfigurationTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/config/S3NioSpiConfigurationTest.java
@@ -8,15 +8,13 @@ import static com.github.stefanbirkner.systemlambda.SystemLambda.restoreSystemPr
 import static com.github.stefanbirkner.systemlambda.SystemLambda.withEnvironmentVariable;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.BDDAssertions.entry;
-
-import static org.assertj.core.api.BDDAssertions.then;
-import static org.assertj.core.api.BDDAssertions.thenExceptionOfType;
+import static org.assertj.core.api.BDDAssertions.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -334,6 +332,16 @@ public class S3NioSpiConfigurationTest {
             then(o).isInstanceOfAny(option1.getClass(), option2.getClass());
             then(o).isNotInstanceOf(S3OpenOption.useTransferManager().getClass());
         });
+    }
+
+    @Test
+    public void withAndGetOpenOptions_duplicateCheck() {
+        thenThrownBy(() -> config.withOpenOptions(List.of(S3OpenOption.useTransferManager(), S3OpenOption.useTransferManager())))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageStartingWith("Duplicate key software.amazon.nio.spi.s3.S3UseTransferManager");
+        thenThrownBy(() -> config.withOpenOptions(List.of(S3OpenOption.preventConcurrentOverwrite(), S3OpenOption.preventConcurrentOverwrite())))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageStartingWith("Duplicate key software.amazon.nio.spi.s3.S3PreventConcurrentOverwrite");
     }
 
 }


### PR DESCRIPTION
The `S3TransferManager` is particularly good for large S3 objects that are to be downloaded from AWS S3 or uploaded to AWS S3. If the S3 objects are small, it is sufficient to do plain `GetObject` or `PutObject` requests. When setting the HTTP `Range` header on an `GetObjectRequest`, e.g. by setting the open option`S3OpenOption.range(start, end)`, the `HeadRequest` can be avoided and thus the latency can be reduced while opening a `FileChannel` or `SeekableByteChannel`. When the `S3TransferManager` is used, the `HeadRequest` will always be performed on download no matter if a `Range` header is present.

By default, the `S3TransferManager` is enabled. But the users of this library can change the defaults. To make this possible, we introduced a method to programmatically change the default open options by calling `withOpenOptions` on the file systems' configuration.

#### Example how to overwrite the default open options
```java
var newDefaults = Set.of(S3OpenOption.putOnlyIfModified());
var fileSystem = (S3FileSystem) path.getFileSystem();
fileSystem .getConfiguration().withOpenOptions(newDefaults);
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
