### PR TITLE
fix: correct AWS_ACCESS_KEY_PROPERTY value to aws.accessKeyId

### DIFF
--- a/src/main/java/software/amazon/nio/spi/s3/config/S3NioSpiConfiguration.java
+++ b/src/main/java/software/amazon/nio/spi/s3/config/S3NioSpiConfiguration.java
@@ -32,7 +32,7 @@ import software.amazon.nio.spi.s3.util.TimeOutUtils;
 public class S3NioSpiConfiguration extends HashMap<String, Object> {
 
     public static final String AWS_REGION_PROPERTY = "aws.region";
-    public static final String AWS_ACCESS_KEY_PROPERTY = "aws.accessKey";
+    public static final String AWS_ACCESS_KEY_PROPERTY = "aws.accessKeyId";
     public static final String AWS_SECRET_ACCESS_KEY_PROPERTY = "aws.secretAccessKey";
 
     /**
@@ -167,7 +167,7 @@ public class S3NioSpiConfiguration extends HashMap<String, Object> {
         // With the below we pick existing environment variables and system
         // properties as overrides of the default aws-nio specific properties.
         // We do not pick aws generic properties like aws.region or
-        // aws.accessKey, leaving the framework and the underlying AWS client
+        // aws.accessKeyId, leaving the framework and the underlying AWS client
         // the possibility to use the standard behaviour.
         //
 


### PR DESCRIPTION
The constant was set to 'aws.accessKey' but the correct AWS SDK system property name is 'aws.accessKeyId', as documented in the README and the AWS SDK for Java credentials documentation.

Fixes #665


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
