### PR TITLE
fix: S3Path.startsWith() throws on root path instead of returning true

### DIFF
--- a/src/main/java/software/amazon/nio/spi/s3/S3Path.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3Path.java
@@ -286,11 +286,17 @@ class S3Path implements Path {
      */
     @Override
     public boolean startsWith(Path other) {
-        return this.equals(other) ||
-            this.fileSystem.equals(other.getFileSystem()) &&
-                this.isAbsolute() == other.isAbsolute() &&
-                this.getNameCount() >= other.getNameCount() &&
-                this.subpath(0, other.getNameCount()).equals(other);
+        if (this.equals(other)) {
+            return true;
+        }
+        if (!this.fileSystem.equals(other.getFileSystem()) || this.isAbsolute() != other.isAbsolute()) {
+            return false;
+        }
+        if (other.getNameCount() == 0) {
+            return true;
+        }
+        return this.getNameCount() >= other.getNameCount() &&
+            this.subpath(0, other.getNameCount()).equals(other);
     }
 
     /**
@@ -332,10 +338,17 @@ class S3Path implements Path {
      */
     @Override
     public boolean endsWith(Path other) {
-        return this.equals(other) ||
-            this.fileSystem == other.getFileSystem() &&
-                this.getNameCount() >= other.getNameCount() &&
-                this.subpath(this.getNameCount() - other.getNameCount(), this.getNameCount()).equals(other);
+        if (this.equals(other)) {
+            return true;
+        }
+        if (this.fileSystem != other.getFileSystem()) {
+            return false;
+        }
+        if (other.getNameCount() == 0) {
+            return false;
+        }
+        return this.getNameCount() >= other.getNameCount() &&
+            this.subpath(this.getNameCount() - other.getNameCount(), this.getNameCount()).equals(other);
     }
 
     /**

--- a/src/test/java/software/amazon/nio/spi/s3/S3PathTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3PathTest.java
@@ -215,6 +215,30 @@ public class S3PathTest {
     }
 
     @Test
+    public void startsWithRootPath() {
+        // Any absolute path in the same filesystem should start with the root
+        assertTrue(absoluteObject.startsWith(root));
+        assertTrue(absoluteDirectory.startsWith(root));
+
+        // The root itself starts with root
+        assertTrue(root.startsWith(root));
+
+        // A resolved path should start with root
+        var resolved = root.resolve("test");
+        assertTrue(resolved.startsWith(root));
+
+        // Relative paths do not start with root (different absoluteness)
+        assertFalse(relativeObject.startsWith(root));
+        assertFalse(relativeDirectory.startsWith(root));
+
+        // Root from a different filesystem should not match
+        var otherFs = (S3FileSystem) provider.getFileSystem(URI.create("s3://other-bucket"));
+        var otherRoot = S3Path.getPath(otherFs, PATH_SEPARATOR);
+        assertFalse(absoluteObject.startsWith(otherRoot));
+        provider.closeFileSystem(otherFs);
+    }
+
+    @Test
     public void testStartsWithString() {
         assertFalse(absoluteObject.startsWith("no"));
         assertFalse(absoluteObject.startsWith("dir1"));
@@ -247,6 +271,17 @@ public class S3PathTest {
         assertFalse(absoluteDirectory.endsWith(S3Path.getPath(fileSystem, "/no/")));
 
         assertTrue(relativeDirectory.endsWith(dir3));
+    }
+
+    @Test
+    public void endsWithRootPath() {
+        // Only root itself ends with root
+        assertTrue(root.endsWith(root));
+
+        // Other paths do not end with root (should return false, not throw)
+        assertFalse(absoluteObject.endsWith(root));
+        assertFalse(absoluteDirectory.endsWith(root));
+        assertFalse(relativeObject.endsWith(root));
     }
 
     @Test


### PR DESCRIPTION
When calling path.startsWith(root) where root has getNameCount() == 0, the code called subpath(0, 0) which threw IllegalArgumentException because endIndex <= beginIndex.

Fixed by adding an early return when other.getNameCount() == 0: if the filesystems match and both paths share the same absoluteness, the path trivially starts with the root.

Also fixed the same potential issue in endsWith() where passing a root path would throw instead of returning false.

Fixes #690

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
