### PR TITLE
add AwsCredentialsProvider support

### DIFF
--- a/src/main/java/software/amazon/nio/spi/s3/S3ClientProvider.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3ClientProvider.java
@@ -150,9 +150,9 @@ public class S3ClientProvider {
             builder.endpointOverride(endpointUri);
         }
 
-        var credentials = configuration.getCredentials();
-        if (credentials != null) {
-            builder.credentialsProvider(() -> credentials);
+        var credentialsProvider = configuration.getCredentialsProvider();
+        if (credentialsProvider != null) {
+            builder.credentialsProvider(credentialsProvider);
         }
 
         var region = configuration.getRegion();

--- a/src/main/java/software/amazon/nio/spi/s3/config/S3NioSpiConfiguration.java
+++ b/src/main/java/software/amazon/nio/spi/s3/config/S3NioSpiConfiguration.java
@@ -553,7 +553,14 @@ public class S3NioSpiConfiguration extends HashMap<String, Object> {
      */
     public AwsCredentialsProvider getCredentialsProvider() {
         if (containsKey(S3_SPI_CREDENTIALS_PROVIDER_PROPERTY)) {
-            return (AwsCredentialsProvider) get(S3_SPI_CREDENTIALS_PROVIDER_PROPERTY);
+            if (get(S3_SPI_CREDENTIALS_PROVIDER_PROPERTY) instanceof AwsCredentialsProvider) {
+                return (AwsCredentialsProvider) get(S3_SPI_CREDENTIALS_PROVIDER_PROPERTY);
+            } else {
+                logger.warn(
+                        "The value of property '{}' was found, but it is not a type of AwsCredentialsProvider. " +
+                                "Will fallback to AwsCredentials.",
+                        S3_SPI_CREDENTIALS_PROVIDER_PROPERTY);
+            }
         }
 
         final AwsCredentials awsCredentials = getCredentials();

--- a/src/test/java/software/amazon/nio/spi/s3/config/S3NioSpiConfigurationTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/config/S3NioSpiConfigurationTest.java
@@ -55,6 +55,7 @@ public class S3NioSpiConfigurationTest {
         then(config.getBucketName()).isNull();
         then(config.getRegion()).isNull();
         then(config.getCredentials()).isNull();
+        then(config.getCredentialsProvider()).isNull();
         then(config.getForcePathStyle()).isFalse();
         then(config.getTimeoutLow()).isEqualTo(S3_SPI_TIMEOUT_LOW_DEFAULT);
         then(config.getTimeoutMedium()).isEqualTo(S3_SPI_TIMEOUT_MEDIUM_DEFAULT);
@@ -225,7 +226,6 @@ public class S3NioSpiConfigurationTest {
         then(config.getCredentialsProvider()).isSameAs(C1);
         then(config.withCredentialsProvider(C2)).isSameAs(config);
         then(config.getCredentialsProvider()).isSameAs(C2);
-        then(config.withCredentialsProvider(null).getCredentials()).isNull();
         then(config.withCredentialsProvider(C1).withCredentialsProvider(null).getCredentialsProvider()).isNull();
 
         //
@@ -248,6 +248,22 @@ public class S3NioSpiConfigurationTest {
         then(config.withCredentials(null).getCredentials()).isNull();
         then(config.withCredentials(null).withCredentialsProvider(null).getCredentialsProvider()).isNull();
 
+        then(
+                config.withCredentials(C1)
+                        .withCredentialsProvider(null)
+                        .getCredentials()
+        ).isSameAs(C1);
+    }
+
+    @Test
+    public void getCredentialsProviderWithWrongTypeOfObject() {
+
+        final AwsCredentials C1 = AwsBasicCredentials.create("key1", "secret1");
+        config.put(S3_SPI_CREDENTIALS_PROVIDER_PROPERTY, "IAmNotAProvider");
+        then(config.getCredentialsProvider()).isNull();
+
+        then(config.withCredentials(C1)).isSameAs(config);
+        then(config.getCredentials()).isSameAs(C1);
         then(
                 config.withCredentials(C1)
                         .withCredentialsProvider(null)


### PR DESCRIPTION
Issue: (https://github.com/awslabs/aws-java-nio-spi-for-s3/issues/703)

allow pass AwsCredentialsProvider into S3 Client directly, which solve the taken refreshe problem