### PR TITLE
Handle `null` message in `S3TransferException`

### DIFF
--- a/src/main/java/software/amazon/nio/spi/s3/S3TransferException.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3TransferException.java
@@ -70,7 +70,7 @@ public class S3TransferException extends IOException {
 
     private static String message(String method, Path path, AwsServiceException cause) {
         String errorMessage = errorMessage(cause);
-        errorMessage = errorMessage.isEmpty() ? "" : "; " + errorMessage;
+        errorMessage = errorMessage == null || errorMessage.isEmpty() ? "" : "; " + errorMessage;
         return method + " => " + cause.statusCode() + "; " + path + errorMessage;
     }
 

--- a/src/test/java/software/amazon/nio/spi/s3/S3TransferExceptionTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3TransferExceptionTest.java
@@ -58,4 +58,29 @@ class S3TransferExceptionTest {
         assertThat(exception.requestId()).isNull();
         assertThat(exception.statusCode()).isEqualTo(0);
     }
+
+    @Test
+    void test_nullMessage() {
+        var fs = mock(S3FileSystem.class);
+        var provider = mock(FileSystemProvider.class);
+        when(fs.provider()).thenReturn(provider);
+        when(provider.getScheme()).thenReturn("s3");
+        var path = S3Path.getPath(fs, "somefile");
+        var cause = S3Exception.builder()
+            .awsErrorDetails(AwsErrorDetails.builder()
+                .errorCode("NullMessage")
+                .errorMessage(null)
+                .build())
+            .numAttempts(1)
+            .requestId("some-request")
+            .statusCode(400)
+            .build();
+        var exception = new S3TransferException("HeadObject", path, cause);
+        assertThat(exception).hasMessage("HeadObject => 400; somefile");
+        assertThat(exception.errorCode()).isEqualTo("NullMessage");
+        assertThat(exception.errorMessage()).isNull();
+        assertThat(exception.numAttempts()).isEqualTo(1);
+        assertThat(exception.requestId()).isEqualTo("some-request");
+        assertThat(exception.statusCode()).isEqualTo(400);
+    }
 }


### PR DESCRIPTION
I observed in production that an error message of an `AwsServiceException` can be `null`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
