### PR TITLE
Add option to prevent an existing S3 object from being overwritten

### DIFF
--- a/src/main/java/software/amazon/nio/spi/s3/S3AssumeObjectNotExists.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3AssumeObjectNotExists.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.nio.spi.s3;
+
+import java.nio.file.Path;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+/**
+ * Assume that the S3 object does not exist and therefore no download from S3 is needed and an accidental overwrite is
+ * prevented while uploading to S3.
+ *
+ * <p>
+ * This option sets an HTTP <code>If-None-Match</code> header with a wildcard value for the {@link PutObjectRequest},
+ * which tells S3 to proceed with the upload only if the object doesn't already exist.
+ *
+ * <p>
+ * This is meant to be used while opening a {@code FileChannel} or {@code SeekableByteChannel}. Additionally, it
+ * suppresses the download while opening the channel - no {@code GetObjectRequest} is involved. When closing the channel
+ * the <code>If-None-Match</code> header is set to prevent overwriting an existing S3 object.
+ *
+ * <p>
+ * Currently, this option in combination with <code>FileChannel.force</code> is unsupported. The reason is, that
+ * <code>FileChannel.force</code> uploads to S3 and any subsequent <code>force</code> or <code>close</code> would fail
+ * due to the <code>If-None-Match</code> header.
+ */
+class S3AssumeObjectNotExists extends S3OpenOption {
+
+    static final S3AssumeObjectNotExists INSTANCE = new S3AssumeObjectNotExists();
+
+    private S3AssumeObjectNotExists() {
+    }
+
+    @Override
+    protected void apply(PutObjectRequest.Builder putObjectRequest, Path file) {
+        putObjectRequest.ifNoneMatch("*");
+    }
+
+    @Override
+    public S3OpenOption copy() {
+        return INSTANCE;
+    }
+}

--- a/src/main/java/software/amazon/nio/spi/s3/S3OpenOption.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3OpenOption.java
@@ -22,6 +22,30 @@ import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 public abstract class S3OpenOption implements OpenOption {
 
     /**
+     * Assume that the S3 object does not exist and therefore no download from S3 is needed and an accidental overwrite
+     * is prevented while uploading to S3.
+     *
+     * <p>
+     * This option sets an HTTP <code>If-None-Match</code> header with a wildcard value for the
+     * {@link PutObjectRequest}, which tells S3 to proceed with the upload only if the object doesn't already exist.
+     *
+     * <p>
+     * This is meant to be used while opening a {@code FileChannel} or {@code SeekableByteChannel}. Additionally, it
+     * suppresses the download while opening the channel - no {@code GetObjectRequest} is involved. When closing the
+     * channel the <code>If-None-Match</code> header is set to prevent overwriting an existing S3 object.
+     *
+     * <p>
+     * Currently, this option in combination with <code>FileChannel.force</code> is unsupported. The reason is, that
+     * <code>FileChannel.force</code> uploads to S3 and any subsequent <code>force</code> or <code>close</code> would
+     * fail due to the <code>If-None-Match</code> header.
+     *
+     * @return same instance
+     */
+    public static S3OpenOption assumeObjectNotExists() {
+        return S3AssumeObjectNotExists.INSTANCE;
+    }
+
+    /**
      * Sets an HTTP <code>If-Match</code> header for the {@link PutObjectRequest} with a previously read ETag from the
      * {@link GetObjectResponse}.
      *

--- a/src/main/java/software/amazon/nio/spi/s3/S3WritableByteChannel.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3WritableByteChannel.java
@@ -44,11 +44,12 @@ class S3WritableByteChannel implements SeekableByteChannel {
             var fileSystemProvider = (S3FileSystemProvider) path.getFileSystem().provider();
 
             if (options.contains(StandardOpenOption.CREATE_NEW) && fileSystemProvider.exists(client, path)) {
-                throw new FileAlreadyExistsException("File at path:" + path + " already exists");
+                throw new FileAlreadyExistsException(path.toString());
             }
 
             tempFile = path.getFileSystem().createTempFile(path);
-            if (!options.contains(StandardOpenOption.CREATE_NEW)) {
+            if (!options.contains(StandardOpenOption.CREATE_NEW)
+                && !options.contains(S3AssumeObjectNotExists.INSTANCE)) {
                 s3TransferUtil.downloadToLocalFile(path, tempFile, options);
             }
 

--- a/src/test/java/software/amazon/nio/spi/s3/S3PreventOverwriteIfExistsTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3PreventOverwriteIfExistsTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.nio.spi.s3;
+
+import static org.assertj.core.api.BDDAssertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+class S3AssumeObjectNotExistsTest {
+
+    @Test
+    void test_apply() {
+        var putObjectRequest = PutObjectRequest.builder();
+        then(putObjectRequest.build().ifNoneMatch()).isNull();
+        S3AssumeObjectNotExists.INSTANCE.apply(putObjectRequest, null);
+        then(putObjectRequest.build().ifNoneMatch()).isEqualTo("*");
+    }
+
+    @Test
+    void test_copy() {
+        var instance = S3AssumeObjectNotExists.INSTANCE;
+        then(instance.copy())
+            .isSameAs(instance)
+            .isSameAs(S3OpenOption.assumeObjectNotExists())
+            .isSameAs(S3AssumeObjectNotExists.INSTANCE);
+    }
+}


### PR DESCRIPTION
I want to prevent myself from accidentally overwriting existing S3 objects, especially in a scenario where only new objects should be created.

With this change, we introduce a new `OpenOption` that prevents overwriting an existing object by applying an HTTP `If-None-Match=*` header to the corresponding `PutObjectRequest` when closing the underlying `SeekableByteChannel`. Additionally, if this new option is present, no download attempt is made to reduce latency.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
