### PR TITLE
feat(streaming-multipart-upload): add streaming multipart uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ target
 # sdkman files
 .sdkmanrc
 
+# jqwik property-based testing database
+.jqwik-database
+
 
 # Internal release documentation (AWS only)
 RELEASE.md

--- a/.kiro/specs/streaming-multipart-upload/.config.kiro
+++ b/.kiro/specs/streaming-multipart-upload/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "d7acff9d-cff3-47ea-bd3d-9f31dad8fc90", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/streaming-multipart-upload/design.md
+++ b/.kiro/specs/streaming-multipart-upload/design.md
@@ -1,0 +1,577 @@
+# Design Document: Streaming Multipart Upload
+
+## Overview
+
+This design introduces a streaming multipart upload capability to the AWS Java NIO SPI for S3 library. The current write path (`S3WritableByteChannel`) buffers all written data to a local temporary file and uploads it as a single object on `close()`. This is inefficient for large files because:
+
+1. It requires local disk space equal to the full object size
+2. No data reaches S3 until the channel is closed
+3. A failure at close time loses all progress
+
+The streaming multipart upload feature uploads parts to S3 incrementally as data is written, using S3's multipart upload API. This reduces memory/disk pressure and provides incremental progress. The feature operates in two modes:
+
+- **Append-Only Mode**: Data is uploaded in parts as it arrives (default when writes are sequential)
+- **Random-Access Mode**: Falls back to the existing temp-file approach when a backward seek is detected
+
+The feature requires the AWS CRT client for high-performance multipart operations and is activated via a new `S3OpenOption`.
+
+## Architecture
+
+```mermaid
+graph TD
+    A[S3FileSystemProvider.newByteChannel] --> B{Has streaming option?}
+    B -->|No| C[S3WritableByteChannel<br/>existing temp-file approach]
+    B -->|Yes| D{CRT client available?}
+    D -->|No| E[Throw UnsupportedOperationException]
+    D -->|Yes| F[S3StreamingMultipartUploadChannel]
+    
+    F --> G{Mode?}
+    G -->|Append-Only| H[Part Buffer]
+    G -->|Random-Access| I[Temp File Delegate]
+    
+    H -->|Buffer full| J[Async Part Upload]
+    J --> K[CompletedPart ETags]
+    K -->|On close| L[CompleteMultipartUpload]
+    
+    I -->|On close| M[S3TransferUtil.uploadLocalFile]
+    
+    H -->|Backward seek| N[Abort + Download Parts]
+    N --> I
+```
+
+### High-Level Flow
+
+1. User opens a channel with `S3OpenOption.streamingMultipartUpload()`
+2. `S3SeekableByteChannel` detects the option and creates an `S3StreamingMultipartUploadChannel` as the write delegate
+3. On first write, `CreateMultipartUpload` is called to initiate the session
+4. Bytes accumulate in a `PartBuffer` until the configured part size is reached
+5. Full buffers are uploaded asynchronously as numbered parts
+6. On `close()`, remaining bytes are flushed as the final part and `CompleteMultipartUpload` is called
+7. If a backward seek occurs, the channel aborts the multipart session, reconstructs a local temp file, and delegates to the existing upload-on-close behavior
+
+## Components and Interfaces
+
+### New Classes
+
+#### `S3StreamingMultipartUpload` (extends `S3OpenOption`)
+
+The open option that activates streaming multipart upload behavior.
+
+```java
+class S3StreamingMultipartUpload extends S3OpenOption {
+    static final long MIN_PART_SIZE = 5 * 1024 * 1024;        // 5 MiB
+    static final long MAX_PART_SIZE = 5L * 1024 * 1024 * 1024; // 5 GiB
+    static final long DEFAULT_PART_SIZE = 8 * 1024 * 1024;     // 8 MiB
+    static final int MAX_PARTS = 10_000;
+    static final int DEFAULT_MAX_IN_FLIGHT = 4;
+
+    private final long partSize;
+    private final int maxInFlight;
+
+    // Factory accessed via S3OpenOption.streamingMultipartUpload()
+    // and S3OpenOption.streamingMultipartUpload(long partSize)
+}
+```
+
+#### `S3StreamingMultipartUploadChannel` (implements `SeekableByteChannel`)
+
+The core channel implementation that manages the multipart upload lifecycle.
+
+```java
+class S3StreamingMultipartUploadChannel implements SeekableByteChannel {
+    // State
+    private enum Mode { APPEND_ONLY, RANDOM_ACCESS }
+    private Mode mode = Mode.APPEND_ONLY;
+    private boolean open = true;
+    private long position = 0;
+    
+    // Multipart upload state
+    private String uploadId;
+    private int nextPartNumber = 1;
+    private final List<CompletedPart> completedParts = new ArrayList<>();
+    private ByteBuffer currentBuffer;
+    
+    // Backpressure
+    private final Semaphore inFlightPermits;
+    private final Queue<CompletableFuture<CompletedPart>> inFlightUploads;
+    
+    // Fallback
+    private S3WritableByteChannel fallbackChannel;
+    
+    // Key methods
+    int write(ByteBuffer src);
+    SeekableByteChannel position(long newPosition);
+    void close();
+    void force();
+}
+```
+
+#### `PartBuffer`
+
+Internal helper that manages the byte buffer for accumulating part data.
+
+```java
+class PartBuffer {
+    private ByteBuffer buffer;
+    private final long partSize;
+    
+    int write(ByteBuffer src);  // Returns bytes written
+    boolean isFull();
+    ByteBuffer flip();          // Prepare for upload
+    int remaining();
+}
+```
+
+### Modified Classes
+
+#### `S3OpenOption`
+
+Add factory methods:
+
+```java
+public static S3OpenOption streamingMultipartUpload() {
+    return new S3StreamingMultipartUpload(
+        S3StreamingMultipartUpload.DEFAULT_PART_SIZE,
+        S3StreamingMultipartUpload.DEFAULT_MAX_IN_FLIGHT
+    );
+}
+
+public static S3OpenOption streamingMultipartUpload(long partSize) {
+    if (partSize < S3StreamingMultipartUpload.MIN_PART_SIZE) {
+        throw new IllegalArgumentException(
+            "Part size must be at least 5 MiB, got: " + partSize);
+    }
+    if (partSize > S3StreamingMultipartUpload.MAX_PART_SIZE) {
+        throw new IllegalArgumentException(
+            "Part size must not exceed 5 GiB, got: " + partSize);
+    }
+    return new S3StreamingMultipartUpload(partSize,
+        S3StreamingMultipartUpload.DEFAULT_MAX_IN_FLIGHT);
+}
+```
+
+#### `S3SeekableByteChannel`
+
+Modify the constructor to detect the streaming multipart upload option and create an `S3StreamingMultipartUploadChannel` as the write delegate instead of `S3WritableByteChannel`:
+
+```java
+if (options.contains(StandardOpenOption.WRITE)) {
+    if (hasStreamingMultipartOption(options)) {
+        validateCrtClient(s3Client);
+        writeDelegate = new S3StreamingMultipartUploadChannel(s3Path, s3Client, options);
+    } else {
+        writeDelegate = new S3WritableByteChannel(s3Path, s3Client, transferUtil, options);
+    }
+}
+```
+
+### Interaction Sequence
+
+```mermaid
+sequenceDiagram
+    participant App as Application
+    participant Ch as StreamingUploadChannel
+    participant Buf as PartBuffer
+    participant S3 as S3AsyncClient
+
+    App->>Ch: write(data)
+    Ch->>S3: CreateMultipartUpload (first write only)
+    S3-->>Ch: uploadId
+    Ch->>Buf: write(data)
+    
+    Note over Buf: Buffer fills to partSize
+    
+    Ch->>S3: UploadPart(part#1, data)
+    S3-->>Ch: ETag
+    Ch->>Ch: store CompletedPart
+    
+    App->>Ch: write(more data)
+    Ch->>Buf: write(more data)
+    
+    App->>Ch: close()
+    Ch->>S3: UploadPart(final part, remaining)
+    S3-->>Ch: ETag
+    Ch->>S3: CompleteMultipartUpload(uploadId, parts[])
+    S3-->>Ch: success
+```
+
+### Fallback Sequence
+
+```mermaid
+sequenceDiagram
+    participant App as Application
+    participant Ch as StreamingUploadChannel
+    participant S3 as S3AsyncClient
+    participant TF as TempFile
+
+    App->>Ch: write(data) [parts 1-3 uploaded]
+    App->>Ch: position(0) [backward seek!]
+    
+    Ch->>S3: AbortMultipartUpload(uploadId)
+    Ch->>TF: create temp file
+    Ch->>Ch: write buffered parts data to temp file
+    Ch->>Ch: mode = RANDOM_ACCESS
+    
+    Note over Ch: Now behaves like S3WritableByteChannel
+    
+    App->>Ch: write(overwrite data)
+    Ch->>TF: write to temp file
+    
+    App->>Ch: close()
+    Ch->>S3: PutObject(temp file)
+```
+
+## Data Models
+
+### Multipart Upload State
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `uploadId` | `String` | S3 multipart upload ID, null until first write |
+| `nextPartNumber` | `int` | Next part number to assign (starts at 1) |
+| `completedParts` | `List<CompletedPart>` | ETags and part numbers of uploaded parts |
+| `mode` | `Mode` | Current mode: APPEND_ONLY or RANDOM_ACCESS |
+| `position` | `long` | Current write position (total bytes written) |
+| `currentBuffer` | `ByteBuffer` | Active part buffer being filled |
+| `partSize` | `long` | Configured part size in bytes |
+| `maxInFlight` | `int` | Maximum concurrent part uploads |
+
+### CompletedPart
+
+```java
+record CompletedPart(int partNumber, String eTag) {}
+```
+
+Maps directly to `software.amazon.awssdk.services.s3.model.CompletedPart` from the AWS SDK.
+
+### Configuration Constants
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `MIN_PART_SIZE` | 5 MiB (5,242,880 bytes) | S3 minimum part size |
+| `MAX_PART_SIZE` | 5 GiB (5,368,709,120 bytes) | S3 maximum part size |
+| `DEFAULT_PART_SIZE` | 8 MiB (8,388,608 bytes) | Default part size |
+| `MAX_PARTS` | 10,000 | S3 maximum parts per upload |
+| `DEFAULT_MAX_IN_FLIGHT` | 4 | Default concurrent uploads |
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: Part size validation accepts only valid range
+
+*For any* long value, the `streamingMultipartUpload(partSize)` factory method SHALL accept it if and only if it is in the range [5 MiB, 5 GiB]; values outside this range SHALL cause an `IllegalArgumentException`.
+
+**Validates: Requirements 2.3, 7.2, 7.3, 11.2**
+
+### Property 2: Buffering threshold triggers upload at exactly part size
+
+*For any* sequence of writes to the channel, a part upload SHALL be initiated if and only if the accumulated bytes in the current buffer reach the configured part size. The uploaded part SHALL contain exactly `partSize` bytes (except for the final part on close).
+
+**Validates: Requirements 2.1, 2.2, 2.4**
+
+### Property 3: Sequential part ordering
+
+*For any* sequence of writes that produces N uploaded parts, the parts SHALL be numbered 1 through N in strictly sequential order, and the `CompleteMultipartUpload` request SHALL contain all N ETags in that same sequential order.
+
+**Validates: Requirements 2.5, 3.5**
+
+### Property 4: Close flushes remaining data
+
+*For any* sequence of writes where the total bytes written is not a multiple of the part size, closing the channel SHALL upload the remaining bytes (less than part size) as the final part and complete the multipart upload session.
+
+**Validates: Requirements 3.2, 5.1, 5.5**
+
+### Property 5: Fallback preserves all written data
+
+*For any* sequence of writes followed by a backward seek, the reconstructed temp file SHALL contain exactly the same bytes (in the same order) as were written to the channel before the seek occurred.
+
+**Validates: Requirements 4.1, 4.2, 4.5**
+
+### Property 6: Close idempotence
+
+*For any* channel state, calling `close()` N times (N ≥ 1) SHALL produce the same observable side effects (S3 API calls) as calling `close()` exactly once.
+
+**Validates: Requirements 5.4**
+
+### Property 7: Position equals total bytes written
+
+*For any* sequence of writes in append-only mode, `position()` SHALL return the sum of all bytes written, and `size()` SHALL equal `position()`.
+
+**Validates: Requirements 10.1, 10.2**
+
+### Property 8: Part limit enforcement
+
+*For any* configured part size, if the total bytes written would require more than 10,000 parts, the channel SHALL throw an `IllegalStateException` before initiating the upload of the 10,001st part, and SHALL abort the active multipart upload session.
+
+**Validates: Requirements 11.1, 11.3, 11.4**
+
+### Property 9: Memory bound invariant
+
+*For any* sequence of writes, the number of allocated part buffers SHALL never exceed `maxInFlight + 1`, bounding total memory consumption to approximately `(maxInFlight + 1) × partSize`.
+
+**Validates: Requirements 6.4**
+
+### Property 10: Configuration-driven streaming option inclusion
+
+*For any* combination of default, environment variable, system property, and programmatic override values for `s3.spi.write.streaming-multipart-upload`, the `getOpenOptions()` method SHALL include an `S3StreamingMultipartUpload` option if and only if the resolved value is `true` (following the override precedence: default → env var → system property → programmatic). When included, the option SHALL be configured with the resolved `s3.spi.write.multipart-part-size` value.
+
+**Validates: Requirements 14.1, 14.2, 14.3, 14.4, 14.5, 14.6, 14.7, 14.8, 14.10**
+
+## Configuration Support for SPI Users
+
+### Overview
+
+SPI users (e.g., GATK, genomics pipelines) interact with S3 through standard `java.nio.file.Files` APIs and cannot pass custom `OpenOption` instances programmatically. To enable streaming multipart uploads for these users, the `S3NioSpiConfiguration` class is extended with two new properties that follow the existing configuration pattern (defaults → env var → system property → programmatic override).
+
+### New Configuration Properties
+
+| Property | Env Var | Type | Default | Description |
+|----------|---------|------|---------|-------------|
+| `s3.spi.write.streaming-multipart-upload` | `S3_SPI_WRITE_STREAMING_MULTIPART_UPLOAD` | `boolean` | `false` | Enables streaming multipart upload in default open options |
+| `s3.spi.write.multipart-part-size` | `S3_SPI_WRITE_MULTIPART_PART_SIZE` | `long` (bytes) | `8388608` (8 MiB) | Part size for streaming multipart uploads |
+
+### Changes to `S3NioSpiConfiguration`
+
+#### New Constants
+
+```java
+/**
+ * The name of the streaming multipart upload enabled property
+ */
+public static final String S3_SPI_WRITE_STREAMING_MULTIPART_UPLOAD_PROPERTY = "s3.spi.write.streaming-multipart-upload";
+/**
+ * The default value of the streaming multipart upload enabled property
+ */
+public static final boolean S3_SPI_WRITE_STREAMING_MULTIPART_UPLOAD_DEFAULT = false;
+/**
+ * The name of the multipart part size property
+ */
+public static final String S3_SPI_WRITE_MULTIPART_PART_SIZE_PROPERTY = "s3.spi.write.multipart-part-size";
+/**
+ * The default value of the multipart part size property (8 MiB)
+ */
+public static final long S3_SPI_WRITE_MULTIPART_PART_SIZE_DEFAULT = 8L * 1024 * 1024;
+```
+
+#### Constructor Changes
+
+In the constructor, the two new properties are added to the defaults map before the env var / system property override loop runs:
+
+```java
+put(S3_SPI_WRITE_STREAMING_MULTIPART_UPLOAD_PROPERTY, String.valueOf(S3_SPI_WRITE_STREAMING_MULTIPART_UPLOAD_DEFAULT));
+put(S3_SPI_WRITE_MULTIPART_PART_SIZE_PROPERTY, String.valueOf(S3_SPI_WRITE_MULTIPART_PART_SIZE_DEFAULT));
+```
+
+Because these properties are added to the map before the existing env var and system property override loops, they automatically participate in the standard override chain:
+1. Default value set in constructor
+2. Environment variable override (e.g., `S3_SPI_WRITE_STREAMING_MULTIPART_UPLOAD=true`)
+3. System property override (e.g., `-Ds3.spi.write.streaming-multipart-upload=true`)
+4. Programmatic override via constructor `overrides` map
+
+#### New Getter Methods
+
+```java
+/**
+ * Get whether streaming multipart upload is enabled.
+ *
+ * @return true if streaming multipart upload is enabled
+ */
+public boolean isStreamingMultipartUploadEnabled() {
+    return Boolean.parseBoolean(
+        (String) getOrDefault(S3_SPI_WRITE_STREAMING_MULTIPART_UPLOAD_PROPERTY,
+            String.valueOf(S3_SPI_WRITE_STREAMING_MULTIPART_UPLOAD_DEFAULT)));
+}
+
+/**
+ * Get the configured multipart part size in bytes.
+ *
+ * @return the configured part size or the default (8 MiB) if not overridden or invalid
+ */
+public long getMultipartPartSize() {
+    return parseLongProperty(
+        S3_SPI_WRITE_MULTIPART_PART_SIZE_PROPERTY,
+        S3_SPI_WRITE_MULTIPART_PART_SIZE_DEFAULT);
+}
+```
+
+#### New Fluent Setter Methods
+
+```java
+/**
+ * Fluently sets whether streaming multipart upload is enabled.
+ *
+ * @param enabled true to enable streaming multipart upload
+ * @return this instance
+ */
+public S3NioSpiConfiguration withStreamingMultipartUpload(boolean enabled) {
+    put(S3_SPI_WRITE_STREAMING_MULTIPART_UPLOAD_PROPERTY, String.valueOf(enabled));
+    return this;
+}
+
+/**
+ * Fluently sets the multipart part size.
+ *
+ * @param partSize the part size in bytes
+ * @return this instance
+ * @throws IllegalArgumentException if partSize is less than 5 MiB or greater than 5 GiB
+ */
+public S3NioSpiConfiguration withMultipartPartSize(long partSize) {
+    if (partSize < S3StreamingMultipartUpload.MIN_PART_SIZE) {
+        throw new IllegalArgumentException("partSize must be at least 5 MiB, got: " + partSize);
+    }
+    if (partSize > S3StreamingMultipartUpload.MAX_PART_SIZE) {
+        throw new IllegalArgumentException("partSize must not exceed 5 GiB, got: " + partSize);
+    }
+    put(S3_SPI_WRITE_MULTIPART_PART_SIZE_PROPERTY, String.valueOf(partSize));
+    return this;
+}
+```
+
+#### Modified `getOpenOptions()` Method
+
+The `getOpenOptions()` method is updated to conditionally include the `S3StreamingMultipartUpload` option based on the configuration:
+
+```java
+public Set<S3OpenOption> getOpenOptions() {
+    @SuppressWarnings("unchecked")
+    var options = (Set<S3OpenOption>) getOrDefault(S3_OPEN_OPTIONS_PROPERTY, Set.of());
+    // make a defensive copy to ensure that the thread-safetyness is ensured for the consumers
+    var result = options.stream().map(S3OpenOption::copy).collect(Collectors.toSet());
+
+    // Add streaming multipart upload option if enabled via configuration
+    if (isStreamingMultipartUploadEnabled()) {
+        result.add(S3OpenOption.streamingMultipartUpload(getMultipartPartSize()));
+    }
+
+    return result;
+}
+```
+
+#### Helper Method
+
+A `parseLongProperty` method is added (analogous to the existing `parseIntProperty`):
+
+```java
+private long parseLongProperty(String propName, long defaultVal) {
+    var propertyVal = (String) get(propName);
+    try {
+        return Long.parseLong(propertyVal);
+    } catch (NumberFormatException e) {
+        logger.warn("the value of '{}' for '{}' is not a long, using default value of '{}'",
+            propertyVal, propName, defaultVal);
+        return defaultVal;
+    }
+}
+```
+
+### Override Precedence Diagram
+
+```mermaid
+graph LR
+    A[Default: false / 8 MiB] --> B[Env Var Override]
+    B --> C[System Property Override]
+    C --> D[Programmatic Override]
+    D --> E[Resolved Value]
+    E --> F{streaming enabled?}
+    F -->|Yes| G[Add S3StreamingMultipartUpload to getOpenOptions]
+    F -->|No| H[No streaming option added]
+```
+
+### Integration with Existing Flow
+
+The configuration-based activation integrates seamlessly with the existing channel creation flow:
+
+1. `S3FileSystem.appendConfiguredOpenOptions()` calls `configuration.getOpenOptions()`
+2. If streaming is enabled via config, the returned set includes `S3StreamingMultipartUpload`
+3. `S3SeekableByteChannel` detects the option and creates `S3StreamingMultipartUploadChannel`
+4. No code changes needed in the channel creation path — it already handles the option
+
+This means SPI users can enable streaming multipart uploads with:
+```bash
+# Environment variable
+export S3_SPI_WRITE_STREAMING_MULTIPART_UPLOAD=true
+export S3_SPI_WRITE_MULTIPART_PART_SIZE=16777216  # 16 MiB
+
+# Or system property
+java -Ds3.spi.write.streaming-multipart-upload=true \
+     -Ds3.spi.write.multipart-part-size=16777216 \
+     -jar my-application.jar
+```
+
+## Error Handling
+
+### Error Categories
+
+| Error | Trigger | Response |
+|-------|---------|----------|
+| `UnsupportedOperationException` | Streaming option without CRT client | Thrown at channel creation |
+| `IllegalArgumentException` | Invalid part size or READ + streaming | Thrown at option creation or channel creation |
+| `IllegalStateException` | Part limit (10,000) exceeded | Abort session, throw on write |
+| `IOException` | Part upload failure | Abort session, propagate on next write/close |
+| `IOException` | CompleteMultipartUpload failure | Attempt abort, then throw |
+| `IOException` | Timeout during part upload | Retry once, then abort and throw |
+
+### Cleanup Strategy
+
+1. **Normal close**: `CompleteMultipartUpload` finalizes the upload
+2. **Error during upload**: `AbortMultipartUpload` cleans up incomplete parts
+3. **JVM shutdown**: Shutdown hook calls `AbortMultipartUpload` if session is active
+4. **Abort failure**: Log warning with upload ID for manual cleanup
+
+### Retry Policy
+
+- Part upload timeout: retry once with the same part data
+- All other failures: no retry, abort immediately
+- `AbortMultipartUpload` failure: log and continue (best-effort cleanup)
+
+## Testing Strategy
+
+### Property-Based Tests (JUnit 5 + jqwik)
+
+The project will use [jqwik](https://jqwik.net/) as the property-based testing library, which integrates with JUnit 5 and is the standard PBT library for Java.
+
+Each property test will:
+- Run a minimum of 100 iterations
+- Be tagged with a comment referencing the design property
+- Use `@Property(tries = 100)` annotation
+
+**Property tests to implement:**
+
+1. **Part size validation** — Generate random longs, verify acceptance/rejection based on [5 MiB, 5 GiB] range
+2. **Buffering threshold** — Generate random write sequences, verify uploads trigger at exactly part size
+3. **Sequential part ordering** — Generate multi-part write sequences, verify part numbers are 1..N
+4. **Close flushes remaining** — Generate writes where total % partSize ≠ 0, verify final part upload
+5. **Fallback data preservation** — Generate writes + backward seek, verify temp file content matches
+6. **Close idempotence** — Generate writes, close multiple times, verify single set of API calls
+7. **Position tracking** — Generate write sequences, verify position() == sum of bytes written
+8. **Part limit enforcement** — Generate writes exceeding 10,000 parts, verify exception
+9. **Memory bound** — Generate rapid writes, verify buffer count ≤ maxInFlight + 1
+10. **Configuration-driven streaming option** — Generate combinations of env var, system property, and programmatic overrides; verify `getOpenOptions()` includes streaming option iff resolved value is `true`
+
+Tag format: `// Feature: streaming-multipart-upload, Property {N}: {description}`
+
+### Unit Tests (JUnit 5 + Mockito)
+
+Unit tests cover specific examples, edge cases, and error conditions:
+
+- Channel creation with/without CRT client
+- Channel creation with READ option (error case)
+- First write initiates multipart session
+- Close without writes does not initiate session
+- Error during upload triggers abort
+- Fallback logs warning message
+- force() completes session and starts new one
+- Shutdown hook registration
+- Timeout retry behavior
+- Option combinations (assumeObjectNotExists, CREATE_NEW, useTransferManager)
+
+### Integration Tests (Testcontainers + LocalStack)
+
+Integration tests verify end-to-end behavior against a real S3-compatible service:
+
+- Write a multi-part object and read it back
+- Verify object content matches written data
+- Verify fallback produces correct object
+- Verify concurrent uploads work correctly
+- Verify backpressure behavior under load

--- a/.kiro/specs/streaming-multipart-upload/requirements.md
+++ b/.kiro/specs/streaming-multipart-upload/requirements.md
@@ -1,0 +1,190 @@
+# Requirements Document
+
+## Introduction
+
+This feature introduces streaming multipart upload support to the AWS Java NIO SPI for S3 library. Currently, all write operations buffer the entire content to a local temporary file and upload it to S3 only when the channel is closed. This approach is memory-inefficient and introduces latency for large files, as no data reaches S3 until the channel is closed.
+
+Streaming multipart upload allows parts to be uploaded to S3 as data arrives, significantly reducing memory usage and improving upload latency for large objects. This feature is available when the AWS CRT (Common Runtime) client is in use and the channel is opened in append-only mode. When random-access writes are detected (backward seeks), the system falls back to the existing temp-file approach since multipart uploads require sequential part ordering.
+
+## Glossary
+
+- **Streaming_Upload_Channel**: A write channel implementation that uploads parts to S3 incrementally as data is written, rather than buffering all data locally before uploading.
+- **Part_Buffer**: An in-memory buffer that accumulates written bytes until it reaches the configured part size threshold, at which point it is uploaded as a single multipart upload part.
+- **Part_Size**: The configurable size threshold (in bytes) at which a filled Part_Buffer is uploaded to S3 as one part of a multipart upload. The minimum is 5 MiB (S3 requirement); the default is 8 MiB.
+- **Multipart_Upload_Session**: The lifecycle of a single S3 multipart upload, from initiation (CreateMultipartUpload) through part uploads (UploadPart) to completion (CompleteMultipartUpload) or abort (AbortMultipartUpload).
+- **Append_Only_Mode**: A write mode where data is only appended sequentially; the position advances forward monotonically and no backward seeks or overwrites of previously written data occur.
+- **Random_Access_Mode**: A write mode where the position may move backward (via seek) and previously written data may be overwritten, requiring the full file to be available locally before upload.
+- **CRT_Client**: The AWS Common Runtime-based S3 async client (`S3CrtAsyncClient`) that provides high-performance multipart upload capabilities.
+- **S3_Open_Option**: A custom `OpenOption` implementation that configures behavior when opening channels to S3 objects.
+- **Fallback**: The process of switching from streaming multipart upload mode to the existing temp-file buffering approach when a backward seek is detected.
+- **S3_Writable_Byte_Channel**: The existing channel implementation that buffers all writes to a local temp file and uploads on close.
+- **Example_Application**: A standalone Java class in the examples source set that demonstrates how to use the streaming multipart upload feature.
+- **README**: The project's top-level README.md documentation file that describes library features, configuration, and usage.
+
+## Requirements
+
+### Requirement 1: Streaming Multipart Upload Open Option
+
+**User Story:** As a developer, I want to opt in to streaming multipart uploads via an open option, so that I can control when the library uses streaming uploads versus the traditional temp-file approach.
+
+#### Acceptance Criteria
+
+1. THE S3_Open_Option class SHALL provide a factory method that returns a streaming multipart upload option instance.
+2. WHEN the streaming multipart upload option is included in the open options set, THE S3FileSystemProvider SHALL create a Streaming_Upload_Channel instead of the default S3_Writable_Byte_Channel.
+3. WHEN the streaming multipart upload option is included without the CRT_Client being in use, THE S3FileSystemProvider SHALL throw an `UnsupportedOperationException` with a message indicating that CRT is required.
+4. WHEN the streaming multipart upload option is combined with `StandardOpenOption.READ`, THE S3FileSystemProvider SHALL throw an `IllegalArgumentException` indicating that streaming upload is write-only.
+
+### Requirement 2: Part Buffering and Upload
+
+**User Story:** As a developer, I want written data to be uploaded to S3 in parts as it accumulates, so that large files do not consume excessive local disk space or memory.
+
+#### Acceptance Criteria
+
+1. THE Streaming_Upload_Channel SHALL accumulate written bytes in a Part_Buffer until the Part_Size threshold is reached.
+2. WHEN the Part_Buffer reaches the Part_Size threshold, THE Streaming_Upload_Channel SHALL initiate an asynchronous upload of that part to S3.
+3. THE Streaming_Upload_Channel SHALL support a configurable Part_Size with a minimum of 5 MiB and a default of 8 MiB.
+4. WHEN a write spans the Part_Size boundary, THE Streaming_Upload_Channel SHALL fill the current Part_Buffer, upload it, and place remaining bytes into a new Part_Buffer.
+5. THE Streaming_Upload_Channel SHALL assign sequential part numbers starting from 1 to each uploaded part.
+
+### Requirement 3: Multipart Upload Lifecycle Management
+
+**User Story:** As a developer, I want the multipart upload session to be managed automatically, so that I do not need to handle S3 multipart API calls directly.
+
+#### Acceptance Criteria
+
+1. WHEN the first write occurs on the Streaming_Upload_Channel, THE Streaming_Upload_Channel SHALL initiate a Multipart_Upload_Session by calling CreateMultipartUpload.
+2. WHEN the channel is closed successfully, THE Streaming_Upload_Channel SHALL upload any remaining bytes in the Part_Buffer as the final part and call CompleteMultipartUpload with all part ETags.
+3. IF an error occurs during any part upload, THEN THE Streaming_Upload_Channel SHALL call AbortMultipartUpload to clean up the incomplete upload.
+4. IF the channel is closed without any writes having occurred, THEN THE Streaming_Upload_Channel SHALL not initiate a Multipart_Upload_Session.
+5. WHEN CompleteMultipartUpload is called, THE Streaming_Upload_Channel SHALL include all part numbers and their corresponding ETags in sequential order.
+
+### Requirement 4: Fallback to Temp-File on Random Access
+
+**User Story:** As a developer, I want the channel to automatically fall back to the temp-file approach when I perform random-access writes, so that my code works correctly regardless of write patterns.
+
+#### Acceptance Criteria
+
+1. WHEN a position is set to a value less than the current write position on the Streaming_Upload_Channel, THE Streaming_Upload_Channel SHALL abort the active Multipart_Upload_Session.
+2. WHEN a backward seek is detected, THE Streaming_Upload_Channel SHALL transition to Random_Access_Mode by creating a local temp file and downloading any previously uploaded parts into it.
+3. WHILE in Random_Access_Mode, THE Streaming_Upload_Channel SHALL behave identically to the existing S3_Writable_Byte_Channel (buffering to temp file and uploading on close).
+4. WHEN the Fallback occurs, THE Streaming_Upload_Channel SHALL log a warning message indicating the transition from streaming to temp-file mode.
+5. WHEN the Fallback occurs after parts have been uploaded, THE Streaming_Upload_Channel SHALL reconstruct the local temp file by downloading the object prefix using the already-uploaded parts data held in memory.
+
+### Requirement 5: Channel Close and Completion
+
+**User Story:** As a developer, I want the channel close operation to finalize the upload reliably, so that my data is fully persisted to S3 when close() returns.
+
+#### Acceptance Criteria
+
+1. WHEN close() is called in Append_Only_Mode, THE Streaming_Upload_Channel SHALL flush the remaining Part_Buffer content as the final part and complete the Multipart_Upload_Session.
+2. WHEN close() is called in Random_Access_Mode, THE Streaming_Upload_Channel SHALL upload the temp file using the existing S3TransferUtil upload mechanism.
+3. IF close() fails during CompleteMultipartUpload, THEN THE Streaming_Upload_Channel SHALL attempt to abort the Multipart_Upload_Session and throw an IOException.
+4. THE Streaming_Upload_Channel SHALL be idempotent on close: calling close() multiple times SHALL have no additional effect after the first successful close.
+5. WHEN the final part is smaller than the Part_Size, THE Streaming_Upload_Channel SHALL upload it as the last part (S3 allows the final part to be smaller than 5 MiB).
+
+### Requirement 6: Concurrency and Backpressure
+
+**User Story:** As a developer, I want the channel to handle concurrent part uploads efficiently without unbounded memory growth, so that the system remains stable under heavy write loads.
+
+#### Acceptance Criteria
+
+1. THE Streaming_Upload_Channel SHALL upload parts asynchronously, allowing the next Part_Buffer to fill while the previous part is being uploaded.
+2. WHILE the number of in-flight part uploads reaches a configurable maximum (default: 4), THE Streaming_Upload_Channel SHALL block subsequent writes until an in-flight upload completes.
+3. IF an in-flight part upload fails, THEN THE Streaming_Upload_Channel SHALL propagate the failure on the next write or close operation.
+4. THE Streaming_Upload_Channel SHALL limit total memory consumption to approximately (max_in_flight + 1) multiplied by Part_Size.
+
+### Requirement 7: Part Size Configuration
+
+**User Story:** As a developer, I want to configure the part size for streaming uploads, so that I can tune performance for my specific workload.
+
+#### Acceptance Criteria
+
+1. THE S3_Open_Option class SHALL provide a factory method that accepts a Part_Size parameter for the streaming multipart upload option.
+2. WHEN a Part_Size less than 5 MiB is specified, THE S3_Open_Option factory method SHALL throw an `IllegalArgumentException` indicating the minimum part size.
+3. WHEN a Part_Size greater than 5 GiB is specified, THE S3_Open_Option factory method SHALL throw an `IllegalArgumentException` indicating the maximum part size.
+4. WHEN no Part_Size is specified, THE Streaming_Upload_Channel SHALL use a default Part_Size of 8 MiB.
+
+### Requirement 8: Integration with Existing Open Options
+
+**User Story:** As a developer, I want streaming multipart upload to work alongside existing S3 open options, so that I can combine features like integrity checks and conditional writes.
+
+#### Acceptance Criteria
+
+1. WHEN the streaming multipart upload option is combined with `S3OpenOption.assumeObjectNotExists()`, THE Streaming_Upload_Channel SHALL skip any initial download and set the `If-None-Match` header on the CompleteMultipartUpload request.
+2. WHEN the streaming multipart upload option is combined with `StandardOpenOption.CREATE_NEW`, THE Streaming_Upload_Channel SHALL verify the object does not exist before initiating the Multipart_Upload_Session.
+3. WHEN the streaming multipart upload option is combined with `S3OpenOption.useTransferManager()`, THE Streaming_Upload_Channel SHALL take precedence (streaming upload is used instead of transfer manager for the upload path).
+4. THE Streaming_Upload_Channel SHALL support the `force()` operation by completing the current Multipart_Upload_Session and starting a new one for subsequent writes.
+
+### Requirement 9: Error Handling and Cleanup
+
+**User Story:** As a developer, I want failed uploads to be cleaned up automatically, so that incomplete multipart uploads do not accumulate in my S3 bucket and incur storage costs.
+
+#### Acceptance Criteria
+
+1. IF the JVM terminates abnormally while a Multipart_Upload_Session is active, THEN THE Streaming_Upload_Channel SHALL register a shutdown hook to attempt AbortMultipartUpload.
+2. IF a timeout occurs during a part upload, THEN THE Streaming_Upload_Channel SHALL retry the part upload once before aborting the session.
+3. WHEN an abort is performed, THE Streaming_Upload_Channel SHALL log the upload ID and the number of parts that were successfully uploaded before the failure.
+4. IF AbortMultipartUpload itself fails, THEN THE Streaming_Upload_Channel SHALL log a warning with the upload ID so the user can manually clean up the incomplete upload.
+
+### Requirement 10: Position and Size Tracking
+
+**User Story:** As a developer, I want accurate position and size reporting from the channel, so that my code can make decisions based on how much data has been written.
+
+#### Acceptance Criteria
+
+1. THE Streaming_Upload_Channel SHALL report the current write position as the total number of bytes written since the channel was opened.
+2. THE Streaming_Upload_Channel SHALL report the channel size as equal to the current write position in Append_Only_Mode.
+3. WHILE in Random_Access_Mode, THE Streaming_Upload_Channel SHALL report size based on the underlying temp file size.
+4. WHEN position() is called, THE Streaming_Upload_Channel SHALL return the value without blocking on in-flight uploads.
+
+### Requirement 11: S3 Part Limits Enforcement
+
+**User Story:** As a developer, I want the streaming upload channel to enforce S3's hard limits on part count and part size, so that uploads never fail due to exceeding S3 service constraints.
+
+#### Acceptance Criteria
+
+1. THE Streaming_Upload_Channel SHALL reject uploads that would exceed 10,000 parts by throwing an `IllegalStateException` with a message indicating the S3 maximum part limit has been reached.
+2. WHEN the configured Part_Size exceeds 5 GiB, THE S3_Open_Option factory method SHALL throw an `IllegalArgumentException` indicating the maximum S3 part size.
+3. WHEN the total data written would require more than 10,000 parts at the configured Part_Size, THE Streaming_Upload_Channel SHALL throw an `IllegalStateException` before initiating the part that would exceed the limit.
+4. IF the part number counter reaches 10,000, THEN THE Streaming_Upload_Channel SHALL abort the active Multipart_Upload_Session and throw an `IllegalStateException` with a descriptive error message including the configured Part_Size and total bytes written.
+
+### Requirement 12: README Documentation
+
+**User Story:** As a developer, I want the README to document streaming multipart upload support, so that I can understand how to configure and use the feature without reading source code.
+
+#### Acceptance Criteria
+
+1. THE README SHALL include a section describing how streaming multipart uploads are supported, including the requirement for the CRT_Client.
+2. THE README SHALL document the configuration options for streaming multipart upload, including Part_Size and maximum in-flight uploads.
+3. THE README SHALL provide a code example demonstrating how to open a channel with the streaming multipart upload option.
+4. THE README SHALL document the fallback behavior that occurs when a backward seek is detected during a streaming upload.
+5. THE README SHALL document the S3 part limits (maximum 10,000 parts, maximum 5 GiB per part, minimum 5 MiB per part) and how they affect the maximum uploadable object size.
+
+### Requirement 13: Example Application
+
+**User Story:** As a developer, I want a working example application demonstrating streaming multipart upload, so that I can quickly understand how to integrate the feature into my own code.
+
+#### Acceptance Criteria
+
+1. THE Example_Application SHALL be located in the examples source set at `src/examples/java/software/amazon/nio/spi/examples/`.
+2. THE Example_Application SHALL demonstrate opening a channel with the streaming multipart upload open option.
+3. THE Example_Application SHALL demonstrate writing data to S3 using the Streaming_Upload_Channel in a loop to illustrate incremental part uploads.
+4. THE Example_Application SHALL demonstrate configuring a custom Part_Size via the S3_Open_Option factory method.
+5. THE Example_Application SHALL include inline comments explaining each step of the streaming upload process.
+
+### Requirement 14: Environment Variable and System Property Configuration for SPI Users
+
+**User Story:** As an SPI user (e.g., GATK), I want to enable streaming multipart uploads via environment variables or system properties, so that I can activate the feature without modifying application code or passing custom open options programmatically.
+
+#### Acceptance Criteria
+
+1. THE S3NioSpiConfiguration SHALL define a property `s3.spi.write.streaming-multipart-upload` that accepts a boolean string value (`true` or `false`) with a default of `false`.
+2. THE S3NioSpiConfiguration SHALL define a property `s3.spi.write.multipart-part-size` that accepts a long value in bytes with a default of 8388608 (8 MiB).
+3. WHEN the environment variable `S3_SPI_WRITE_STREAMING_MULTIPART_UPLOAD` is set to `true`, THE S3NioSpiConfiguration SHALL override the default value of the `s3.spi.write.streaming-multipart-upload` property.
+4. WHEN the system property `s3.spi.write.streaming-multipart-upload` is set to `true`, THE S3NioSpiConfiguration SHALL override the environment variable value of the `s3.spi.write.streaming-multipart-upload` property.
+5. WHEN the environment variable `S3_SPI_WRITE_MULTIPART_PART_SIZE` is set, THE S3NioSpiConfiguration SHALL override the default value of the `s3.spi.write.multipart-part-size` property.
+6. WHEN the system property `s3.spi.write.multipart-part-size` is set, THE S3NioSpiConfiguration SHALL override the environment variable value of the `s3.spi.write.multipart-part-size` property.
+7. WHEN `s3.spi.write.streaming-multipart-upload` resolves to `true`, THE S3NioSpiConfiguration SHALL include an `S3StreamingMultipartUpload` option (configured with the resolved part size) in the set returned by `getOpenOptions()`.
+8. WHEN `s3.spi.write.streaming-multipart-upload` resolves to `false`, THE S3NioSpiConfiguration SHALL not include an `S3StreamingMultipartUpload` option in the set returned by `getOpenOptions()`.
+9. WHEN `s3.spi.write.multipart-part-size` contains a non-numeric value, THE S3NioSpiConfiguration SHALL log a warning and use the default value of 8388608 bytes.
+10. THE S3NioSpiConfiguration SHALL apply overrides in the standard order: defaults, then environment variable, then system property, then programmatic (via constructor overrides map).

--- a/.kiro/specs/streaming-multipart-upload/tasks.md
+++ b/.kiro/specs/streaming-multipart-upload/tasks.md
@@ -1,0 +1,101 @@
+# Tasks
+
+## Task 1: Create S3StreamingMultipartUpload Open Option
+
+- [x] 1.1 Create `S3StreamingMultipartUpload` class extending `S3OpenOption` with constants (MIN_PART_SIZE, MAX_PART_SIZE, DEFAULT_PART_SIZE, MAX_PARTS, DEFAULT_MAX_IN_FLIGHT), configurable partSize and maxInFlight fields, and a `copy()` method
+- [x] 1.2 Add `streamingMultipartUpload()` factory method to `S3OpenOption` returning default instance (8 MiB part size, 4 max in-flight)
+- [x] 1.3 Add `streamingMultipartUpload(long partSize)` factory method to `S3OpenOption` with validation: throw `IllegalArgumentException` if partSize < 5 MiB or > 5 GiB
+- [x] 1.4 Write unit tests for the open option class: factory methods, validation, defaults, copy behavior
+
+## Task 2: Create PartBuffer Helper Class
+
+- [x] 2.1 Create `PartBuffer` class with a `ByteBuffer` of configurable size, `write(ByteBuffer src)` method that copies bytes into the buffer and returns bytes written, `isFull()`, `flip()`, and `remaining()` methods
+- [x] 2.2 Write unit tests for PartBuffer: write fills buffer, isFull detection, boundary writes, flip prepares for reading
+
+## Task 3: Implement S3StreamingMultipartUploadChannel Core
+
+- [x] 3.1 Create `S3StreamingMultipartUploadChannel` implementing `SeekableByteChannel` with mode enum (APPEND_ONLY, RANDOM_ACCESS), position tracking, and open/closed state management
+- [x] 3.2 Implement `write(ByteBuffer src)`: on first write call `CreateMultipartUpload`, accumulate bytes in PartBuffer, trigger async upload when buffer is full, assign sequential part numbers, store CompletedPart ETags
+- [x] 3.3 Implement `close()` for append-only mode: flush remaining buffer as final part, call `CompleteMultipartUpload` with all part ETags in order, make close idempotent
+- [x] 3.4 Implement `position()` and `size()`: position returns total bytes written, size equals position in append-only mode
+- [x] 3.5 Implement `read(ByteBuffer dst)`: throw `NonReadableChannelException` (write-only channel)
+- [x] 3.6 Implement `truncate(long size)`: throw `UnsupportedOperationException`
+
+## Task 4: Implement Backpressure and Concurrency
+
+- [x] 4.1 Add a `Semaphore` with `maxInFlight` permits to control concurrent part uploads; acquire permit before upload, release on completion
+- [x] 4.2 Implement blocking behavior: when all permits are taken, `write()` blocks until an in-flight upload completes and releases a permit
+- [x] 4.3 Implement async failure propagation: track failed futures, check for failures at the start of each `write()` and on `close()`, propagate as `IOException`
+- [x] 4.4 Write unit tests for backpressure: verify writes block at max in-flight, verify failure propagation
+
+## Task 5: Implement Fallback to Temp-File Mode
+
+- [x] 5.1 Implement `position(long newPosition)`: if newPosition < current position, trigger fallback; otherwise update position normally
+- [x] 5.2 Implement fallback logic: abort active multipart session, create temp file, write all previously buffered/uploaded data (from in-memory completed parts data) to temp file, switch mode to RANDOM_ACCESS
+- [x] 5.3 Implement random-access mode write/close: delegate writes to temp file channel, on close upload temp file via `S3TransferUtil.uploadLocalFile()`, report size from temp file
+- [x] 5.4 Log a warning when fallback occurs including the upload ID
+- [x] 5.5 Write unit tests for fallback: backward seek triggers abort, temp file contains correct data, subsequent writes go to temp file, close uploads temp file
+
+## Task 6: Implement Error Handling and Cleanup
+
+- [x] 6.1 Implement abort on part upload failure: catch exceptions from async uploads, call `AbortMultipartUpload`, log upload ID and successful part count
+- [x] 6.2 Implement close failure handling: if `CompleteMultipartUpload` fails, attempt abort then throw `IOException`
+- [x] 6.3 Register JVM shutdown hook on session initiation to call `AbortMultipartUpload` if session is still active; deregister on successful close
+- [x] 6.4 Implement timeout retry: on part upload timeout, retry once before aborting
+- [x] 6.5 Handle abort failure gracefully: log warning with upload ID for manual cleanup
+- [x] 6.6 Write unit tests for error handling: upload failure triggers abort, close failure aborts, shutdown hook registration, timeout retry, abort failure logging
+
+## Task 7: Implement Part Limit Enforcement
+
+- [x] 7.1 Before initiating each part upload, check if `nextPartNumber > MAX_PARTS`; if so, abort the session and throw `IllegalStateException` with descriptive message including configured part size and total bytes written
+- [x] 7.2 Write unit tests for part limit: verify exception at 10,001st part, verify abort is called, verify error message content
+
+## Task 8: Integrate with S3SeekableByteChannel
+
+- [x] 8.1 Modify `S3SeekableByteChannel` constructor to detect `S3StreamingMultipartUpload` option: validate CRT client (throw `UnsupportedOperationException` if not CRT), validate no READ option (throw `IllegalArgumentException`), create `S3StreamingMultipartUploadChannel` as write delegate
+- [x] 8.2 Handle option combinations: `assumeObjectNotExists` skips download and sets If-None-Match on complete; `CREATE_NEW` checks existence before session; `useTransferManager` is overridden by streaming option
+- [x] 8.3 Implement `force()` support: complete current multipart session, start new session for subsequent writes
+- [x] 8.4 Write unit tests for integration: channel creation with various option combinations, CRT validation, force() behavior
+
+## Task 9: Write Property-Based Tests
+
+- [x] 9.1 Add jqwik dependency to build.gradle test dependencies
+- [x] 9.2 Write property test: Part size validation — for any long value, factory accepts iff value in [5 MiB, 5 GiB]
+- [x] 9.3 Write property test: Buffering threshold — for any write sequence, upload triggers at exactly part size
+- [x] 9.4 Write property test: Sequential part ordering — for any multi-part upload, parts numbered 1..N in order
+- [x] 9.5 Write property test: Close flushes remaining — for any writes where total % partSize ≠ 0, final part is uploaded
+- [x] 9.6 Write property test: Fallback data preservation — for any writes + backward seek, temp file matches written data
+- [x] 9.7 Write property test: Close idempotence — for any state, multiple close() calls produce same API calls as one
+- [x] 9.8 Write property test: Position tracking — for any write sequence, position() == sum of bytes written
+- [x] 9.9 Write property test: Part limit enforcement — for writes exceeding 10,000 parts, IllegalStateException thrown
+- [x] 9.10 Write property test: Memory bound — for any writes, buffer count ≤ maxInFlight + 1
+
+## Task 10: Write Integration Tests
+
+- [x] 10.1 Write integration test: streaming upload of multi-part object, read back and verify content matches
+- [x] 10.2 Write integration test: fallback on backward seek produces correct object content
+- [x] 10.3 Write integration test: channel with default options uploads successfully
+- [x] 10.4 Write integration test: force() persists data mid-stream
+
+## Task 11: Update README Documentation
+
+- [x] 11.1 Add "Streaming Multipart Upload" section to README describing the feature, CRT requirement, and when to use it
+- [x] 11.2 Document configuration options: part size, max in-flight uploads, and their defaults
+- [x] 11.3 Add code example showing how to open a channel with `S3OpenOption.streamingMultipartUpload()`
+- [x] 11.4 Document fallback behavior on backward seek
+- [x] 11.5 Document S3 part limits (10,000 parts max, 5 GiB max part, 5 MiB min part) and maximum uploadable object size calculation
+
+## Task 12: Create Example Application
+
+- [x] 12.1 Create `StreamingMultipartUploadDemo.java` in `src/examples/java/software/amazon/nio/spi/examples/` demonstrating: opening a channel with streaming option, writing data in a loop, configuring custom part size, with inline comments explaining each step
+
+## Task 13: Add Configuration Properties to S3NioSpiConfiguration
+
+- [x] 13.1 Add constants `S3_SPI_WRITE_STREAMING_MULTIPART_UPLOAD_PROPERTY` (`s3.spi.write.streaming-multipart-upload`, default `false`) and `S3_SPI_WRITE_MULTIPART_PART_SIZE_PROPERTY` (`s3.spi.write.multipart-part-size`, default `8388608`) to `S3NioSpiConfiguration`
+- [x] 13.2 Register both properties in the constructor defaults map (before the env var / system property override loops) so they participate in the standard override chain: defaults → env var → system property → programmatic
+- [x] 13.3 Add `isStreamingMultipartUploadEnabled()` getter that parses the resolved boolean value, and `getMultipartPartSize()` getter that parses the resolved long value (logging a warning and returning default on parse failure)
+- [x] 13.4 Add `parseLongProperty(String propName, long defaultVal)` private helper method analogous to the existing `parseIntProperty`
+- [x] 13.5 Add fluent setter `withStreamingMultipartUpload(boolean enabled)` and `withMultipartPartSize(long partSize)` (with validation: partSize must be in [5 MiB, 5 GiB])
+- [x] 13.6 Modify `getOpenOptions()` to conditionally add `S3OpenOption.streamingMultipartUpload(getMultipartPartSize())` to the returned set when `isStreamingMultipartUploadEnabled()` returns `true`
+- [x] 13.7 Write unit tests: verify default values, verify env var override, verify system property override, verify programmatic override, verify `getOpenOptions()` includes streaming option when enabled, verify `getOpenOptions()` excludes streaming option when disabled, verify invalid part size logs warning and uses default
+- [x] 13.8 Write property-based test: for any combination of override sources (env var, system property, programmatic), `getOpenOptions()` includes `S3StreamingMultipartUpload` iff the resolved value of `s3.spi.write.streaming-multipart-upload` is `true`, configured with the resolved part size

--- a/.kiro/steering/tech.md
+++ b/.kiro/steering/tech.md
@@ -16,6 +16,7 @@
 - **JUnit 5** - Primary testing framework
 - **AssertJ** - Fluent assertions
 - **Mockito** - Mocking framework
+- **jqwik** - Property-based testing
 - **Testcontainers** - Integration testing with LocalStack
 - **System Lambda** - System property testing utilities
 

--- a/README.md
+++ b/README.md
@@ -290,6 +290,145 @@ To configure timeouts for writing files or opening files for write access, you m
 new S3SeekableByteChannel(s3Path, s3Client, channelOpenOptions, timeout, timeUnit);
 ```
 
+## Streaming Multipart Upload
+
+Streaming multipart upload allows parts to be uploaded to S3 as data is written, rather than buffering everything
+to a local temp file. This reduces memory and disk usage and provides incremental upload progress for large objects.
+
+### Requirements
+
+This feature requires the AWS CRT (Common Runtime) client. If the CRT client is not in use, an
+`UnsupportedOperationException` is thrown when attempting to open a channel with the streaming multipart upload option.
+
+### When to Use
+
+Use streaming multipart upload when writing large objects (greater than 8 MiB) sequentially and you want to minimize
+local disk and memory usage. This is not suitable for random-access write patterns — if a backward seek is detected,
+the channel automatically falls back to the traditional temp-file approach.
+
+### Configuration Options
+
+| Option | Default | Min | Max | Description |
+|--------|---------|-----|-----|-------------|
+| Part size | 8 MiB | 5 MiB | 5 GiB | Size of each part uploaded to S3 |
+| Max in-flight uploads | 4 | — | — | Maximum concurrent part uploads |
+
+Memory usage is approximately `(maxInFlight + 1) × partSize`. With defaults this is about 40 MiB.
+
+### Code Example
+
+```java
+// Open a channel with streaming multipart upload (default 8 MiB parts)
+Set<OpenOption> options = Set.of(
+    StandardOpenOption.WRITE,
+    StandardOpenOption.CREATE,
+    S3OpenOption.streamingMultipartUpload()
+);
+Path s3Path = Paths.get(URI.create("s3://my-bucket/large-file.dat"));
+try (SeekableByteChannel channel = Files.newByteChannel(s3Path, options)) {
+    ByteBuffer buffer = ByteBuffer.allocate(64 * 1024); // 64 KiB write buffer
+    while (hasMoreData()) {
+        fillBuffer(buffer);
+        buffer.flip();
+        channel.write(buffer);
+        buffer.clear();
+    }
+}
+
+// With custom part size (16 MiB)
+Set<OpenOption> options = Set.of(
+    StandardOpenOption.WRITE,
+    StandardOpenOption.CREATE,
+    S3OpenOption.streamingMultipartUpload(16 * 1024 * 1024)
+);
+```
+
+### Environment Variable / System Property Configuration
+
+SPI users who cannot pass custom open options programmatically can enable streaming multipart upload via
+environment variables or system properties:
+
+```bash
+export S3_SPI_WRITE_STREAMING_MULTIPART_UPLOAD=true
+export S3_SPI_WRITE_MULTIPART_PART_SIZE=16777216  # 16 MiB
+export S3_SPI_WRITE_MULTIPART_FALLBACK_ENABLED=true  # enable fallback to temp-file on seeks
+```
+
+Or via system properties:
+
+```bash
+java -Ds3.spi.write.streaming-multipart-upload=true \
+     -Ds3.spi.write.multipart-part-size=16777216 \
+     -Ds3.spi.write.multipart-fallback-enabled=true \
+     -jar my-application.jar
+```
+
+### Fallback Behavior
+
+If any explicit position change is detected (either a backward seek or a forward seek that creates a gap), the
+channel automatically aborts the multipart upload and falls back to the traditional temp-file approach. A warning
+is logged when this occurs. Subsequent writes and the final upload on close behave identically to the standard
+write channel.
+
+This includes:
+- **Backward seeks** — setting position to a value less than the current write position
+- **Forward seeks (gaps)** — setting position to a value greater than the current write position, which would
+  create a zero-filled hole in the data
+
+On a standard filesystem, a forward seek past the end of written data creates a sparse file with implicit zeros
+in the gap. Since streaming multipart upload cannot represent these gaps without materializing potentially large
+amounts of zero bytes through the upload pipeline, the channel falls back to temp-file mode where the filesystem
+handles sparse positioning natively.
+
+Only purely sequential writes (where position advances naturally via `write()`) remain in streaming mode. Calling
+`position(currentPosition)` (a no-op) does not trigger fallback.
+
+#### Enabling Fallback
+
+By default, the channel operates in strict append-only mode: seeks throw `UnsupportedOperationException` and
+part data is not retained in memory after upload. This keeps memory usage bounded to approximately
+`(maxInFlight + 1) × partSize`.
+
+If your use case may involve non-sequential writes (e.g., seeking backward to overwrite a header), you can
+enable fallback to temp-file mode:
+
+```java
+// Enable fallback: seeks trigger temp-file mode instead of throwing
+// Tradeoff: all written data is retained in memory to support reconstruction
+S3OpenOption.streamingMultipartUpload(8 * 1024 * 1024, true)
+```
+
+Or via environment variable / system property:
+```bash
+export S3_SPI_WRITE_MULTIPART_FALLBACK_ENABLED=true
+```
+
+When fallback is enabled:
+- Non-sequential position changes trigger automatic fallback to temp-file mode
+- All part data is retained in memory (total memory usage equals total bytes written)
+- After fallback, the channel behaves identically to the standard write channel
+
+### S3 Part Limits
+
+S3 imposes hard limits on multipart uploads:
+
+| Limit | Value |
+|-------|-------|
+| Maximum parts per upload | 10,000 |
+| Minimum part size | 5 MiB (except the final part) |
+| Maximum part size | 5 GiB |
+
+The maximum uploadable object size is `partSize × 10,000`:
+
+| Part Size | Max Object Size |
+|-----------|-----------------|
+| 8 MiB (default) | ~78 GiB |
+| 100 MiB | ~976 GiB |
+| 5 GiB | ~48.8 TiB (S3 limit is 5 TiB) |
+
+If the part limit is exceeded during a write, the channel aborts the multipart upload and throws an
+`IllegalStateException`. To upload larger objects, configure a larger part size.
+
 ## Design Decisions
 
 As an object store, S3 is not completely analogous to a traditional file system. Therefore, several opinionated decisions

--- a/build.gradle
+++ b/build.gradle
@@ -173,6 +173,8 @@ testing {
                 implementation('org.testcontainers:testcontainers-junit-jupiter:2.0.5')
                 implementation('org.testcontainers:testcontainers-localstack:2.0.5')
                 implementation('org.testcontainers:testcontainers:2.0.5')
+                implementation(platform('software.amazon.awssdk:bom:2.44.1'))
+                implementation('software.amazon.awssdk:s3')
             }
         }
         withType(JvmTestSuite).configureEach {
@@ -189,6 +191,7 @@ testing {
                 implementation('org.mockito:mockito-core:5.23.0')
                 implementation('org.mockito:mockito-junit-jupiter:5.23.0')
                 implementation('com.github.stefanbirkner:system-lambda:1.2.1')
+                implementation('net.jqwik:jqwik:1.8.2')
                 runtimeOnly('ch.qos.logback:logback-classic:1.5.32')
             }
         }

--- a/src/examples/java/software/amazon/nio/spi/examples/StreamingMultipartUploadDemo.java
+++ b/src/examples/java/software/amazon/nio/spi/examples/StreamingMultipartUploadDemo.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.nio.spi.examples;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import software.amazon.nio.spi.s3.S3OpenOption;
+
+/**
+ * Demonstrates streaming multipart upload to S3 using the NIO SPI.
+ *
+ * <p>
+ * This example shows how to upload large objects to S3 incrementally,
+ * with parts being uploaded as data is written rather than buffering
+ * everything to a local temp file.
+ *
+ * <p>
+ * Prerequisites:
+ * <ul>
+ *   <li>AWS CRT client must be on the classpath</li>
+ *   <li>AWS credentials configured (environment, profile, or IAM role)</li>
+ * </ul>
+ *
+ * <p>
+ * Usage: {@code java StreamingMultipartUploadDemo s3://my-bucket/path/to/object.dat}
+ */
+public class StreamingMultipartUploadDemo {
+
+    // Simulated data chunk size for writing (64 KiB per iteration)
+    private static final int WRITE_CHUNK_SIZE = 64 * 1024;
+
+    // Total number of chunks to write (simulates a ~40 MiB upload = 5 parts at default 8 MiB)
+    private static final int TOTAL_CHUNKS = 640;
+
+    // Custom part size: 16 MiB (must be between 5 MiB and 5 GiB)
+    private static final long CUSTOM_PART_SIZE = 16 * 1024 * 1024;
+
+    public static void main(String[] args) throws IOException {
+        if (args.length < 1) {
+            System.err.println("Usage: StreamingMultipartUploadDemo <s3-uri>");
+            System.err.println("  e.g. StreamingMultipartUploadDemo s3://my-bucket/uploads/large-file.dat");
+            System.exit(1);
+        }
+
+        var s3Uri = args[0];
+
+        // Example 1: Streaming upload with default settings (8 MiB parts, 4 concurrent uploads)
+        uploadWithDefaults(s3Uri + "-default.dat");
+
+        // Example 2: Streaming upload with a custom part size (16 MiB parts)
+        uploadWithCustomPartSize(s3Uri + "-custom.dat");
+
+        // Verify: read back both objects and check data integrity
+        verifyUpload(s3Uri + "-default.dat");
+        verifyUpload(s3Uri + "-custom.dat");
+    }
+
+    /**
+     * Demonstrates a streaming multipart upload using default settings.
+     *
+     * <p>
+     * Default configuration:
+     * <ul>
+     *   <li>Part size: 8 MiB — each part is uploaded when the buffer fills to this size</li>
+     *   <li>Max in-flight: 4 — up to 4 parts upload concurrently for throughput</li>
+     * </ul>
+     */
+    private static void uploadWithDefaults(String s3Uri) throws IOException {
+        System.out.println("=== Streaming Upload with Default Settings ===");
+        System.out.println("Target: " + s3Uri);
+
+        var path = Paths.get(URI.create(s3Uri));
+
+        // Step 1: Open a SeekableByteChannel with the streaming multipart upload option.
+        // The streamingMultipartUpload() option tells the provider to upload parts
+        // incrementally as data is written, instead of buffering to a temp file.
+        try (SeekableByteChannel channel = Files.newByteChannel(
+                path,
+                StandardOpenOption.WRITE,
+                StandardOpenOption.CREATE,
+                S3OpenOption.streamingMultipartUpload())) {
+
+            // Step 2: Write data in a loop. As the internal buffer fills to the
+            // configured part size (8 MiB by default), parts are automatically
+            // uploaded to S3 in the background.
+            var buffer = ByteBuffer.allocate(WRITE_CHUNK_SIZE);
+            for (int i = 0; i < TOTAL_CHUNKS; i++) {
+                // Fill the buffer with sample data
+                buffer.clear();
+                fillBuffer(buffer, (byte) (i % 256));
+                buffer.flip();
+
+                // Write to the channel — when enough data accumulates, a part
+                // upload is triggered automatically
+                channel.write(buffer);
+            }
+
+            // Step 3: When the channel is closed (end of try-with-resources),
+            // any remaining buffered data is flushed as the final part and
+            // CompleteMultipartUpload is called to finalize the object in S3.
+            System.out.println("Bytes written: " + channel.position());
+        }
+
+        System.out.println("Upload complete (default settings).\n");
+    }
+
+    /**
+     * Demonstrates a streaming multipart upload with a custom part size.
+     *
+     * <p>
+     * A larger part size means fewer S3 API calls but more memory usage per buffer.
+     * Choose a part size based on your memory constraints and upload size:
+     * <ul>
+     *   <li>Minimum: 5 MiB (S3 requirement)</li>
+     *   <li>Maximum: 5 GiB (S3 requirement)</li>
+     *   <li>Larger parts = fewer API calls, higher memory usage</li>
+     *   <li>Smaller parts = more API calls, lower memory usage</li>
+     * </ul>
+     */
+    private static void uploadWithCustomPartSize(String s3Uri) throws IOException {
+        System.out.println("=== Streaming Upload with Custom Part Size (16 MiB) ===");
+        System.out.println("Target: " + s3Uri);
+
+        var path = Paths.get(URI.create(s3Uri));
+
+        // Step 1: Create the streaming option with a custom part size.
+        // The factory method validates that the part size is within S3's
+        // allowed range [5 MiB, 5 GiB]. An IllegalArgumentException is
+        // thrown if the value is out of range.
+        var streamingOption = S3OpenOption.streamingMultipartUpload(CUSTOM_PART_SIZE);
+
+        // Step 2: Open the channel with the custom streaming option.
+        try (SeekableByteChannel channel = Files.newByteChannel(
+                path,
+                StandardOpenOption.WRITE,
+                StandardOpenOption.CREATE,
+                streamingOption)) {
+
+            // Step 3: Write data incrementally. With a 16 MiB part size,
+            // parts are uploaded less frequently but each part is larger.
+            // This can be more efficient for very large uploads where
+            // reducing the number of S3 API calls is beneficial.
+            var buffer = ByteBuffer.allocate(WRITE_CHUNK_SIZE);
+            for (int i = 0; i < TOTAL_CHUNKS; i++) {
+                buffer.clear();
+                fillBuffer(buffer, (byte) (i % 256));
+                buffer.flip();
+
+                channel.write(buffer);
+
+                // Optional: track progress by checking the channel position
+                if (i > 0 && i % 128 == 0) {
+                    System.out.printf("  Progress: %d MiB written%n", channel.position() / (1024 * 1024));
+                }
+            }
+
+            // Step 4: Close flushes remaining data and completes the upload.
+            System.out.println("Bytes written: " + channel.position());
+        }
+
+        System.out.println("Upload complete (custom part size).\n");
+    }
+
+    /**
+     * Reads back an uploaded object and verifies every byte matches the expected pattern.
+     * The demo writes chunk i with all bytes set to (byte)(i % 256), so we can reconstruct
+     * the expected content and compare.
+     */
+    private static void verifyUpload(String s3Uri) throws IOException {
+        System.out.println("=== Verifying: " + s3Uri + " ===");
+
+        var path = Paths.get(URI.create(s3Uri));
+        byte[] content = Files.readAllBytes(path);
+
+        long expectedSize = (long) TOTAL_CHUNKS * WRITE_CHUNK_SIZE;
+        if (content.length != expectedSize) {
+            System.err.printf("  FAILED: expected %d bytes, got %d bytes%n", expectedSize, content.length);
+            return;
+        }
+
+        // Verify each chunk has the expected byte pattern
+        int errors = 0;
+        for (int chunk = 0; chunk < TOTAL_CHUNKS; chunk++) {
+            byte expectedValue = (byte) (chunk % 256);
+            int offset = chunk * WRITE_CHUNK_SIZE;
+            for (int j = 0; j < WRITE_CHUNK_SIZE; j++) {
+                if (content[offset + j] != expectedValue) {
+                    if (errors < 5) {
+                        System.err.printf("  MISMATCH at byte %d: expected %d, got %d (chunk %d)%n",
+                            offset + j, expectedValue & 0xFF, content[offset + j] & 0xFF, chunk);
+                    }
+                    errors++;
+                }
+            }
+        }
+
+        if (errors == 0) {
+            System.out.printf("  PASSED: all %d bytes verified correctly (%d chunks of %d bytes)%n",
+                content.length, TOTAL_CHUNKS, WRITE_CHUNK_SIZE);
+        } else {
+            System.err.printf("  FAILED: %d byte mismatches found%n", errors);
+        }
+    }
+
+    /**
+     * Fills a ByteBuffer with a repeating byte value.
+     */
+    private static void fillBuffer(ByteBuffer buffer, byte value) {
+        while (buffer.hasRemaining()) {
+            buffer.put(value);
+        }
+    }
+}

--- a/src/integrationTest/java/software/amazon/nio/spi/s3/StreamingMultipartUploadIntegrationTest.java
+++ b/src/integrationTest/java/software/amazon/nio/spi/s3/StreamingMultipartUploadIntegrationTest.java
@@ -84,7 +84,7 @@ public class StreamingMultipartUploadIntegrationTest {
     void fallbackOnBackwardSeek_producesCorrectContent() throws Exception {
         var key = "fallback-test-object.bin";
         var s3Path = createS3Path(key);
-        var option = new S3StreamingMultipartUpload(PART_SIZE, 4);
+        var option = new S3StreamingMultipartUpload(PART_SIZE, 4, true);
 
         // Write enough data to fill at least one part, then seek backward
         int initialSize = PART_SIZE + (PART_SIZE / 2); // 1.5 parts

--- a/src/integrationTest/java/software/amazon/nio/spi/s3/StreamingMultipartUploadIntegrationTest.java
+++ b/src/integrationTest/java/software/amazon/nio/spi/s3/StreamingMultipartUploadIntegrationTest.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.nio.spi.s3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.nio.file.Paths;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+
+@DisplayName("StreamingMultipartUploadChannel integration tests with LocalStack")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class StreamingMultipartUploadIntegrationTest {
+
+    private static final int PART_SIZE = 5 * 1024 * 1024; // 5 MiB (minimum)
+
+    private S3AsyncClient s3Client;
+    private String bucketName;
+
+    @BeforeEach
+    void setUp() {
+        bucketName = "streaming-upload-bucket" + System.currentTimeMillis();
+        Containers.createBucket(bucketName);
+
+        s3Client = S3AsyncClient.builder()
+            .endpointOverride(Containers.LOCAL_STACK_CONTAINER.getEndpoint())
+            .region(Region.of(Containers.LOCAL_STACK_CONTAINER.getRegion()))
+            .credentialsProvider(StaticCredentialsProvider.create(
+                AwsBasicCredentials.create(
+                    Containers.LOCAL_STACK_CONTAINER.getAccessKey(),
+                    Containers.LOCAL_STACK_CONTAINER.getSecretKey())))
+            .forcePathStyle(true)
+            .build();
+    }
+
+    @Test
+    @DisplayName("streaming upload of multi-part object, read back and verify content matches")
+    void streamingUploadMultiPartObject_readBackVerifiesContent() throws Exception {
+        var key = "multipart-test-object.bin";
+        var s3Path = createS3Path(key);
+        var option = new S3StreamingMultipartUpload(PART_SIZE, 4);
+
+        // Write 2.5 parts worth of data (12.5 MiB) to trigger multiple part uploads
+        int totalSize = (int) (PART_SIZE * 2.5);
+        byte[] expectedData = createDeterministicData(totalSize);
+
+        try (var channel = new S3StreamingMultipartUploadChannel(s3Path, s3Client, option)) {
+            // Write in chunks to simulate realistic usage
+            int chunkSize = 64 * 1024; // 64 KiB chunks
+            ByteBuffer writeBuffer = ByteBuffer.allocate(chunkSize);
+            int offset = 0;
+            while (offset < totalSize) {
+                int remaining = Math.min(chunkSize, totalSize - offset);
+                writeBuffer.clear();
+                writeBuffer.put(expectedData, offset, remaining);
+                writeBuffer.flip();
+                channel.write(writeBuffer);
+                offset += remaining;
+            }
+        }
+
+        // Read back the object and verify content matches
+        byte[] actualData = readObject(key);
+        assertThat(actualData).isEqualTo(expectedData);
+    }
+
+    @Test
+    @DisplayName("fallback on backward seek produces correct object content")
+    void fallbackOnBackwardSeek_producesCorrectContent() throws Exception {
+        var key = "fallback-test-object.bin";
+        var s3Path = createS3Path(key);
+        var option = new S3StreamingMultipartUpload(PART_SIZE, 4);
+
+        // Write enough data to fill at least one part, then seek backward
+        int initialSize = PART_SIZE + (PART_SIZE / 2); // 1.5 parts
+        byte[] initialData = createDeterministicData(initialSize);
+
+        // Data to write after seeking back to position 0
+        byte[] overwriteData = "OVERWRITTEN_DATA_AT_START".getBytes();
+
+        try (var channel = new S3StreamingMultipartUploadChannel(s3Path, s3Client, option)) {
+            // Write initial data
+            channel.write(ByteBuffer.wrap(initialData));
+
+            // Seek backward - triggers fallback to temp-file mode
+            channel.position(0);
+
+            // Write overwrite data at position 0
+            channel.write(ByteBuffer.wrap(overwriteData));
+        }
+
+        // Build expected content: overwrite data at start, rest of initial data unchanged
+        byte[] expectedData = Arrays.copyOf(initialData, initialSize);
+        System.arraycopy(overwriteData, 0, expectedData, 0, overwriteData.length);
+
+        // Read back and verify
+        byte[] actualData = readObject(key);
+        assertThat(actualData).isEqualTo(expectedData);
+    }
+
+    @Test
+    @DisplayName("channel with default options uploads successfully")
+    void channelWithDefaultOptions_uploadsSuccessfully() throws Exception {
+        var key = "default-options-test.bin";
+        var s3Path = createS3Path(key);
+        // Use default streaming option (8 MiB part size, 4 max in-flight)
+        var option = new S3StreamingMultipartUpload(
+            S3StreamingMultipartUpload.DEFAULT_PART_SIZE,
+            S3StreamingMultipartUpload.DEFAULT_MAX_IN_FLIGHT);
+
+        // Write just under one part (less than 8 MiB) to test single-part upload on close
+        int dataSize = 1024 * 1024; // 1 MiB
+        byte[] expectedData = createDeterministicData(dataSize);
+
+        try (var channel = new S3StreamingMultipartUploadChannel(s3Path, s3Client, option)) {
+            channel.write(ByteBuffer.wrap(expectedData));
+        }
+
+        // Read back and verify
+        byte[] actualData = readObject(key);
+        assertThat(actualData).isEqualTo(expectedData);
+    }
+
+    @Test
+    @DisplayName("force() persists data mid-stream")
+    void force_persistsDataMidStream() throws Exception {
+        var key = "force-test-object.bin";
+        var s3Path = createS3Path(key);
+        var option = new S3StreamingMultipartUpload(PART_SIZE, 4);
+
+        // Write data and force to persist mid-stream
+        int firstWriteSize = PART_SIZE + (PART_SIZE / 2); // 1.5 parts
+        byte[] firstData = createDeterministicData(firstWriteSize);
+
+        try (var channel = new S3StreamingMultipartUploadChannel(s3Path, s3Client, option)) {
+            channel.write(ByteBuffer.wrap(firstData));
+
+            // Force completes the current session
+            channel.force();
+
+            // Verify the object exists with the first data
+            byte[] midStreamData = readObject(key);
+            assertThat(midStreamData).isEqualTo(firstData);
+
+            // Write more data (starts a new multipart session)
+            int secondWriteSize = PART_SIZE + 1024; // slightly over 1 part
+            byte[] secondData = createDeterministicData(secondWriteSize);
+            channel.write(ByteBuffer.wrap(secondData));
+        }
+
+        // After close, the object should have the second write's data
+        // (force() completed the first session, close() completes the second)
+        int secondWriteSize = PART_SIZE + 1024;
+        byte[] expectedFinalData = createDeterministicData(secondWriteSize);
+        byte[] finalData = readObject(key);
+        assertThat(finalData).isEqualTo(expectedFinalData);
+    }
+
+    // ---- Helper methods ----
+
+    /**
+     * Creates a deterministic byte array of the given size with a repeating pattern.
+     */
+    private byte[] createDeterministicData(int size) {
+        byte[] data = new byte[size];
+        for (int i = 0; i < size; i++) {
+            data[i] = (byte) (i % 251); // Use prime number for varied pattern
+        }
+        return data;
+    }
+
+    /**
+     * Creates an S3Path for the given key in the test bucket.
+     */
+    private S3Path createS3Path(String key) {
+        var path = Paths.get(URI.create(
+            Containers.localStackConnectionEndpoint() + "/" + bucketName + "/" + key));
+        return (S3Path) path;
+    }
+
+    /**
+     * Reads an object from S3 and returns its content as a byte array.
+     */
+    private byte[] readObject(String key) throws Exception {
+        var request = GetObjectRequest.builder()
+            .bucket(bucketName)
+            .key(key)
+            .build();
+
+        return s3Client.getObject(request, AsyncResponseTransformer.toBytes()).get().asByteArray();
+    }
+}

--- a/src/main/java/software/amazon/nio/spi/s3/AsyncS3FileChannel.java
+++ b/src/main/java/software/amazon/nio/spi/s3/AsyncS3FileChannel.java
@@ -37,7 +37,12 @@ public class AsyncS3FileChannel extends AsynchronousFileChannel {
     @Override
     public void force(boolean metaData) throws IOException {
         if (byteChannel.getWriteDelegate() != null) {
-            ((S3WritableByteChannel) byteChannel.getWriteDelegate()).force();
+            var delegate = byteChannel.getWriteDelegate();
+            if (delegate instanceof S3WritableByteChannel) {
+                ((S3WritableByteChannel) delegate).force();
+            } else if (delegate instanceof S3StreamingMultipartUploadChannel) {
+                ((S3StreamingMultipartUploadChannel) delegate).force();
+            }
         }
     }
 

--- a/src/main/java/software/amazon/nio/spi/s3/PartBuffer.java
+++ b/src/main/java/software/amazon/nio/spi/s3/PartBuffer.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.nio.spi.s3;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Internal helper that manages a byte buffer for accumulating part data during streaming multipart uploads.
+ *
+ * <p>
+ * A {@code PartBuffer} wraps a {@link ByteBuffer} of configurable size (the part size) and provides methods to
+ * write data into the buffer, check if it is full, and prepare it for reading (upload).
+ */
+class PartBuffer {
+
+    private final ByteBuffer buffer;
+
+    /**
+     * Creates a new PartBuffer with the specified part size.
+     *
+     * @param partSize the size of the buffer in bytes
+     * @throws IllegalArgumentException if partSize is not positive
+     */
+    PartBuffer(int partSize) {
+        if (partSize <= 0) {
+            throw new IllegalArgumentException("partSize must be positive, got: " + partSize);
+        }
+        this.buffer = ByteBuffer.allocate(partSize);
+    }
+
+    /**
+     * Copies bytes from the source buffer into this part buffer.
+     *
+     * <p>
+     * The number of bytes actually written may be less than {@code src.remaining()} if this buffer fills up.
+     *
+     * @param src the source buffer to copy bytes from
+     * @return the number of bytes written into this buffer
+     */
+    int write(ByteBuffer src) {
+        int bytesToWrite = Math.min(src.remaining(), buffer.remaining());
+        if (bytesToWrite > 0) {
+            // Use a limited view of src to avoid writing more than we can hold
+            int srcLimit = src.limit();
+            src.limit(src.position() + bytesToWrite);
+            buffer.put(src);
+            src.limit(srcLimit);
+        }
+        return bytesToWrite;
+    }
+
+    /**
+     * Returns whether this buffer is full (no remaining capacity for writing).
+     *
+     * @return {@code true} if the buffer has no remaining capacity
+     */
+    boolean isFull() {
+        return buffer.remaining() == 0;
+    }
+
+    /**
+     * Prepares this buffer for reading by flipping the underlying {@link ByteBuffer}.
+     *
+     * <p>
+     * After calling this method, the buffer's position is set to zero and its limit is set to the number of bytes
+     * that were written. This prepares the buffer for uploading its content as a part.
+     *
+     * @return the underlying ByteBuffer, flipped and ready for reading
+     */
+    ByteBuffer flip() {
+        buffer.flip();
+        return buffer;
+    }
+
+    /**
+     * Returns the number of bytes that can still be written into this buffer.
+     *
+     * @return the remaining capacity for writing
+     */
+    int remaining() {
+        return buffer.remaining();
+    }
+}

--- a/src/main/java/software/amazon/nio/spi/s3/S3FileChannel.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3FileChannel.java
@@ -239,7 +239,12 @@ public class S3FileChannel extends FileChannel {
     @Override
     public void force(boolean metaData) throws IOException {
         if (byteChannel.getWriteDelegate() != null) {
-            ((S3WritableByteChannel) byteChannel.getWriteDelegate()).force();
+            var delegate = byteChannel.getWriteDelegate();
+            if (delegate instanceof S3WritableByteChannel) {
+                ((S3WritableByteChannel) delegate).force();
+            } else if (delegate instanceof S3StreamingMultipartUploadChannel) {
+                ((S3StreamingMultipartUploadChannel) delegate).force();
+            }
         }
     }
 

--- a/src/main/java/software/amazon/nio/spi/s3/S3OpenOption.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3OpenOption.java
@@ -171,6 +171,87 @@ public abstract class S3OpenOption implements OpenOption {
     }
 
     /**
+     * Enables streaming multipart upload with default settings (8 MiB part size, 4 max in-flight uploads).
+     *
+     * <p>
+     * When this option is used, data is uploaded to S3 incrementally as it is written to the channel, rather than
+     * buffering all data to a local temporary file. This requires the AWS CRT client to be in use.
+     *
+     * @return new instance with default part size and max in-flight
+     */
+    public static S3OpenOption streamingMultipartUpload() {
+        return new S3StreamingMultipartUpload(
+            S3StreamingMultipartUpload.DEFAULT_PART_SIZE,
+            S3StreamingMultipartUpload.DEFAULT_MAX_IN_FLIGHT
+        );
+    }
+
+    /**
+     * Enables streaming multipart upload with a custom part size and default max in-flight uploads (4).
+     *
+     * <p>
+     * When this option is used, data is uploaded to S3 incrementally as it is written to the channel, rather than
+     * buffering all data to a local temporary file. This requires the AWS CRT client to be in use.
+     *
+     * @param partSize
+     *            the part size in bytes, must be between 5 MiB and 5 GiB
+     * @return new instance with the specified part size
+     * @throws IllegalArgumentException
+     *             if partSize is less than 5 MiB or greater than 5 GiB
+     */
+    public static S3OpenOption streamingMultipartUpload(long partSize) {
+        if (partSize < S3StreamingMultipartUpload.MIN_PART_SIZE) {
+            throw new IllegalArgumentException(
+                "Part size must be at least 5 MiB, got: " + partSize);
+        }
+        if (partSize > S3StreamingMultipartUpload.MAX_PART_SIZE) {
+            throw new IllegalArgumentException(
+                "Part size must not exceed 5 GiB, got: " + partSize);
+        }
+        return new S3StreamingMultipartUpload(partSize,
+            S3StreamingMultipartUpload.DEFAULT_MAX_IN_FLIGHT);
+    }
+
+    /**
+     * Enables streaming multipart upload with a custom part size and fallback control.
+     *
+     * <p>
+     * When {@code fallbackEnabled} is {@code false}, the channel operates in strict append-only mode:
+     * <ul>
+     *   <li>Any call to {@code position()} that changes the current position throws
+     *       {@link UnsupportedOperationException}</li>
+     *   <li>Part data is not retained in memory after upload, significantly reducing memory usage
+     *       for large uploads</li>
+     *   <li>Memory usage is bounded to approximately {@code (maxInFlight + 1) × partSize} instead of
+     *       the total bytes written</li>
+     * </ul>
+     *
+     * <p>
+     * When {@code fallbackEnabled} is {@code true} (the default), the channel retains all written data in memory
+     * so it can reconstruct a temp file if a non-sequential position change is detected.
+     *
+     * @param partSize
+     *            the part size in bytes, must be between 5 MiB and 5 GiB
+     * @param fallbackEnabled
+     *            whether to enable fallback to temp-file mode on seeks (true = enable, false = strict append-only)
+     * @return new instance with the specified configuration
+     * @throws IllegalArgumentException
+     *             if partSize is less than 5 MiB or greater than 5 GiB
+     */
+    public static S3OpenOption streamingMultipartUpload(long partSize, boolean fallbackEnabled) {
+        if (partSize < S3StreamingMultipartUpload.MIN_PART_SIZE) {
+            throw new IllegalArgumentException(
+                "Part size must be at least 5 MiB, got: " + partSize);
+        }
+        if (partSize > S3StreamingMultipartUpload.MAX_PART_SIZE) {
+            throw new IllegalArgumentException(
+                "Part size must not exceed 5 GiB, got: " + partSize);
+        }
+        return new S3StreamingMultipartUpload(partSize,
+            S3StreamingMultipartUpload.DEFAULT_MAX_IN_FLIGHT, fallbackEnabled);
+    }
+
+    /**
      * Adapts the given {@link GetObjectRequest.Builder}.
      *
      * @param getObjectRequest

--- a/src/main/java/software/amazon/nio/spi/s3/S3SeekableByteChannel.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3SeekableByteChannel.java
@@ -23,6 +23,13 @@ import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.nio.spi.s3.util.TimeOutUtils;
 
+/**
+ * A seekable byte channel implementation for S3 that delegates to either a read-ahead channel
+ * for reading or a writable channel for writing. When the streaming multipart upload option is
+ * present, uses {@link S3StreamingMultipartUploadChannel} as the write delegate instead of
+ * {@link S3WritableByteChannel}.
+ */
+
 class S3SeekableByteChannel implements SeekableByteChannel {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(S3SeekableByteChannel.class);
@@ -31,7 +38,7 @@ class S3SeekableByteChannel implements SeekableByteChannel {
     private long position;
     private final S3Path path;
     private final ReadableByteChannel readDelegate;
-    private final S3WritableByteChannel writeDelegate;
+    private final SeekableByteChannel writeDelegate;
 
     private boolean closed;
     private long size = -1L;
@@ -63,12 +70,39 @@ class S3SeekableByteChannel implements SeekableByteChannel {
         }
 
         var config = s3Path.getFileSystem().getConfiguration();
+        var streamingOption = findStreamingOption(options);
+
         if (options.contains(StandardOpenOption.WRITE)) {
-            LOGGER.debug("using S3WritableByteChannel as write delegate for path '{}'", s3Path.toUri());
-            readDelegate = null;
-            var transferUtil = new S3TransferUtil(s3Client, timeout, timeUnit);
-            writeDelegate = new S3WritableByteChannel(s3Path, s3Client, transferUtil, options);
-            position = 0L;
+            if (streamingOption != null) {
+                // Streaming multipart upload path
+                validateStreamingOptions(s3Client, options);
+                LOGGER.debug("using S3StreamingMultipartUploadChannel as write delegate for path '{}'", s3Path.toUri());
+                readDelegate = null;
+
+                // Handle CREATE_NEW: check existence before creating the streaming channel
+                if (options.contains(StandardOpenOption.CREATE_NEW)) {
+                    try {
+                        var fileSystemProvider = (S3FileSystemProvider) s3Path.getFileSystem().provider();
+                        if (fileSystemProvider.exists(s3Client, s3Path)) {
+                            throw new java.nio.file.FileAlreadyExistsException(s3Path.toString());
+                        }
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new IOException("Interrupted while checking object existence: " + s3Path, e);
+                    } catch (java.util.concurrent.TimeoutException e) {
+                        throw new IOException("Timeout while checking object existence: " + s3Path, e);
+                    }
+                }
+
+                writeDelegate = new S3StreamingMultipartUploadChannel(s3Path, s3Client, streamingOption);
+                position = 0L;
+            } else {
+                LOGGER.debug("using S3WritableByteChannel as write delegate for path '{}'", s3Path.toUri());
+                readDelegate = null;
+                var transferUtil = new S3TransferUtil(s3Client, timeout, timeUnit);
+                writeDelegate = new S3WritableByteChannel(s3Path, s3Client, transferUtil, options);
+                position = 0L;
+            }
         } else if (options.contains(StandardOpenOption.READ) || S3OpenOption.removeAll(options).isEmpty()) {
             LOGGER.debug("using S3ReadAheadByteChannel as read delegate for path '{}'", s3Path.toUri());
             readDelegate =
@@ -312,5 +346,98 @@ class S3SeekableByteChannel implements SeekableByteChannel {
      */
     WritableByteChannel getWriteDelegate() {
         return this.writeDelegate;
+    }
+
+    /**
+     * Finds the {@link S3StreamingMultipartUpload} option in the given options set, if present.
+     *
+     * @param options the set of open options
+     * @return the streaming multipart upload option, or null if not present
+     */
+    private static S3StreamingMultipartUpload findStreamingOption(Set<? extends OpenOption> options) {
+        return options.stream()
+            .filter(o -> o instanceof S3StreamingMultipartUpload)
+            .map(o -> (S3StreamingMultipartUpload) o)
+            .findFirst()
+            .orElse(null);
+    }
+
+    /**
+     * Validates that the streaming multipart upload option can be used with the given client and options.
+     *
+     * @param s3Client the S3 async client
+     * @param options the set of open options
+     * @throws UnsupportedOperationException if the client is not a CRT client
+     * @throws IllegalArgumentException if READ option is combined with streaming upload
+     */
+    static void validateStreamingOptions(S3AsyncClient s3Client, Set<? extends OpenOption> options) {
+        // Validate CRT client
+        validateCrtClient(s3Client);
+
+        // Validate no READ option
+        if (options.contains(StandardOpenOption.READ)) {
+            throw new IllegalArgumentException(
+                "Streaming multipart upload is write-only and cannot be combined with READ");
+        }
+    }
+
+    /**
+     * Validates that the given client is a CRT-based S3 client.
+     * The check inspects the class hierarchy for any class or interface name containing "Crt".
+     *
+     * @param s3Client the S3 async client to validate
+     * @throws UnsupportedOperationException if the client is not a CRT client
+     */
+    static void validateCrtClient(S3AsyncClient s3Client) {
+        if (!isCrtClient(s3Client)) {
+            throw new UnsupportedOperationException(
+                "Streaming multipart upload requires the AWS CRT client. "
+                    + "Current client type: " + s3Client.getClass().getName());
+        }
+    }
+
+    /**
+     * Determines if the given client is a CRT-based S3 client by checking the class hierarchy.
+     * If the client is a delegating wrapper (e.g., CacheableS3Client), it unwraps to check the underlying client.
+     */
+    private static boolean isCrtClient(S3AsyncClient s3Client) {
+        S3AsyncClient clientToCheck = s3Client;
+
+        // Walk through the delegation chain, checking each layer for CRT
+        while (clientToCheck != null) {
+            if (hasCrtInHierarchy(clientToCheck.getClass())) {
+                return true;
+            }
+            // Try to unwrap if it's a delegating client
+            if (clientToCheck instanceof software.amazon.awssdk.services.s3.DelegatingS3AsyncClient) {
+                var delegate = ((software.amazon.awssdk.services.s3.DelegatingS3AsyncClient) clientToCheck).delegate();
+                if (delegate instanceof S3AsyncClient && delegate != clientToCheck) {
+                    clientToCheck = (S3AsyncClient) delegate;
+                } else {
+                    break;
+                }
+            } else {
+                break;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Checks if any class or interface in the hierarchy contains "Crt" in its name.
+     */
+    private static boolean hasCrtInHierarchy(Class<?> clazz) {
+        while (clazz != null) {
+            if (clazz.getName().contains("Crt")) {
+                return true;
+            }
+            for (Class<?> iface : clazz.getInterfaces()) {
+                if (iface.getName().contains("Crt")) {
+                    return true;
+                }
+            }
+            clazz = clazz.getSuperclass();
+        }
+        return false;
     }
 }

--- a/src/main/java/software/amazon/nio/spi/s3/S3StreamingMultipartUpload.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3StreamingMultipartUpload.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.nio.spi.s3;
+
+/**
+ * An {@link S3OpenOption} that activates streaming multipart upload behavior.
+ *
+ * <p>
+ * When this option is included in the open options set, the channel will upload parts to S3 incrementally as data is
+ * written, rather than buffering all data to a local temporary file. This reduces memory/disk pressure and provides
+ * incremental upload progress for large objects.
+ *
+ * <p>
+ * This option requires the AWS CRT client to be in use. The channel operates in append-only mode by default; if a
+ * backward seek is detected, it falls back to the existing temp-file approach.
+ *
+ * @see S3OpenOption#streamingMultipartUpload()
+ * @see S3OpenOption#streamingMultipartUpload(long)
+ */
+class S3StreamingMultipartUpload extends S3OpenOption {
+
+    /**
+     * Minimum part size allowed by S3: 5 MiB.
+     */
+    static final long MIN_PART_SIZE = 5 * 1024 * 1024;
+
+    /**
+     * Maximum part size allowed by S3: 5 GiB.
+     */
+    static final long MAX_PART_SIZE = 5L * 1024 * 1024 * 1024;
+
+    /**
+     * Default part size: 8 MiB.
+     */
+    static final long DEFAULT_PART_SIZE = 8 * 1024 * 1024;
+
+    /**
+     * Maximum number of parts allowed by S3 per multipart upload.
+     */
+    static final int MAX_PARTS = 10_000;
+
+    /**
+     * Default maximum number of concurrent in-flight part uploads.
+     */
+    static final int DEFAULT_MAX_IN_FLIGHT = 4;
+
+    private final long partSize;
+    private final int maxInFlight;
+    private final boolean fallbackEnabled;
+
+    S3StreamingMultipartUpload(long partSize, int maxInFlight) {
+        this(partSize, maxInFlight, false);
+    }
+
+    S3StreamingMultipartUpload(long partSize, int maxInFlight, boolean fallbackEnabled) {
+        this.partSize = partSize;
+        this.maxInFlight = maxInFlight;
+        this.fallbackEnabled = fallbackEnabled;
+    }
+
+    /**
+     * Returns the configured part size in bytes.
+     *
+     * @return the part size
+     */
+    long getPartSize() {
+        return partSize;
+    }
+
+    /**
+     * Returns the configured maximum number of concurrent in-flight part uploads.
+     *
+     * @return the max in-flight count
+     */
+    int getMaxInFlight() {
+        return maxInFlight;
+    }
+
+    /**
+     * Returns whether fallback to temp-file mode is enabled on non-sequential position changes.
+     * When disabled, seeks throw {@link UnsupportedOperationException} and part data is not retained in memory.
+     *
+     * @return true if fallback is enabled (default), false if disabled for lower memory usage
+     */
+    boolean isFallbackEnabled() {
+        return fallbackEnabled;
+    }
+
+    @Override
+    public S3OpenOption copy() {
+        return new S3StreamingMultipartUpload(partSize, maxInFlight, fallbackEnabled);
+    }
+}

--- a/src/main/java/software/amazon/nio/spi/s3/S3StreamingMultipartUploadChannel.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3StreamingMultipartUploadChannel.java
@@ -1,0 +1,814 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.nio.spi.s3;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
+import java.nio.channels.FileChannel;
+import java.nio.channels.NonReadableChannelException;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeoutException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.exception.ApiCallAttemptTimeoutException;
+import software.amazon.awssdk.core.exception.ApiCallTimeoutException;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CompletedMultipartUpload;
+import software.amazon.awssdk.services.s3.model.CompletedPart;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.UploadPartRequest;
+
+/**
+ * A write-only {@link SeekableByteChannel} that uploads data to S3 incrementally using the multipart upload API.
+ *
+ * <p>
+ * Data is accumulated in a {@link PartBuffer} until the configured part size is reached, at which point the buffer
+ * is uploaded asynchronously as a numbered part. On {@link #close()}, any remaining buffered data is flushed as the
+ * final part and the multipart upload is completed.
+ *
+ * <p>
+ * This channel operates in append-only mode by default. If a backward seek is detected, it falls back to
+ * the existing temp-file approach.
+ */
+class S3StreamingMultipartUploadChannel implements SeekableByteChannel {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(S3StreamingMultipartUploadChannel.class);
+
+    /**
+     * The operating mode of the channel.
+     */
+    enum Mode {
+        /** Sequential append-only writes; parts are uploaded as they fill. */
+        APPEND_ONLY,
+        /** Random-access mode; delegates to a temp-file channel after a backward seek. */
+        RANDOM_ACCESS
+    }
+
+    // Configuration
+    private final S3Path s3Path;
+    private final S3AsyncClient s3Client;
+    private final int partSize;
+    private final int maxInFlight;
+    private final boolean fallbackEnabled;
+
+    // Channel state
+    private Mode mode = Mode.APPEND_ONLY;
+    private boolean open = true;
+    private long position = 0;
+
+    // Multipart upload state
+    private String uploadId;
+    private int nextPartNumber = 1;
+    private final List<CompletedPart> completedParts = new ArrayList<>();
+    private PartBuffer currentBuffer;
+
+    // Backpressure
+    private final Semaphore inFlightPermits;
+    private final Queue<CompletableFuture<CompletedPart>> inFlightUploads = new ConcurrentLinkedQueue<>();
+
+    // Shutdown hook
+    private Thread shutdownHook;
+
+    // Fallback state (only populated when fallbackEnabled is true)
+    private final List<byte[]> partDataHistory = new ArrayList<>();
+    private Path tempFile;
+    private FileChannel tempFileChannel;
+
+    /**
+     * Creates a new streaming multipart upload channel.
+     *
+     * @param s3Path the S3 path (bucket + key) to upload to
+     * @param s3Client the async S3 client for performing multipart operations
+     * @param option the streaming multipart upload configuration (part size and max in-flight)
+     */
+    S3StreamingMultipartUploadChannel(S3Path s3Path, S3AsyncClient s3Client, S3StreamingMultipartUpload option) {
+        this.s3Path = s3Path;
+        this.s3Client = s3Client;
+        this.partSize = (int) option.getPartSize();
+        this.maxInFlight = option.getMaxInFlight();
+        this.fallbackEnabled = option.isFallbackEnabled();
+        this.inFlightPermits = new Semaphore(maxInFlight);
+        this.currentBuffer = new PartBuffer(partSize);
+    }
+
+    /**
+     * Writes a sequence of bytes from the given buffer to this channel.
+     *
+     * <p>
+     * On the first write, a multipart upload session is initiated via {@code CreateMultipartUpload}. Bytes are
+     * accumulated in the current {@link PartBuffer}. When the buffer is full, it is uploaded asynchronously as a
+     * numbered part.
+     *
+     * @param src the source buffer containing bytes to write
+     * @return the number of bytes written
+     * @throws IOException if an I/O error occurs or a previous async upload failed
+     */
+    @Override
+    public int write(ByteBuffer src) throws IOException {
+        ensureOpen();
+
+        // In random-access mode, delegate to temp file channel
+        if (mode == Mode.RANDOM_ACCESS) {
+            int bytesWritten = tempFileChannel.write(src);
+            position = tempFileChannel.position();
+            return bytesWritten;
+        }
+
+        checkForAsyncFailures();
+
+        if (!src.hasRemaining()) {
+            return 0;
+        }
+
+        // Initiate multipart upload on first write
+        if (uploadId == null) {
+            initiateMultipartUpload();
+        }
+
+        int totalBytesWritten = 0;
+
+        while (src.hasRemaining()) {
+            int bytesWritten = currentBuffer.write(src);
+            totalBytesWritten += bytesWritten;
+            position += bytesWritten;
+
+            if (currentBuffer.isFull()) {
+                uploadCurrentBuffer();
+                currentBuffer = new PartBuffer(partSize);
+            }
+        }
+
+        return totalBytesWritten;
+    }
+
+    /**
+     * Closes this channel, flushing any remaining buffered data as the final part and completing the multipart upload.
+     *
+     * <p>
+     * If no writes have occurred, no multipart session is initiated. This method is idempotent: calling it multiple
+     * times has no additional effect after the first successful close.
+     *
+     * @throws IOException if an I/O error occurs during the final upload or completion
+     */
+    @Override
+    public void close() throws IOException {
+        if (!open) {
+            return;
+        }
+
+        open = false;
+
+        // In random-access mode, upload the temp file and clean up
+        if (mode == Mode.RANDOM_ACCESS) {
+            closeRandomAccessMode();
+            return;
+        }
+
+        // If no writes occurred, nothing to do
+        if (uploadId == null) {
+            return;
+        }
+
+        try {
+            // Wait for all in-flight uploads to complete
+            drainInFlightUploads();
+
+            // Flush remaining buffer as final part (even if smaller than partSize)
+            flushRemainingBuffer();
+
+            // Complete the multipart upload
+            completeMultipartUpload();
+        } catch (IOException e) {
+            abortMultipartUpload();
+            throw e;
+        }
+    }
+
+    /**
+     * Returns this channel's position, which is the total number of bytes written since the channel was opened.
+     *
+     * @return the current write position
+     * @throws IOException if the channel is closed
+     */
+    @Override
+    public long position() throws IOException {
+        ensureOpen();
+        return position;
+    }
+
+    /**
+     * Sets this channel's position.
+     *
+     * <p>
+     * In append-only mode, any explicit repositioning (forward or backward) that changes the current position
+     * triggers a fallback to temp-file mode. A forward seek would create a "hole" (zero-filled gap) in the data
+     * which cannot be represented correctly in a streaming multipart upload without materializing the zeros.
+     * Rather than silently producing incorrect data or writing potentially large amounts of zero bytes through
+     * the upload pipeline, the channel falls back to temp-file mode where sparse positioning is handled natively.
+     *
+     * <p>
+     * In random-access mode, the position is delegated to the temp file channel.
+     *
+     * @param newPosition the new position
+     * @return this channel
+     * @throws IOException if the channel is closed or an I/O error occurs during fallback
+     * @throws IllegalArgumentException if newPosition is negative
+     */
+    @Override
+    public SeekableByteChannel position(long newPosition) throws IOException {
+        ensureOpen();
+
+        if (newPosition < 0) {
+            throw new IllegalArgumentException("newPosition cannot be negative");
+        }
+
+        if (mode == Mode.RANDOM_ACCESS) {
+            tempFileChannel.position(newPosition);
+            position = newPosition;
+            return this;
+        }
+
+        if (newPosition != position) {
+            if (!fallbackEnabled) {
+                throw new UnsupportedOperationException(
+                    "Position change not supported in strict append-only mode (fallback disabled). "
+                        + "Current position: " + position + ", requested: " + newPosition);
+            }
+            // Any explicit repositioning (forward or backward) triggers fallback to temp-file mode.
+            // Forward seeks create gaps that cannot be represented in streaming multipart upload
+            // without zero-filling, which could be extremely expensive for large gaps.
+            fallbackToTempFile(newPosition);
+        }
+
+        return this;
+    }
+
+    /**
+     * Returns the current size of this channel. In append-only mode, this equals the current write position.
+     * In random-access mode, this delegates to the temp file channel.
+     *
+     * @return the current size in bytes
+     * @throws IOException if the channel is closed
+     */
+    @Override
+    public long size() throws IOException {
+        ensureOpen();
+        if (mode == Mode.RANDOM_ACCESS) {
+            return tempFileChannel.size();
+        }
+        return position;
+    }
+
+    /**
+     * Always throws {@link NonReadableChannelException} because this is a write-only channel.
+     *
+     * @param dst the destination buffer (unused)
+     * @return never returns normally
+     * @throws NonReadableChannelException always
+     */
+    @Override
+    public int read(ByteBuffer dst) throws NonReadableChannelException {
+        throw new NonReadableChannelException();
+    }
+
+    /**
+     * Always throws {@link UnsupportedOperationException} because truncation is not supported.
+     *
+     * @param size the new size (unused)
+     * @return never returns normally
+     * @throws UnsupportedOperationException always
+     */
+    @Override
+    public SeekableByteChannel truncate(long size) {
+        throw new UnsupportedOperationException("Truncate is not supported for streaming multipart upload channels");
+    }
+
+    /**
+     * Completes the current multipart upload session and resets state so that subsequent writes
+     * start a new multipart upload session. This allows data written so far to be persisted to S3
+     * without closing the channel.
+     *
+     * <p>
+     * In random-access mode, this forces the temp file channel and returns without completing
+     * a multipart session.
+     *
+     * @throws IOException if an I/O error occurs during the completion
+     * @throws ClosedChannelException if the channel is closed
+     */
+    void force() throws IOException {
+        ensureOpen();
+
+        if (mode == Mode.RANDOM_ACCESS) {
+            tempFileChannel.force(true);
+            return;
+        }
+
+        // Nothing to force if no session started
+        if (uploadId == null) {
+            return;
+        }
+
+        // Complete current session
+        drainInFlightUploads();
+        flushRemainingBuffer();
+        completeMultipartUpload();
+
+        // Reset for new session
+        uploadId = null;
+        nextPartNumber = 1;
+        completedParts.clear();
+        partDataHistory.clear();
+        currentBuffer = new PartBuffer(partSize);
+    }
+
+    /**
+     * Returns whether this channel is open.
+     *
+     * @return {@code true} if the channel is open
+     */
+    @Override
+    public boolean isOpen() {
+        return open;
+    }
+
+    // ---- Internal methods ----
+
+    /**
+     * Initiates the multipart upload session by calling CreateMultipartUpload.
+     * Registers a JVM shutdown hook to abort the upload if the session is still active.
+     */
+    private void initiateMultipartUpload() throws IOException {
+        var request = CreateMultipartUploadRequest.builder()
+            .bucket(s3Path.bucketName())
+            .key(s3Path.getKey())
+            .build();
+
+        try {
+            var response = s3Client.createMultipartUpload(request).get();
+            uploadId = response.uploadId();
+            LOGGER.debug("Initiated multipart upload for '{}' with uploadId '{}'", s3Path.toUri(), uploadId);
+            registerShutdownHook();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted while initiating multipart upload for: " + s3Path.toUri(), e);
+        } catch (ExecutionException e) {
+            throw new IOException("Failed to initiate multipart upload for: " + s3Path.toUri(), e.getCause());
+        }
+    }
+
+    /**
+     * Uploads the current buffer as a part. Acquires a permit from the semaphore to enforce backpressure.
+     * Saves a copy of the buffer data to partDataHistory for potential fallback.
+     * If the upload times out, retries once before allowing the failure to propagate.
+     */
+    private void uploadCurrentBuffer() throws IOException {
+        checkForAsyncFailures();
+
+        // Enforce S3 part limit before initiating the upload
+        if (nextPartNumber > S3StreamingMultipartUpload.MAX_PARTS) {
+            abortMultipartUpload();
+            throw new IllegalStateException(String.format(
+                "S3 multipart upload part limit (%d) exceeded. Configured part size: %d bytes, "
+                    + "total bytes written: %d. Consider increasing the part size.",
+                S3StreamingMultipartUpload.MAX_PARTS, partSize, position));
+        }
+
+        try {
+            inFlightPermits.acquire();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted while waiting for upload permit", e);
+        }
+
+        int partNumber = nextPartNumber++;
+        ByteBuffer data = currentBuffer.flip();
+
+        // Save a copy of the part data for potential fallback and retry.
+        // When fallback is disabled, we still need the copy for timeout retry,
+        // but we don't retain it in partDataHistory.
+        byte[] dataCopy = new byte[data.remaining()];
+        data.get(dataCopy);
+        if (fallbackEnabled) {
+            partDataHistory.add(dataCopy);
+        }
+
+        var request = UploadPartRequest.builder()
+            .bucket(s3Path.bucketName())
+            .key(s3Path.getKey())
+            .uploadId(uploadId)
+            .partNumber(partNumber)
+            .contentLength((long) dataCopy.length)
+            .build();
+
+        var future = s3Client.uploadPart(request, AsyncRequestBody.fromBytes(dataCopy))
+            .handle((response, error) -> {
+                if (error != null && isTimeoutException(error)) {
+                    LOGGER.warn("Part {} upload timed out for uploadId '{}', retrying once",
+                        partNumber, uploadId);
+                    return null; // Signal retry needed
+                }
+                if (error != null) {
+                    throw new java.util.concurrent.CompletionException(error);
+                }
+                return response;
+            })
+            .thenCompose(response -> {
+                if (response == null) {
+                    // Retry the upload
+                    return s3Client.uploadPart(request, AsyncRequestBody.fromBytes(dataCopy));
+                }
+                return CompletableFuture.completedFuture(response);
+            })
+            .thenApply(response -> {
+                var completedPart = CompletedPart.builder()
+                    .partNumber(partNumber)
+                    .eTag(response.eTag())
+                    .build();
+                LOGGER.debug("Uploaded part {} for uploadId '{}', eTag: {}", partNumber, uploadId, response.eTag());
+                return completedPart;
+            })
+            .whenComplete((result, error) -> inFlightPermits.release());
+
+        inFlightUploads.add(future);
+    }
+
+    /**
+     * Flushes the remaining bytes in the current buffer as the final part.
+     */
+    private void flushRemainingBuffer() throws IOException {
+        ByteBuffer data = currentBuffer.flip();
+        if (!data.hasRemaining()) {
+            return;
+        }
+
+        int partNumber = nextPartNumber++;
+
+        var request = UploadPartRequest.builder()
+            .bucket(s3Path.bucketName())
+            .key(s3Path.getKey())
+            .uploadId(uploadId)
+            .partNumber(partNumber)
+            .contentLength((long) data.remaining())
+            .build();
+
+        try {
+            var response = s3Client.uploadPart(request, AsyncRequestBody.fromByteBuffer(data)).get();
+            var completedPart = CompletedPart.builder()
+                .partNumber(partNumber)
+                .eTag(response.eTag())
+                .build();
+            completedParts.add(completedPart);
+            LOGGER.debug("Uploaded final part {} for uploadId '{}', eTag: {}", partNumber, uploadId, response.eTag());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted while uploading final part", e);
+        } catch (ExecutionException e) {
+            throw new IOException("Failed to upload final part for uploadId: " + uploadId, e.getCause());
+        }
+    }
+
+    /**
+     * Completes the multipart upload by calling CompleteMultipartUpload with all part ETags in order.
+     * Deregisters the shutdown hook on success.
+     */
+    private void completeMultipartUpload() throws IOException {
+        var completedUpload = CompletedMultipartUpload.builder()
+            .parts(completedParts)
+            .build();
+
+        var request = CompleteMultipartUploadRequest.builder()
+            .bucket(s3Path.bucketName())
+            .key(s3Path.getKey())
+            .uploadId(uploadId)
+            .multipartUpload(completedUpload)
+            .build();
+
+        try {
+            s3Client.completeMultipartUpload(request).get();
+            LOGGER.debug("Completed multipart upload for '{}' with uploadId '{}'", s3Path.toUri(), uploadId);
+            deregisterShutdownHook();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted while completing multipart upload for uploadId: " + uploadId, e);
+        } catch (ExecutionException e) {
+            throw new IOException("Failed to complete multipart upload for uploadId: " + uploadId, e.getCause());
+        }
+    }
+
+    /**
+     * Aborts the multipart upload session. Best-effort: logs a warning if abort itself fails.
+     * Logs the upload ID and the number of successfully completed parts before the failure.
+     */
+    private void abortMultipartUpload() {
+        if (uploadId == null) {
+            return;
+        }
+
+        LOGGER.warn("Aborting multipart upload for uploadId '{}'. Successfully completed parts: {}",
+            uploadId, completedParts.size());
+
+        var request = AbortMultipartUploadRequest.builder()
+            .bucket(s3Path.bucketName())
+            .key(s3Path.getKey())
+            .uploadId(uploadId)
+            .build();
+
+        try {
+            s3Client.abortMultipartUpload(request).get();
+            LOGGER.debug("Aborted multipart upload for '{}' with uploadId '{}'", s3Path.toUri(), uploadId);
+            deregisterShutdownHook();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.warn("Interrupted while aborting multipart upload for uploadId '{}'. "
+                + "Manual cleanup may be required.", uploadId);
+        } catch (ExecutionException e) {
+            LOGGER.warn("Failed to abort multipart upload for uploadId '{}'. "
+                + "Manual cleanup may be required. Error: {}", uploadId, e.getCause().getMessage());
+        }
+    }
+
+    /**
+     * Waits for all in-flight uploads to complete and collects their CompletedPart results.
+     */
+    private void drainInFlightUploads() throws IOException {
+        CompletableFuture<CompletedPart> future;
+        while ((future = inFlightUploads.poll()) != null) {
+            try {
+                completedParts.add(future.get());
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IOException("Interrupted while waiting for in-flight uploads to complete", e);
+            } catch (ExecutionException e) {
+                throw new IOException("An in-flight part upload failed for uploadId: " + uploadId, e.getCause());
+            }
+        }
+
+        // Sort completed parts by part number to ensure correct ordering
+        completedParts.sort((a, b) -> Integer.compare(a.partNumber(), b.partNumber()));
+    }
+
+    /**
+     * Checks if any in-flight uploads have failed and propagates the failure as an IOException.
+     */
+    private void checkForAsyncFailures() throws IOException {
+        for (var future : inFlightUploads) {
+            if (future.isCompletedExceptionally()) {
+                // Drain to get the actual exception
+                try {
+                    future.get();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IOException("Interrupted while checking for async failures", e);
+                } catch (ExecutionException e) {
+                    throw new IOException("A previous part upload failed for uploadId: " + uploadId, e.getCause());
+                }
+            }
+        }
+    }
+
+    /**
+     * Falls back to temp-file mode when a backward seek is detected.
+     *
+     * <p>
+     * This method:
+     * <ol>
+     *   <li>Logs a warning with the upload ID</li>
+     *   <li>Drains in-flight uploads (ignoring failures since we're aborting)</li>
+     *   <li>Aborts the active multipart upload session</li>
+     *   <li>Creates a temp file and opens a FileChannel on it</li>
+     *   <li>Writes all previously uploaded part data and current buffer content to the temp file</li>
+     *   <li>Switches mode to RANDOM_ACCESS</li>
+     *   <li>Positions the temp file channel at newPosition</li>
+     * </ol>
+     *
+     * @param newPosition the position to seek to after fallback
+     * @throws IOException if an I/O error occurs during fallback
+     */
+    private void fallbackToTempFile(long newPosition) throws IOException {
+        LOGGER.warn("Non-sequential position change detected for uploadId '{}'. Falling back to temp-file mode. "
+            + "Current position: {}, requested position: {}", uploadId, position, newPosition);
+
+        // Drain in-flight uploads (best-effort, ignore failures since we're aborting)
+        drainInFlightUploadsBestEffort();
+
+        // Abort the active multipart upload session
+        abortMultipartUpload();
+
+        // Create temp file and open a FileChannel
+        tempFile = Files.createTempFile("s3-streaming-", ".tmp");
+        tempFile.toFile().deleteOnExit();
+        tempFileChannel = FileChannel.open(tempFile,
+            StandardOpenOption.READ, StandardOpenOption.WRITE);
+
+        // Write all previously uploaded part data to the temp file
+        for (byte[] partData : partDataHistory) {
+            tempFileChannel.write(ByteBuffer.wrap(partData));
+        }
+
+        // Write current buffer content to the temp file
+        ByteBuffer currentData = currentBuffer.flip();
+        if (currentData.hasRemaining()) {
+            tempFileChannel.write(currentData);
+        }
+
+        // Switch mode
+        mode = Mode.RANDOM_ACCESS;
+
+        // Clear partDataHistory (no longer needed)
+        partDataHistory.clear();
+
+        // Position the temp file channel at newPosition
+        tempFileChannel.position(newPosition);
+        position = newPosition;
+    }
+
+    /**
+     * Drains in-flight uploads best-effort, ignoring any failures.
+     * Used during fallback when we're about to abort the multipart upload anyway.
+     */
+    private void drainInFlightUploadsBestEffort() {
+        CompletableFuture<CompletedPart> future;
+        while ((future = inFlightUploads.poll()) != null) {
+            try {
+                future.get();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            } catch (ExecutionException e) {
+                // Ignore failures - we're aborting anyway
+                LOGGER.debug("Ignoring in-flight upload failure during fallback: {}", e.getCause().getMessage());
+            }
+        }
+    }
+
+    /**
+     * Closes the channel in random-access mode: uploads the temp file to S3 via PutObject,
+     * then cleans up the temp file. Deregisters the shutdown hook since the multipart session
+     * was already aborted during fallback.
+     */
+    private void closeRandomAccessMode() throws IOException {
+        try {
+            tempFileChannel.force(true);
+            long fileSize = tempFileChannel.size();
+            tempFileChannel.close();
+
+            // Upload the temp file to S3 using PutObject
+            var putRequest = PutObjectRequest.builder()
+                .bucket(s3Path.bucketName())
+                .key(s3Path.getKey())
+                .contentLength(fileSize)
+                .build();
+
+            s3Client.putObject(putRequest, AsyncRequestBody.fromFile(tempFile)).get();
+            LOGGER.debug("Uploaded temp file for '{}' via PutObject ({} bytes)", s3Path.toUri(), fileSize);
+            deregisterShutdownHook();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted while uploading temp file for: " + s3Path.toUri(), e);
+        } catch (ExecutionException e) {
+            throw new IOException("Failed to upload temp file for: " + s3Path.toUri(), e.getCause());
+        } finally {
+            deleteTempFile();
+        }
+    }
+
+    /**
+     * Deletes the temp file if it exists. Best-effort: logs a warning on failure.
+     */
+    private void deleteTempFile() {
+        if (tempFile != null) {
+            try {
+                Files.deleteIfExists(tempFile);
+            } catch (IOException e) {
+                LOGGER.warn("Failed to delete temp file '{}': {}", tempFile, e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * Ensures the channel is open, throwing ClosedChannelException if not.
+     */
+    private void ensureOpen() throws ClosedChannelException {
+        if (!open) {
+            throw new ClosedChannelException();
+        }
+    }
+
+    /**
+     * Registers a JVM shutdown hook that will attempt to abort the multipart upload
+     * if the session is still active when the JVM shuts down.
+     */
+    private void registerShutdownHook() {
+        shutdownHook = new Thread(() -> {
+            if (open && uploadId != null) {
+                LOGGER.warn("JVM shutting down with active multipart upload session. "
+                    + "Attempting to abort uploadId '{}'", uploadId);
+                abortMultipartUpload();
+            }
+        });
+        Runtime.getRuntime().addShutdownHook(shutdownHook);
+    }
+
+    /**
+     * Deregisters the JVM shutdown hook. Called after successful completion or abort.
+     * Handles the case where the JVM is already shutting down gracefully.
+     */
+    private void deregisterShutdownHook() {
+        if (shutdownHook != null) {
+            try {
+                Runtime.getRuntime().removeShutdownHook(shutdownHook);
+            } catch (IllegalStateException e) {
+                // JVM is already shutting down, ignore
+            }
+            shutdownHook = null;
+        }
+    }
+
+    /**
+     * Determines if the given throwable is a timeout exception that warrants a retry.
+     *
+     * @param error the throwable to check
+     * @return true if the error is a timeout exception
+     */
+    private boolean isTimeoutException(Throwable error) {
+        Throwable cause = error;
+        while (cause != null) {
+            if (cause instanceof TimeoutException
+                || cause instanceof ApiCallTimeoutException
+                || cause instanceof ApiCallAttemptTimeoutException) {
+                return true;
+            }
+            cause = cause.getCause();
+        }
+        return false;
+    }
+
+    // ---- Package-private accessors for testing ----
+
+    /**
+     * Returns the current mode of the channel.
+     */
+    Mode getMode() {
+        return mode;
+    }
+
+    /**
+     * Returns the upload ID of the current multipart session, or null if not yet initiated.
+     */
+    String getUploadId() {
+        return uploadId;
+    }
+
+    /**
+     * Returns the next part number that will be assigned.
+     */
+    int getNextPartNumber() {
+        return nextPartNumber;
+    }
+
+    /**
+     * Returns the list of completed parts.
+     */
+    List<CompletedPart> getCompletedParts() {
+        return completedParts;
+    }
+
+    /**
+     * Returns the temp file path, or null if not in random-access mode.
+     */
+    Path getTempFile() {
+        return tempFile;
+    }
+
+    /**
+     * Returns the temp file channel, or null if not in random-access mode.
+     */
+    FileChannel getTempFileChannel() {
+        return tempFileChannel;
+    }
+
+    /**
+     * Returns the shutdown hook thread, or null if not registered.
+     */
+    Thread getShutdownHook() {
+        return shutdownHook;
+    }
+}

--- a/src/main/java/software/amazon/nio/spi/s3/config/S3NioSpiConfiguration.java
+++ b/src/main/java/software/amazon/nio/spi/s3/config/S3NioSpiConfiguration.java
@@ -124,9 +124,44 @@ public class S3NioSpiConfiguration extends HashMap<String, Object> {
         "CRC32", "CRC32C", "CRC64NVME", S3_INTEGRITY_CHECK_ALGORITHM_DEFAULT.toUpperCase());
 
     /**
+     * The name of the streaming multipart upload enabled property
+     */
+    public static final String S3_SPI_WRITE_STREAMING_MULTIPART_UPLOAD_PROPERTY = "s3.spi.write.streaming-multipart-upload";
+    /**
+     * The default value of the streaming multipart upload enabled property
+     */
+    public static final boolean S3_SPI_WRITE_STREAMING_MULTIPART_UPLOAD_DEFAULT = false;
+    /**
+     * The name of the multipart part size property
+     */
+    public static final String S3_SPI_WRITE_MULTIPART_PART_SIZE_PROPERTY = "s3.spi.write.multipart-part-size";
+    /**
+     * The default value of the multipart part size property (8 MiB)
+     */
+    public static final long S3_SPI_WRITE_MULTIPART_PART_SIZE_DEFAULT = 8L * 1024 * 1024;
+
+    /**
+     * The name of the streaming multipart upload fallback enabled property
+     */
+    public static final String S3_SPI_WRITE_MULTIPART_FALLBACK_PROPERTY = "s3.spi.write.multipart-fallback-enabled";
+    /**
+     * The default value of the streaming multipart upload fallback enabled property
+     */
+    public static final boolean S3_SPI_WRITE_MULTIPART_FALLBACK_DEFAULT = false;
+
+    /**
      * This configuration is not meant to be configured via System Properties, but to be set programmatically.
      */
     static final String S3_OPEN_OPTIONS_PROPERTY = "s3.open-options";
+
+    /**
+     * Minimum part size for streaming multipart upload: 5 MiB.
+     */
+    private static final long MIN_PART_SIZE = 5L * 1024 * 1024;
+    /**
+     * Maximum part size for streaming multipart upload: 5 GiB.
+     */
+    private static final long MAX_PART_SIZE = 5L * 1024 * 1024 * 1024;
 
     private static final Pattern ENDPOINT_REGEXP = Pattern.compile("(\\w[\\w\\-\\.]*)?(:(\\d+))?");
 
@@ -161,6 +196,9 @@ public class S3NioSpiConfiguration extends HashMap<String, Object> {
         put(S3_SPI_TIMEOUT_MEDIUM_PROPERTY, String.valueOf(S3_SPI_TIMEOUT_MEDIUM_DEFAULT));
         put(S3_SPI_TIMEOUT_HIGH_PROPERTY, String.valueOf(S3_SPI_TIMEOUT_HIGH_DEFAULT));
         put(S3_INTEGRITY_CHECK_ALGORITHM_PROPERTY, S3_INTEGRITY_CHECK_ALGORITHM_DEFAULT);
+        put(S3_SPI_WRITE_STREAMING_MULTIPART_UPLOAD_PROPERTY, String.valueOf(S3_SPI_WRITE_STREAMING_MULTIPART_UPLOAD_DEFAULT));
+        put(S3_SPI_WRITE_MULTIPART_PART_SIZE_PROPERTY, String.valueOf(S3_SPI_WRITE_MULTIPART_PART_SIZE_DEFAULT));
+        put(S3_SPI_WRITE_MULTIPART_FALLBACK_PROPERTY, String.valueOf(S3_SPI_WRITE_MULTIPART_FALLBACK_DEFAULT));
         put(S3_OPEN_OPTIONS_PROPERTY, Set.of(S3OpenOption.useTransferManager()));
 
         //
@@ -471,6 +509,46 @@ public class S3NioSpiConfiguration extends HashMap<String, Object> {
     }
 
     /**
+     * Fluently sets whether streaming multipart upload is enabled.
+     *
+     * @param enabled true to enable streaming multipart upload
+     * @return this instance
+     */
+    public S3NioSpiConfiguration withStreamingMultipartUpload(boolean enabled) {
+        put(S3_SPI_WRITE_STREAMING_MULTIPART_UPLOAD_PROPERTY, String.valueOf(enabled));
+        return this;
+    }
+
+    /**
+     * Fluently sets the multipart part size.
+     *
+     * @param partSize the part size in bytes
+     * @return this instance
+     * @throws IllegalArgumentException if partSize is less than 5 MiB or greater than 5 GiB
+     */
+    public S3NioSpiConfiguration withMultipartPartSize(long partSize) {
+        if (partSize < MIN_PART_SIZE) {
+            throw new IllegalArgumentException("partSize must be at least 5 MiB, got: " + partSize);
+        }
+        if (partSize > MAX_PART_SIZE) {
+            throw new IllegalArgumentException("partSize must not exceed 5 GiB, got: " + partSize);
+        }
+        put(S3_SPI_WRITE_MULTIPART_PART_SIZE_PROPERTY, String.valueOf(partSize));
+        return this;
+    }
+
+    /**
+     * Fluently sets whether fallback to temp-file mode is enabled for streaming multipart uploads.
+     *
+     * @param enabled true to enable fallback (default), false for strict append-only mode with lower memory usage
+     * @return this instance
+     */
+    public S3NioSpiConfiguration withMultipartFallbackEnabled(boolean enabled) {
+        put(S3_SPI_WRITE_MULTIPART_FALLBACK_PROPERTY, String.valueOf(enabled));
+        return this;
+    }
+
+    /**
      * Get the value of the Maximum Fragment Size
      *
      * @return the configured value or the default if not overridden
@@ -492,6 +570,41 @@ public class S3NioSpiConfiguration extends HashMap<String, Object> {
             S3_SPI_READ_MAX_FRAGMENT_NUMBER_PROPERTY,
             S3_SPI_READ_MAX_FRAGMENT_NUMBER_DEFAULT
         );
+    }
+
+    /**
+     * Get whether streaming multipart upload is enabled.
+     *
+     * @return true if streaming multipart upload is enabled
+     */
+    public boolean isStreamingMultipartUploadEnabled() {
+        return Boolean.parseBoolean(
+            (String) getOrDefault(S3_SPI_WRITE_STREAMING_MULTIPART_UPLOAD_PROPERTY,
+                String.valueOf(S3_SPI_WRITE_STREAMING_MULTIPART_UPLOAD_DEFAULT)));
+    }
+
+    /**
+     * Get the configured multipart part size in bytes.
+     *
+     * @return the configured part size or the default (8 MiB) if not overridden or invalid
+     */
+    public long getMultipartPartSize() {
+        return parseLongProperty(
+            S3_SPI_WRITE_MULTIPART_PART_SIZE_PROPERTY,
+            S3_SPI_WRITE_MULTIPART_PART_SIZE_DEFAULT);
+    }
+
+    /**
+     * Get whether fallback to temp-file mode is enabled for streaming multipart uploads.
+     * When disabled, seeks throw {@code UnsupportedOperationException} and part data is not
+     * retained in memory, reducing memory usage for large uploads.
+     *
+     * @return true if fallback is enabled (default), false for strict append-only mode
+     */
+    public boolean isMultipartFallbackEnabled() {
+        return Boolean.parseBoolean(
+            (String) getOrDefault(S3_SPI_WRITE_MULTIPART_FALLBACK_PROPERTY,
+                String.valueOf(S3_SPI_WRITE_MULTIPART_FALLBACK_DEFAULT)));
     }
 
     /**
@@ -646,7 +759,14 @@ public class S3NioSpiConfiguration extends HashMap<String, Object> {
         @SuppressWarnings("unchecked")
         var options = (Set<S3OpenOption>) getOrDefault(S3_OPEN_OPTIONS_PROPERTY, Set.of());
         // make a defensive copy to ensure that the thread-safetyness is ensured for the consumers
-        return options.stream().map(S3OpenOption::copy).collect(Collectors.toSet());
+        var result = options.stream().map(S3OpenOption::copy).collect(Collectors.toSet());
+
+        // Add streaming multipart upload option if enabled via configuration
+        if (isStreamingMultipartUploadEnabled()) {
+            result.add(S3OpenOption.streamingMultipartUpload(getMultipartPartSize(), isMultipartFallbackEnabled()));
+        }
+
+        return result;
     }
 
     private void validateIntegrityAlgorithm(String algorithm) {
@@ -678,6 +798,17 @@ public class S3NioSpiConfiguration extends HashMap<String, Object> {
             return Integer.parseInt(propertyVal);
         } catch (NumberFormatException e) {
             logger.warn("the value of '{}' for '{}' is not an integer, using default value of '{}'",
+                propertyVal, propName, defaultVal);
+            return defaultVal;
+        }
+    }
+
+    private long parseLongProperty(String propName, long defaultVal) {
+        var propertyVal = (String) get(propName);
+        try {
+            return Long.parseLong(propertyVal);
+        } catch (NumberFormatException e) {
+            logger.warn("the value of '{}' for '{}' is not a long, using default value of '{}'",
                 propertyVal, propName, defaultVal);
             return defaultVal;
         }

--- a/src/test/java/software/amazon/nio/spi/s3/AsyncS3FileChannelTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/AsyncS3FileChannelTest.java
@@ -81,6 +81,19 @@ class AsyncS3FileChannelTest {
     }
 
     @Test
+    void force_WithStreamingWriteDelegate_CallsForce() throws IOException {
+        // Given
+        var mockStreamingDelegate = mock(S3StreamingMultipartUploadChannel.class);
+        when(mockByteChannel.getWriteDelegate()).thenReturn(mockStreamingDelegate);
+
+        // When
+        channel.force(true);
+
+        // Then
+        verify(mockStreamingDelegate).force();
+    }
+
+    @Test
     void force_WithoutWriteDelegate_DoesNothing() throws IOException {
         // Given
         when(mockByteChannel.getWriteDelegate()).thenReturn(null);

--- a/src/test/java/software/amazon/nio/spi/s3/PartBufferTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/PartBufferTest.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.nio.spi.s3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.ByteBuffer;
+import org.junit.jupiter.api.Test;
+
+class PartBufferTest {
+
+    @Test
+    void constructor_positivePartSize_createsBuffer() {
+        PartBuffer buffer = new PartBuffer(1024);
+
+        assertThat(buffer.remaining()).isEqualTo(1024);
+        assertThat(buffer.isFull()).isFalse();
+    }
+
+    @Test
+    void constructor_zeroPartSize_throwsIllegalArgumentException() {
+        assertThatThrownBy(() -> new PartBuffer(0))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("partSize must be positive");
+    }
+
+    @Test
+    void constructor_negativePartSize_throwsIllegalArgumentException() {
+        assertThatThrownBy(() -> new PartBuffer(-1))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("partSize must be positive");
+    }
+
+    @Test
+    void write_fillsBuffer_returnsCorrectBytesWritten() {
+        PartBuffer buffer = new PartBuffer(10);
+        ByteBuffer src = ByteBuffer.wrap(new byte[]{1, 2, 3, 4, 5});
+
+        int written = buffer.write(src);
+
+        assertThat(written).isEqualTo(5);
+        assertThat(buffer.remaining()).isEqualTo(5);
+        assertThat(src.remaining()).isZero();
+    }
+
+    @Test
+    void write_multipleWrites_accumulatesBytes() {
+        PartBuffer buffer = new PartBuffer(10);
+        ByteBuffer src1 = ByteBuffer.wrap(new byte[]{1, 2, 3});
+        ByteBuffer src2 = ByteBuffer.wrap(new byte[]{4, 5, 6, 7});
+
+        int written1 = buffer.write(src1);
+        int written2 = buffer.write(src2);
+
+        assertThat(written1).isEqualTo(3);
+        assertThat(written2).isEqualTo(4);
+        assertThat(buffer.remaining()).isEqualTo(3);
+    }
+
+    @Test
+    void write_exactlyFillsBuffer_returnsFullSize() {
+        PartBuffer buffer = new PartBuffer(5);
+        ByteBuffer src = ByteBuffer.wrap(new byte[]{1, 2, 3, 4, 5});
+
+        int written = buffer.write(src);
+
+        assertThat(written).isEqualTo(5);
+        assertThat(buffer.remaining()).isZero();
+        assertThat(buffer.isFull()).isTrue();
+    }
+
+    @Test
+    void write_sourceExceedsCapacity_writesOnlyWhatFits() {
+        PartBuffer buffer = new PartBuffer(5);
+        ByteBuffer src = ByteBuffer.wrap(new byte[]{1, 2, 3, 4, 5, 6, 7, 8});
+
+        int written = buffer.write(src);
+
+        assertThat(written).isEqualTo(5);
+        assertThat(src.remaining()).isEqualTo(3);
+        assertThat(buffer.isFull()).isTrue();
+    }
+
+    @Test
+    void write_emptySource_returnsZero() {
+        PartBuffer buffer = new PartBuffer(10);
+        ByteBuffer src = ByteBuffer.allocate(0);
+
+        int written = buffer.write(src);
+
+        assertThat(written).isZero();
+        assertThat(buffer.remaining()).isEqualTo(10);
+    }
+
+    @Test
+    void write_bufferAlreadyFull_returnsZero() {
+        PartBuffer buffer = new PartBuffer(3);
+        ByteBuffer src1 = ByteBuffer.wrap(new byte[]{1, 2, 3});
+        buffer.write(src1);
+
+        ByteBuffer src2 = ByteBuffer.wrap(new byte[]{4, 5});
+        int written = buffer.write(src2);
+
+        assertThat(written).isZero();
+        assertThat(src2.remaining()).isEqualTo(2);
+    }
+
+    @Test
+    void isFull_emptyBuffer_returnsFalse() {
+        PartBuffer buffer = new PartBuffer(10);
+
+        assertThat(buffer.isFull()).isFalse();
+    }
+
+    @Test
+    void isFull_partiallyFilledBuffer_returnsFalse() {
+        PartBuffer buffer = new PartBuffer(10);
+        buffer.write(ByteBuffer.wrap(new byte[]{1, 2, 3}));
+
+        assertThat(buffer.isFull()).isFalse();
+    }
+
+    @Test
+    void isFull_completelyFilledBuffer_returnsTrue() {
+        PartBuffer buffer = new PartBuffer(5);
+        buffer.write(ByteBuffer.wrap(new byte[]{1, 2, 3, 4, 5}));
+
+        assertThat(buffer.isFull()).isTrue();
+    }
+
+    @Test
+    void flip_preparesBufferForReading() {
+        PartBuffer buffer = new PartBuffer(10);
+        buffer.write(ByteBuffer.wrap(new byte[]{1, 2, 3, 4, 5}));
+
+        ByteBuffer flipped = buffer.flip();
+
+        assertThat(flipped.position()).isZero();
+        assertThat(flipped.limit()).isEqualTo(5);
+        assertThat(flipped.remaining()).isEqualTo(5);
+    }
+
+    @Test
+    void flip_fullBuffer_preparesEntireBufferForReading() {
+        PartBuffer buffer = new PartBuffer(5);
+        buffer.write(ByteBuffer.wrap(new byte[]{1, 2, 3, 4, 5}));
+
+        ByteBuffer flipped = buffer.flip();
+
+        assertThat(flipped.position()).isZero();
+        assertThat(flipped.limit()).isEqualTo(5);
+        assertThat(flipped.remaining()).isEqualTo(5);
+    }
+
+    @Test
+    void flip_emptyBuffer_returnsEmptyReadableBuffer() {
+        PartBuffer buffer = new PartBuffer(10);
+
+        ByteBuffer flipped = buffer.flip();
+
+        assertThat(flipped.position()).isZero();
+        assertThat(flipped.limit()).isZero();
+        assertThat(flipped.remaining()).isZero();
+    }
+
+    @Test
+    void flip_contentIsCorrect() {
+        PartBuffer buffer = new PartBuffer(10);
+        byte[] data = {10, 20, 30, 40, 50};
+        buffer.write(ByteBuffer.wrap(data));
+
+        ByteBuffer flipped = buffer.flip();
+
+        byte[] result = new byte[flipped.remaining()];
+        flipped.get(result);
+        assertThat(result).isEqualTo(data);
+    }
+
+    @Test
+    void remaining_newBuffer_equalsPartSize() {
+        PartBuffer buffer = new PartBuffer(256);
+
+        assertThat(buffer.remaining()).isEqualTo(256);
+    }
+
+    @Test
+    void remaining_afterWrite_decreasesByBytesWritten() {
+        PartBuffer buffer = new PartBuffer(100);
+        buffer.write(ByteBuffer.wrap(new byte[30]));
+
+        assertThat(buffer.remaining()).isEqualTo(70);
+    }
+
+    @Test
+    void remaining_fullBuffer_returnsZero() {
+        PartBuffer buffer = new PartBuffer(5);
+        buffer.write(ByteBuffer.wrap(new byte[5]));
+
+        assertThat(buffer.remaining()).isZero();
+    }
+
+    @Test
+    void write_boundaryWrite_sourcePositionAdvancesCorrectly() {
+        PartBuffer buffer = new PartBuffer(5);
+        ByteBuffer src = ByteBuffer.wrap(new byte[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
+
+        int written = buffer.write(src);
+
+        assertThat(written).isEqualTo(5);
+        assertThat(src.position()).isEqualTo(5);
+        assertThat(src.remaining()).isEqualTo(5);
+
+        // The remaining bytes in src should be 6, 7, 8, 9, 10
+        byte[] remaining = new byte[src.remaining()];
+        src.get(remaining);
+        assertThat(remaining).isEqualTo(new byte[]{6, 7, 8, 9, 10});
+    }
+
+    @Test
+    void write_sourceWithOffset_writesFromCurrentPosition() {
+        PartBuffer buffer = new PartBuffer(10);
+        ByteBuffer src = ByteBuffer.wrap(new byte[]{1, 2, 3, 4, 5, 6, 7, 8});
+        src.position(3); // Skip first 3 bytes
+
+        int written = buffer.write(src);
+
+        assertThat(written).isEqualTo(5);
+        assertThat(src.remaining()).isZero();
+
+        ByteBuffer flipped = buffer.flip();
+        byte[] result = new byte[flipped.remaining()];
+        flipped.get(result);
+        assertThat(result).isEqualTo(new byte[]{4, 5, 6, 7, 8});
+    }
+}

--- a/src/test/java/software/amazon/nio/spi/s3/S3SeekableByteChannelStreamingIntegrationTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3SeekableByteChannelStreamingIntegrationTest.java
@@ -1,0 +1,381 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.nio.spi.s3;
+
+import static java.nio.file.StandardOpenOption.CREATE;
+import static java.nio.file.StandardOpenOption.READ;
+import static java.nio.file.StandardOpenOption.WRITE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static software.amazon.nio.spi.s3.S3Matchers.anyConsumer;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.OpenOption;
+import java.nio.file.StandardOpenOption;
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadResponse;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadResponse;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.UploadPartRequest;
+import software.amazon.awssdk.services.s3.model.UploadPartResponse;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("unchecked")
+@DisplayName("S3SeekableByteChannel Streaming Multipart Upload Integration")
+public class S3SeekableByteChannelStreamingIntegrationTest {
+
+    /**
+     * A marker interface with "Crt" in the name to satisfy the CRT client validation.
+     */
+    interface S3CrtAsyncClientMarker extends S3AsyncClient {
+    }
+
+    S3FileSystem fs;
+    S3Path path;
+
+    @Mock
+    S3AsyncClient mockClient;
+
+    @BeforeEach
+    void init() {
+        var provider = new S3FileSystemProvider();
+        fs = (S3FileSystem) provider.getFileSystem(URI.create("s3://test-bucket"));
+        fs.clientProvider(new FixedS3ClientProvider(mockClient));
+        path = (S3Path) fs.getPath("/test-object");
+    }
+
+    @AfterEach
+    void after() throws IOException {
+        fs.close();
+    }
+
+    /**
+     * Creates a mock CRT client by mocking the marker interface that has "Crt" in its name.
+     */
+    private S3AsyncClient createMockCrtClient() {
+        return mock(S3CrtAsyncClientMarker.class);
+    }
+
+    @Nested
+    @DisplayName("8.1 - Channel creation with streaming option")
+    class ChannelCreationTests {
+
+        @Test
+        @DisplayName("Creates S3StreamingMultipartUploadChannel when streaming option is present with CRT client")
+        void createsStreamingChannelWithCrtClient() throws IOException {
+            // The mock client class name must contain "Crt"
+            var crtClient = createMockCrtClient();
+            fs.clientProvider(new FixedS3ClientProvider(crtClient));
+
+            Set<OpenOption> options = new HashSet<>();
+            options.add(WRITE);
+            options.add(CREATE);
+            options.add(S3OpenOption.streamingMultipartUpload());
+
+            try (var channel = new S3SeekableByteChannel(path, crtClient, options)) {
+                assertThat(channel.getWriteDelegate()).isInstanceOf(S3StreamingMultipartUploadChannel.class);
+                assertThat(channel.getReadDelegate()).isNull();
+            }
+        }
+
+        @Test
+        @DisplayName("Throws UnsupportedOperationException when streaming option used without CRT client")
+        void throwsWhenNonCrtClient() {
+            // mockClient's class name is a Mockito proxy, not containing "Crt"
+            Set<OpenOption> options = new HashSet<>();
+            options.add(WRITE);
+            options.add(CREATE);
+            options.add(S3OpenOption.streamingMultipartUpload());
+
+            assertThatThrownBy(() -> new S3SeekableByteChannel(path, mockClient, options))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("Streaming multipart upload requires the AWS CRT client");
+        }
+
+        @Test
+        @DisplayName("Throws IllegalArgumentException when streaming option combined with READ")
+        void throwsWhenCombinedWithRead() {
+            var crtClient = createMockCrtClient();
+            fs.clientProvider(new FixedS3ClientProvider(crtClient));
+
+            Set<OpenOption> options = new HashSet<>();
+            options.add(WRITE);
+            options.add(READ);
+            options.add(S3OpenOption.streamingMultipartUpload());
+
+            assertThatThrownBy(() -> new S3SeekableByteChannel(path, crtClient, options))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("write-only")
+                .hasMessageContaining("cannot be combined with READ");
+        }
+
+        @Test
+        @DisplayName("Creates S3WritableByteChannel when no streaming option is present")
+        void createsWritableChannelWithoutStreamingOption() throws IOException {
+            // Setup mocks for the S3WritableByteChannel path
+            // Use CREATE_NEW + assumeObjectNotExists to skip download
+            lenient().when(mockClient.headObject(anyConsumer())).thenCallRealMethod();
+            lenient().when(mockClient.headObject(any(HeadObjectRequest.class))).thenReturn(
+                CompletableFuture.failedFuture(NoSuchKeyException.builder().build())
+            );
+            lenient().when(mockClient.putObject(any(software.amazon.awssdk.services.s3.model.PutObjectRequest.class),
+                any(AsyncRequestBody.class)))
+                .thenReturn(CompletableFuture.completedFuture(
+                    software.amazon.awssdk.services.s3.model.PutObjectResponse.builder().build()));
+
+            Set<OpenOption> options = new HashSet<>();
+            options.add(WRITE);
+            options.add(StandardOpenOption.CREATE_NEW);
+            options.add(S3OpenOption.assumeObjectNotExists());
+
+            try (var channel = new S3SeekableByteChannel(path, mockClient, options)) {
+                assertThat(channel.getWriteDelegate()).isInstanceOf(S3WritableByteChannel.class);
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("8.2 - Option combinations")
+    class OptionCombinationTests {
+
+        @Test
+        @DisplayName("useTransferManager is overridden by streaming option")
+        void streamingOverridesTransferManager() throws IOException {
+            var crtClient = createMockCrtClient();
+            fs.clientProvider(new FixedS3ClientProvider(crtClient));
+
+            Set<OpenOption> options = new HashSet<>();
+            options.add(WRITE);
+            options.add(CREATE);
+            options.add(S3OpenOption.streamingMultipartUpload());
+            options.add(S3OpenOption.useTransferManager());
+
+            try (var channel = new S3SeekableByteChannel(path, crtClient, options)) {
+                // Streaming takes precedence over transfer manager
+                assertThat(channel.getWriteDelegate()).isInstanceOf(S3StreamingMultipartUploadChannel.class);
+            }
+        }
+
+        @Test
+        @DisplayName("CREATE_NEW with streaming option checks existence and throws if object exists")
+        void createNewThrowsIfObjectExists() {
+            var crtClient = createMockCrtClient();
+            fs.clientProvider(new FixedS3ClientProvider(crtClient));
+
+            // Mock headObject to indicate object exists
+            when(crtClient.headObject(any(HeadObjectRequest.class))).thenReturn(
+                CompletableFuture.completedFuture(
+                    HeadObjectResponse.builder().contentLength(100L).lastModified(Instant.now()).build()
+                )
+            );
+            lenient().when(crtClient.headObject(anyConsumer())).thenCallRealMethod();
+
+            Set<OpenOption> options = new HashSet<>();
+            options.add(WRITE);
+            options.add(StandardOpenOption.CREATE_NEW);
+            options.add(S3OpenOption.streamingMultipartUpload());
+
+            assertThatThrownBy(() -> new S3SeekableByteChannel(path, crtClient, options))
+                .isInstanceOf(FileAlreadyExistsException.class);
+        }
+
+        @Test
+        @DisplayName("CREATE_NEW with streaming option succeeds if object does not exist")
+        void createNewSucceedsIfObjectNotExists() throws IOException {
+            var crtClient = createMockCrtClient();
+            fs.clientProvider(new FixedS3ClientProvider(crtClient));
+
+            // Mock headObject to indicate object does not exist
+            when(crtClient.headObject(any(HeadObjectRequest.class))).thenReturn(
+                CompletableFuture.failedFuture(NoSuchKeyException.builder().build())
+            );
+            lenient().when(crtClient.headObject(anyConsumer())).thenCallRealMethod();
+
+            Set<OpenOption> options = new HashSet<>();
+            options.add(WRITE);
+            options.add(StandardOpenOption.CREATE_NEW);
+            options.add(S3OpenOption.streamingMultipartUpload());
+
+            try (var channel = new S3SeekableByteChannel(path, crtClient, options)) {
+                assertThat(channel.getWriteDelegate()).isInstanceOf(S3StreamingMultipartUploadChannel.class);
+            }
+        }
+
+        @Test
+        @DisplayName("assumeObjectNotExists with streaming option skips download")
+        void assumeObjectNotExistsSkipsDownload() throws IOException {
+            var crtClient = createMockCrtClient();
+            fs.clientProvider(new FixedS3ClientProvider(crtClient));
+
+            Set<OpenOption> options = new HashSet<>();
+            options.add(WRITE);
+            options.add(CREATE);
+            options.add(S3OpenOption.streamingMultipartUpload());
+            options.add(S3OpenOption.assumeObjectNotExists());
+
+            try (var channel = new S3SeekableByteChannel(path, crtClient, options)) {
+                assertThat(channel.getWriteDelegate()).isInstanceOf(S3StreamingMultipartUploadChannel.class);
+                // No getObject call should have been made
+                verify(crtClient, never()).getObject(
+                    any(software.amazon.awssdk.services.s3.model.GetObjectRequest.class),
+                    any(AsyncResponseTransformer.class));
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("8.3 - force() support")
+    class ForceTests {
+
+        @Test
+        @DisplayName("force() completes current session and allows subsequent writes")
+        void forceCompletesSessionAndAllowsSubsequentWrites() throws IOException {
+            var crtClient = createMockCrtClient();
+            fs.clientProvider(new FixedS3ClientProvider(crtClient));
+
+            // Mock multipart upload lifecycle
+            when(crtClient.createMultipartUpload(any(CreateMultipartUploadRequest.class)))
+                .thenReturn(CompletableFuture.completedFuture(
+                    CreateMultipartUploadResponse.builder().uploadId("upload-1").build()))
+                .thenReturn(CompletableFuture.completedFuture(
+                    CreateMultipartUploadResponse.builder().uploadId("upload-2").build()));
+
+            when(crtClient.uploadPart(any(UploadPartRequest.class), any(AsyncRequestBody.class)))
+                .thenReturn(CompletableFuture.completedFuture(
+                    UploadPartResponse.builder().eTag("etag-1").build()));
+
+            when(crtClient.completeMultipartUpload(any(CompleteMultipartUploadRequest.class)))
+                .thenReturn(CompletableFuture.completedFuture(
+                    CompleteMultipartUploadResponse.builder().build()));
+
+            Set<OpenOption> options = new HashSet<>();
+            options.add(WRITE);
+            options.add(CREATE);
+            options.add(S3OpenOption.streamingMultipartUpload());
+
+            var streamingChannel = new S3StreamingMultipartUploadChannel(
+                path, crtClient,
+                (S3StreamingMultipartUpload) S3OpenOption.streamingMultipartUpload());
+
+            // Write some data
+            ByteBuffer data = ByteBuffer.allocate(100);
+            data.put(new byte[100]);
+            data.flip();
+            streamingChannel.write(data);
+
+            assertThat(streamingChannel.getUploadId()).isEqualTo("upload-1");
+
+            // Force completes the session
+            streamingChannel.force();
+
+            // Upload ID should be reset
+            assertThat(streamingChannel.getUploadId()).isNull();
+            assertThat(streamingChannel.getNextPartNumber()).isEqualTo(1);
+            assertThat(streamingChannel.getCompletedParts()).isEmpty();
+
+            // Write more data - should start a new session
+            ByteBuffer moreData = ByteBuffer.allocate(50);
+            moreData.put(new byte[50]);
+            moreData.flip();
+            streamingChannel.write(moreData);
+
+            assertThat(streamingChannel.getUploadId()).isEqualTo("upload-2");
+
+            // Clean up
+            when(crtClient.completeMultipartUpload(any(CompleteMultipartUploadRequest.class)))
+                .thenReturn(CompletableFuture.completedFuture(
+                    CompleteMultipartUploadResponse.builder().build()));
+            streamingChannel.close();
+        }
+
+        @Test
+        @DisplayName("force() with no active session is a no-op")
+        void forceWithNoSessionIsNoOp() throws IOException {
+            var crtClient = createMockCrtClient();
+
+            var streamingChannel = new S3StreamingMultipartUploadChannel(
+                path, crtClient,
+                (S3StreamingMultipartUpload) S3OpenOption.streamingMultipartUpload());
+
+            // force() without any writes should not throw
+            streamingChannel.force();
+
+            // Verify no S3 calls were made
+            verify(crtClient, never()).completeMultipartUpload(any(CompleteMultipartUploadRequest.class));
+
+            streamingChannel.close();
+        }
+
+        @Test
+        @DisplayName("force() via S3FileChannel delegates to streaming channel")
+        void forceViaFileChannelDelegatesToStreamingChannel() throws IOException {
+            var crtClient = createMockCrtClient();
+            fs.clientProvider(new FixedS3ClientProvider(crtClient));
+
+            // Mock multipart upload lifecycle
+            when(crtClient.createMultipartUpload(any(CreateMultipartUploadRequest.class)))
+                .thenReturn(CompletableFuture.completedFuture(
+                    CreateMultipartUploadResponse.builder().uploadId("upload-1").build()));
+
+            when(crtClient.uploadPart(any(UploadPartRequest.class), any(AsyncRequestBody.class)))
+                .thenReturn(CompletableFuture.completedFuture(
+                    UploadPartResponse.builder().eTag("etag-1").build()));
+
+            when(crtClient.completeMultipartUpload(any(CompleteMultipartUploadRequest.class)))
+                .thenReturn(CompletableFuture.completedFuture(
+                    CompleteMultipartUploadResponse.builder().build()));
+
+            Set<OpenOption> options = new HashSet<>();
+            options.add(WRITE);
+            options.add(CREATE);
+            options.add(S3OpenOption.streamingMultipartUpload());
+
+            var seekableChannel = new S3SeekableByteChannel(path, crtClient, options);
+            var fileChannel = new S3FileChannel(seekableChannel);
+
+            // Write some data
+            ByteBuffer data = ByteBuffer.allocate(100);
+            data.put(new byte[100]);
+            data.flip();
+            fileChannel.write(data);
+
+            // force() should complete the session
+            fileChannel.force(true);
+
+            // Verify completeMultipartUpload was called
+            verify(crtClient).completeMultipartUpload(any(CompleteMultipartUploadRequest.class));
+
+            fileChannel.close();
+        }
+    }
+}

--- a/src/test/java/software/amazon/nio/spi/s3/S3StreamingMultipartUploadChannelTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3StreamingMultipartUploadChannelTest.java
@@ -1,0 +1,1489 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.nio.spi.s3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.AbortMultipartUploadResponse;
+import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadResponse;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadResponse;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.services.s3.model.UploadPartRequest;
+import software.amazon.awssdk.services.s3.model.UploadPartResponse;
+
+/**
+ * Unit tests for backpressure and concurrency control in S3StreamingMultipartUploadChannel.
+ * Verifies:
+ * - Writes block when all permits are taken (max in-flight reached)
+ * - Failure propagation: when an async upload fails, the next write() or close() throws IOException
+ * - Semaphore permits are released on both success and failure
+ */
+class S3StreamingMultipartUploadChannelTest {
+
+    private static final int PART_SIZE = 5 * 1024 * 1024; // 5 MiB (minimum)
+
+    private S3AsyncClient mockClient;
+    private S3Path mockPath;
+
+    @BeforeEach
+    void setUp() {
+        mockClient = mock(S3AsyncClient.class);
+        mockPath = mock(S3Path.class);
+        when(mockPath.bucketName()).thenReturn("test-bucket");
+        when(mockPath.getKey()).thenReturn("test-key");
+        when(mockPath.toUri()).thenReturn(java.net.URI.create("s3://test-bucket/test-key"));
+
+        // Default: createMultipartUpload succeeds
+        when(mockClient.createMultipartUpload(any(CreateMultipartUploadRequest.class)))
+            .thenReturn(CompletableFuture.completedFuture(
+                CreateMultipartUploadResponse.builder().uploadId("test-upload-id").build()));
+
+        // Default: abortMultipartUpload succeeds
+        when(mockClient.abortMultipartUpload(any(AbortMultipartUploadRequest.class)))
+            .thenReturn(CompletableFuture.completedFuture(
+                AbortMultipartUploadResponse.builder().build()));
+    }
+
+    @Test
+    @DisplayName("write blocks when all in-flight permits are taken")
+    void writeBlocksWhenAllPermitsAreTaken() throws Exception {
+        int maxInFlight = 1;
+        var option = new S3StreamingMultipartUpload(PART_SIZE, maxInFlight);
+        var channel = new S3StreamingMultipartUploadChannel(mockPath, mockClient, option);
+
+        // Use a CompletableFuture that we never complete - this holds the permit
+        var hangingFuture = new CompletableFuture<UploadPartResponse>();
+        when(mockClient.uploadPart(any(UploadPartRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(hangingFuture);
+
+        // First write fills the buffer and triggers an upload (acquires the only permit)
+        ByteBuffer firstWrite = ByteBuffer.allocate(PART_SIZE);
+        channel.write(firstWrite);
+
+        // Now the permit is taken. The next write that fills the buffer should block.
+        var writeBlocked = new AtomicBoolean(false);
+        var writeCompleted = new AtomicBoolean(false);
+        var blockedLatch = new CountDownLatch(1);
+
+        Thread writerThread = new Thread(() -> {
+            try {
+                // This write will fill the buffer and try to upload, which requires a permit
+                ByteBuffer secondWrite = ByteBuffer.allocate(PART_SIZE);
+                writeBlocked.set(true);
+                blockedLatch.countDown();
+                channel.write(secondWrite);
+                writeCompleted.set(true);
+            } catch (IOException e) {
+                // Expected if channel is closed while blocked
+            }
+        });
+
+        writerThread.start();
+
+        // Wait for the writer thread to start and attempt the write
+        blockedLatch.await(2, TimeUnit.SECONDS);
+        // Give the thread time to actually block on the semaphore
+        Thread.sleep(200);
+
+        // The write should be blocked (not completed) because the permit is held
+        assertThat(writeCompleted.get())
+            .as("Write should be blocked waiting for a permit")
+            .isFalse();
+
+        // Release the permit by completing the hanging future
+        hangingFuture.complete(UploadPartResponse.builder().eTag("etag-1").build());
+
+        // Now the writer thread should unblock and complete
+        writerThread.join(2000);
+        assertThat(writeCompleted.get())
+            .as("Write should complete after permit is released")
+            .isTrue();
+
+        // Clean up
+        when(mockClient.completeMultipartUpload(any(CompleteMultipartUploadRequest.class)))
+            .thenReturn(CompletableFuture.completedFuture(
+                CompleteMultipartUploadResponse.builder().build()));
+        channel.close();
+    }
+
+    @SuppressWarnings("resource")
+    @Test
+    @DisplayName("write throws IOException when a previous async upload failed")
+    void writeThrowsIOExceptionOnAsyncFailure() throws Exception {
+        int maxInFlight = 2;
+        var option = new S3StreamingMultipartUpload(PART_SIZE, maxInFlight);
+        var channel = new S3StreamingMultipartUploadChannel(mockPath, mockClient, option);
+
+        // First uploadPart returns a future that completes exceptionally
+        var failedFuture = new CompletableFuture<UploadPartResponse>();
+        failedFuture.completeExceptionally(new RuntimeException("S3 upload failed"));
+        when(mockClient.uploadPart(any(UploadPartRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(failedFuture);
+
+        // First write fills the buffer and triggers the failed upload
+        ByteBuffer firstWrite = ByteBuffer.allocate(PART_SIZE);
+        channel.write(firstWrite);
+
+        // Give the future time to complete exceptionally
+        Thread.sleep(50);
+
+        // Next write should detect the failure and throw IOException
+        ByteBuffer secondWrite = ByteBuffer.allocate(1);
+        assertThatThrownBy(() -> channel.write(secondWrite))
+            .isInstanceOf(IOException.class)
+            .hasMessageContaining("previous part upload failed");
+    }
+
+    @Test
+    @DisplayName("close throws IOException when an in-flight upload failed")
+    void closeThrowsIOExceptionOnInFlightFailure() throws Exception {
+        int maxInFlight = 2;
+        var option = new S3StreamingMultipartUpload(PART_SIZE, maxInFlight);
+        var channel = new S3StreamingMultipartUploadChannel(mockPath, mockClient, option);
+
+        // uploadPart returns a future that completes exceptionally
+        var failedFuture = new CompletableFuture<UploadPartResponse>();
+        failedFuture.completeExceptionally(new RuntimeException("Network error"));
+        when(mockClient.uploadPart(any(UploadPartRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(failedFuture);
+
+        // Write enough to trigger an upload
+        ByteBuffer data = ByteBuffer.allocate(PART_SIZE);
+        channel.write(data);
+
+        // close() should detect the failed in-flight upload and throw IOException
+        assertThatThrownBy(() -> channel.close())
+            .isInstanceOf(IOException.class)
+            .hasMessageContaining("in-flight part upload failed");
+    }
+
+    @Test
+    @DisplayName("semaphore permits are released on successful upload")
+    void permitsReleasedOnSuccess() throws Exception {
+        int maxInFlight = 1;
+        var option = new S3StreamingMultipartUpload(PART_SIZE, maxInFlight);
+        var channel = new S3StreamingMultipartUploadChannel(mockPath, mockClient, option);
+
+        // uploadPart completes immediately with success
+        when(mockClient.uploadPart(any(UploadPartRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(CompletableFuture.completedFuture(
+                UploadPartResponse.builder().eTag("etag-1").build()));
+
+        when(mockClient.completeMultipartUpload(any(CompleteMultipartUploadRequest.class)))
+            .thenReturn(CompletableFuture.completedFuture(
+                CompleteMultipartUploadResponse.builder().build()));
+
+        // With maxInFlight=1, if permits weren't released, the second write would block forever.
+        // Since uploads complete immediately, permits are released and subsequent writes proceed.
+        ByteBuffer firstWrite = ByteBuffer.allocate(PART_SIZE);
+        channel.write(firstWrite);
+
+        // This should not block because the permit was released after the first upload completed
+        ByteBuffer secondWrite = ByteBuffer.allocate(PART_SIZE);
+        channel.write(secondWrite);
+
+        // Third write should also succeed
+        ByteBuffer thirdWrite = ByteBuffer.allocate(PART_SIZE);
+        channel.write(thirdWrite);
+
+        channel.close();
+    }
+
+    @SuppressWarnings("resource")
+    @Test
+    @DisplayName("semaphore permits are released on failed upload")
+    void permitsReleasedOnFailure() throws Exception {
+        int maxInFlight = 1;
+        var option = new S3StreamingMultipartUpload(PART_SIZE, maxInFlight);
+        var channel = new S3StreamingMultipartUploadChannel(mockPath, mockClient, option);
+
+        // First upload fails
+        var failedFuture = new CompletableFuture<UploadPartResponse>();
+        failedFuture.completeExceptionally(new RuntimeException("Upload failed"));
+
+        // Second upload succeeds (if we get there)
+        when(mockClient.uploadPart(any(UploadPartRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(failedFuture);
+
+        // Write enough to trigger the failed upload
+        ByteBuffer firstWrite = ByteBuffer.allocate(PART_SIZE);
+        channel.write(firstWrite);
+
+        // Give the future time to complete
+        Thread.sleep(50);
+
+        // The permit should still be released even though the upload failed.
+        // The next write will detect the failure via checkForAsyncFailures() and throw,
+        // but the important thing is it doesn't deadlock waiting for a permit.
+        ByteBuffer secondWrite = ByteBuffer.allocate(1);
+        assertThatThrownBy(() -> channel.write(secondWrite))
+            .isInstanceOf(IOException.class);
+    }
+
+    @Test
+    @DisplayName("multiple concurrent uploads allowed up to maxInFlight")
+    void multipleConcurrentUploadsAllowed() throws Exception {
+        int maxInFlight = 3;
+        var option = new S3StreamingMultipartUpload(PART_SIZE, maxInFlight);
+        var channel = new S3StreamingMultipartUploadChannel(mockPath, mockClient, option);
+
+        // Use futures that don't complete immediately to simulate in-flight uploads
+        var future1 = new CompletableFuture<UploadPartResponse>();
+        var future2 = new CompletableFuture<UploadPartResponse>();
+        var future3 = new CompletableFuture<UploadPartResponse>();
+        var future4 = new CompletableFuture<UploadPartResponse>();
+
+        when(mockClient.uploadPart(any(UploadPartRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(future1)
+            .thenReturn(future2)
+            .thenReturn(future3)
+            .thenReturn(future4);
+
+        // Write 3 full buffers - should not block since maxInFlight=3
+        for (int i = 0; i < 3; i++) {
+            ByteBuffer data = ByteBuffer.allocate(PART_SIZE);
+            channel.write(data);
+        }
+
+        // 4th write should block because all 3 permits are taken
+        var writeBlocked = new AtomicBoolean(true);
+        var blockedLatch = new CountDownLatch(1);
+
+        Thread writerThread = new Thread(() -> {
+            try {
+                blockedLatch.countDown();
+                ByteBuffer data = ByteBuffer.allocate(PART_SIZE);
+                channel.write(data);
+                writeBlocked.set(false);
+            } catch (IOException e) {
+                // Expected
+            }
+        });
+
+        writerThread.start();
+        blockedLatch.await(2, TimeUnit.SECONDS);
+        Thread.sleep(200);
+
+        // Should still be blocked
+        assertThat(writeBlocked.get())
+            .as("4th write should block when all 3 permits are taken")
+            .isTrue();
+
+        // Release one permit
+        future1.complete(UploadPartResponse.builder().eTag("etag-1").build());
+
+        writerThread.join(2000);
+        assertThat(writeBlocked.get())
+            .as("Write should unblock after one permit is released")
+            .isFalse();
+
+        // Complete remaining futures for cleanup
+        future2.complete(UploadPartResponse.builder().eTag("etag-2").build());
+        future3.complete(UploadPartResponse.builder().eTag("etag-3").build());
+        future4.complete(UploadPartResponse.builder().eTag("etag-4").build());
+
+        when(mockClient.completeMultipartUpload(any(CompleteMultipartUploadRequest.class)))
+            .thenReturn(CompletableFuture.completedFuture(
+                CompleteMultipartUploadResponse.builder().build()));
+        channel.close();
+    }
+
+    @Test
+    @DisplayName("close propagates failure from in-flight uploads and aborts the session")
+    void closePropagatesFailureAndAborts() throws Exception {
+        int maxInFlight = 2;
+        var option = new S3StreamingMultipartUpload(PART_SIZE, maxInFlight);
+        var channel = new S3StreamingMultipartUploadChannel(mockPath, mockClient, option);
+
+        // First upload succeeds, second fails
+        var successFuture = CompletableFuture.completedFuture(
+            UploadPartResponse.builder().eTag("etag-1").build());
+        var failedFuture = new CompletableFuture<UploadPartResponse>();
+        failedFuture.completeExceptionally(new RuntimeException("Part upload timeout"));
+
+        when(mockClient.uploadPart(any(UploadPartRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(successFuture)
+            .thenReturn(failedFuture);
+
+        // Trigger two uploads
+        ByteBuffer data1 = ByteBuffer.allocate(PART_SIZE);
+        channel.write(data1);
+        ByteBuffer data2 = ByteBuffer.allocate(PART_SIZE);
+        channel.write(data2);
+
+        // close() should detect the failure during drainInFlightUploads and throw
+        assertThatThrownBy(() -> channel.close())
+            .isInstanceOf(IOException.class)
+            .hasMessageContaining("in-flight part upload failed");
+
+        // Channel should be closed after the exception
+        assertThat(channel.isOpen()).isFalse();
+    }
+
+    @Test
+    @DisplayName("Small write that doesn't fill buffer should not block")
+    void writeDoesNotBlockWhenBufferNotFull() throws Exception {
+        int maxInFlight = 1;
+        var option = new S3StreamingMultipartUpload(PART_SIZE, maxInFlight);
+        var channel = new S3StreamingMultipartUploadChannel(mockPath, mockClient, option);
+
+        // Use a hanging future to hold the permit
+        var hangingFuture = new CompletableFuture<UploadPartResponse>();
+        when(mockClient.uploadPart(any(UploadPartRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(hangingFuture);
+
+        // First write fills the buffer and triggers upload (takes the permit)
+        ByteBuffer firstWrite = ByteBuffer.allocate(PART_SIZE);
+        channel.write(firstWrite);
+
+        // A small write that doesn't fill the buffer should NOT block
+        // because no upload is triggered (no permit needed)
+        ByteBuffer smallWrite = ByteBuffer.allocate(100);
+        var writeCompleted = new AtomicBoolean(false);
+        var exceptionRef = new AtomicReference<Exception>();
+
+        Thread writerThread = new Thread(() -> {
+            try {
+                channel.write(smallWrite);
+                writeCompleted.set(true);
+            } catch (IOException e) {
+                exceptionRef.set(e);
+            }
+        });
+
+        writerThread.start();
+        writerThread.join(1000);
+
+        assertThat(writeCompleted.get())
+            .as("Small write that doesn't fill buffer should not block")
+            .isTrue();
+
+        // Clean up
+        hangingFuture.complete(UploadPartResponse.builder().eTag("etag-1").build());
+        when(mockClient.completeMultipartUpload(any(CompleteMultipartUploadRequest.class)))
+            .thenReturn(CompletableFuture.completedFuture(
+                CompleteMultipartUploadResponse.builder().build()));
+        channel.close();
+    }
+
+    // ---- Fallback to Temp-File Mode Tests ----
+
+    @Test
+    @DisplayName("backward seek triggers abort and switches to RANDOM_ACCESS mode")
+    void backwardSeekTriggersAbortAndSwitchesToRandomAccess() throws Exception {
+        int maxInFlight = 2;
+        var option = new S3StreamingMultipartUpload(PART_SIZE, maxInFlight, true);
+        var channel = new S3StreamingMultipartUploadChannel(mockPath, mockClient, option);
+
+        // uploadPart completes immediately
+        when(mockClient.uploadPart(any(UploadPartRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(CompletableFuture.completedFuture(
+                UploadPartResponse.builder().eTag("etag-1").build()));
+
+        // Write enough to trigger one part upload
+        ByteBuffer data = ByteBuffer.allocate(PART_SIZE);
+        for (int i = 0; i < PART_SIZE; i++) {
+            data.put((byte) (i % 127));
+        }
+        data.flip();
+        channel.write(data);
+
+        // Verify we're in APPEND_ONLY mode
+        assertThat(channel.getMode()).isEqualTo(S3StreamingMultipartUploadChannel.Mode.APPEND_ONLY);
+
+        // Backward seek should trigger fallback
+        channel.position(0);
+
+        // Verify mode switched to RANDOM_ACCESS
+        assertThat(channel.getMode()).isEqualTo(S3StreamingMultipartUploadChannel.Mode.RANDOM_ACCESS);
+
+        // Verify abort was called
+        verify(mockClient).abortMultipartUpload(any(AbortMultipartUploadRequest.class));
+
+        // Clean up
+        when(mockClient.putObject(any(PutObjectRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(CompletableFuture.completedFuture(PutObjectResponse.builder().build()));
+        channel.close();
+    }
+
+    @Test
+    @DisplayName("after fallback, temp file contains correct data from uploaded parts")
+    void fallbackTempFileContainsCorrectData() throws Exception {
+        int maxInFlight = 2;
+        var option = new S3StreamingMultipartUpload(PART_SIZE, maxInFlight, true);
+        var channel = new S3StreamingMultipartUploadChannel(mockPath, mockClient, option);
+
+        // uploadPart completes immediately
+        when(mockClient.uploadPart(any(UploadPartRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(CompletableFuture.completedFuture(
+                UploadPartResponse.builder().eTag("etag-1").build()));
+
+        // Write a full part with known data
+        byte[] partData = new byte[PART_SIZE];
+        for (int i = 0; i < PART_SIZE; i++) {
+            partData[i] = (byte) (i % 127);
+        }
+        channel.write(ByteBuffer.wrap(partData));
+
+        // Write some additional data to the current buffer (not yet uploaded)
+        byte[] bufferData = new byte[100];
+        for (int i = 0; i < 100; i++) {
+            bufferData[i] = (byte) (i + 50);
+        }
+        channel.write(ByteBuffer.wrap(bufferData));
+
+        // Trigger fallback
+        channel.position(0);
+
+        // Read the temp file and verify its content
+        var tempFilePath = channel.getTempFile();
+        assertThat(tempFilePath).isNotNull();
+
+        byte[] tempFileContent = Files.readAllBytes(tempFilePath);
+        assertThat(tempFileContent.length).isEqualTo(PART_SIZE + 100);
+
+        // Verify the first part data
+        for (int i = 0; i < PART_SIZE; i++) {
+            assertThat(tempFileContent[i]).isEqualTo((byte) (i % 127));
+        }
+
+        // Verify the buffer data
+        for (int i = 0; i < 100; i++) {
+            assertThat(tempFileContent[PART_SIZE + i]).isEqualTo((byte) (i + 50));
+        }
+
+        // Clean up
+        when(mockClient.putObject(any(PutObjectRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(CompletableFuture.completedFuture(PutObjectResponse.builder().build()));
+        channel.close();
+    }
+
+    @Test
+    @DisplayName("after fallback, writes go to temp file")
+    void afterFallbackWritesGoToTempFile() throws Exception {
+        int maxInFlight = 2;
+        var option = new S3StreamingMultipartUpload(PART_SIZE, maxInFlight, true);
+        var channel = new S3StreamingMultipartUploadChannel(mockPath, mockClient, option);
+
+        // uploadPart completes immediately
+        when(mockClient.uploadPart(any(UploadPartRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(CompletableFuture.completedFuture(
+                UploadPartResponse.builder().eTag("etag-1").build()));
+
+        // Write a full part
+        byte[] originalData = new byte[PART_SIZE];
+        for (int i = 0; i < PART_SIZE; i++) {
+            originalData[i] = (byte) 'A';
+        }
+        channel.write(ByteBuffer.wrap(originalData));
+
+        // Trigger fallback to position 0
+        channel.position(0);
+
+        // Write new data at position 0 (overwriting)
+        byte[] newData = new byte[10];
+        for (int i = 0; i < 10; i++) {
+            newData[i] = (byte) 'B';
+        }
+        channel.write(ByteBuffer.wrap(newData));
+
+        // Read the temp file and verify the overwrite
+        var tempFilePath = channel.getTempFile();
+        byte[] tempFileContent = Files.readAllBytes(tempFilePath);
+
+        // First 10 bytes should be 'B' (overwritten)
+        for (int i = 0; i < 10; i++) {
+            assertThat(tempFileContent[i]).isEqualTo((byte) 'B');
+        }
+
+        // Remaining bytes should still be 'A'
+        for (int i = 10; i < PART_SIZE; i++) {
+            assertThat(tempFileContent[i]).isEqualTo((byte) 'A');
+        }
+
+        // Clean up
+        when(mockClient.putObject(any(PutObjectRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(CompletableFuture.completedFuture(PutObjectResponse.builder().build()));
+        channel.close();
+    }
+
+    @Test
+    @DisplayName("close in random-access mode uploads temp file via PutObject")
+    void closeInRandomAccessModeUploadsTempFile() throws Exception {
+        int maxInFlight = 2;
+        var option = new S3StreamingMultipartUpload(PART_SIZE, maxInFlight, true);
+        var channel = new S3StreamingMultipartUploadChannel(mockPath, mockClient, option);
+
+        // uploadPart completes immediately
+        when(mockClient.uploadPart(any(UploadPartRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(CompletableFuture.completedFuture(
+                UploadPartResponse.builder().eTag("etag-1").build()));
+
+        // putObject should succeed
+        when(mockClient.putObject(any(PutObjectRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(CompletableFuture.completedFuture(PutObjectResponse.builder().build()));
+
+        // Write a full part
+        ByteBuffer data = ByteBuffer.allocate(PART_SIZE);
+        channel.write(data);
+
+        // Trigger fallback
+        channel.position(0);
+
+        // Close should upload via PutObject
+        channel.close();
+
+        // Verify putObject was called
+        verify(mockClient).putObject(any(PutObjectRequest.class), any(AsyncRequestBody.class));
+
+        // Verify completeMultipartUpload was NOT called (we aborted)
+        verify(mockClient, never()).completeMultipartUpload(any(CompleteMultipartUploadRequest.class));
+    }
+
+    @Test
+    @DisplayName("forward seek triggers fallback to temp-file mode")
+    void forwardSeekTriggersFallback() throws Exception {
+        int maxInFlight = 2;
+        var option = new S3StreamingMultipartUpload(PART_SIZE, maxInFlight, true);
+        var channel = new S3StreamingMultipartUploadChannel(mockPath, mockClient, option);
+
+        // uploadPart completes immediately
+        when(mockClient.uploadPart(any(UploadPartRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(CompletableFuture.completedFuture(
+                UploadPartResponse.builder().eTag("etag-1").build()));
+
+        // Write some data
+        ByteBuffer data = ByteBuffer.allocate(100);
+        channel.write(data);
+
+        // Forward seek should trigger fallback (creates a gap that can't be represented in streaming mode)
+        channel.position(200);
+
+        // Verify mode switched to RANDOM_ACCESS
+        assertThat(channel.getMode()).isEqualTo(S3StreamingMultipartUploadChannel.Mode.RANDOM_ACCESS);
+
+        // Verify abort was called (multipart session aborted)
+        verify(mockClient).abortMultipartUpload(any(AbortMultipartUploadRequest.class));
+
+        // Clean up
+        when(mockClient.putObject(any(PutObjectRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(CompletableFuture.completedFuture(PutObjectResponse.builder().build()));
+        channel.close();
+    }
+
+    @Test
+    @DisplayName("forward seek across part boundaries triggers fallback and preserves data")
+    void forwardSeekAcrossPartBoundariesPreservesData() throws Exception {
+        int maxInFlight = 2;
+        var option = new S3StreamingMultipartUpload(PART_SIZE, maxInFlight, true);
+        var channel = new S3StreamingMultipartUploadChannel(mockPath, mockClient, option);
+
+        // uploadPart completes immediately
+        when(mockClient.uploadPart(any(UploadPartRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(CompletableFuture.completedFuture(
+                UploadPartResponse.builder().eTag("etag-1").build()));
+
+        // Write some initial data (less than one part)
+        byte[] initialData = new byte[1000];
+        for (int i = 0; i < 1000; i++) {
+            initialData[i] = (byte) (i % 127);
+        }
+        channel.write(ByteBuffer.wrap(initialData));
+
+        // Forward seek past multiple part boundaries
+        long seekTarget = (long) PART_SIZE * 3;
+        channel.position(seekTarget);
+
+        // Verify fallback occurred
+        assertThat(channel.getMode()).isEqualTo(S3StreamingMultipartUploadChannel.Mode.RANDOM_ACCESS);
+
+        // Verify temp file has the initial data at the beginning
+        var tempFilePath = channel.getTempFile();
+        byte[] tempFileContent = Files.readAllBytes(tempFilePath);
+        assertThat(tempFileContent.length).isEqualTo(1000);
+        for (int i = 0; i < 1000; i++) {
+            assertThat(tempFileContent[i]).isEqualTo((byte) (i % 127));
+        }
+
+        // Verify position is at the seek target
+        assertThat(channel.position()).isEqualTo(seekTarget);
+
+        // Write after the gap — this goes to the temp file at the seeked position
+        byte[] afterGapData = new byte[]{42, 43, 44};
+        channel.write(ByteBuffer.wrap(afterGapData));
+
+        // Clean up
+        when(mockClient.putObject(any(PutObjectRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(CompletableFuture.completedFuture(PutObjectResponse.builder().build()));
+        channel.close();
+    }
+
+    @Test
+    @DisplayName("position(currentPosition) does not trigger fallback (no-op)")
+    void positionAtCurrentPositionDoesNotTriggerFallback() throws Exception {
+        int maxInFlight = 2;
+        var option = new S3StreamingMultipartUpload(PART_SIZE, maxInFlight);
+        var channel = new S3StreamingMultipartUploadChannel(mockPath, mockClient, option);
+
+        // uploadPart completes immediately
+        when(mockClient.uploadPart(any(UploadPartRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(CompletableFuture.completedFuture(
+                UploadPartResponse.builder().eTag("etag-1").build()));
+
+        // Write some data
+        ByteBuffer data = ByteBuffer.allocate(100);
+        channel.write(data);
+
+        // Setting position to current position should be a no-op
+        channel.position(100);
+
+        // Verify still in APPEND_ONLY mode
+        assertThat(channel.getMode()).isEqualTo(S3StreamingMultipartUploadChannel.Mode.APPEND_ONLY);
+
+        // Verify abort was NOT called
+        verify(mockClient, never()).abortMultipartUpload(any(AbortMultipartUploadRequest.class));
+
+        // Clean up
+        when(mockClient.completeMultipartUpload(any(CompleteMultipartUploadRequest.class)))
+            .thenReturn(CompletableFuture.completedFuture(
+                CompleteMultipartUploadResponse.builder().build()));
+        channel.close();
+    }
+
+    @Test
+    @DisplayName("forward seek by 1 byte triggers fallback")
+    void forwardSeekByOneByteTrigersFallback() throws Exception {
+        int maxInFlight = 2;
+        var option = new S3StreamingMultipartUpload(PART_SIZE, maxInFlight, true);
+        var channel = new S3StreamingMultipartUploadChannel(mockPath, mockClient, option);
+
+        // Write some data
+        ByteBuffer data = ByteBuffer.allocate(100);
+        channel.write(data);
+
+        // Even a 1-byte forward seek triggers fallback
+        channel.position(101);
+
+        // Verify mode switched to RANDOM_ACCESS
+        assertThat(channel.getMode()).isEqualTo(S3StreamingMultipartUploadChannel.Mode.RANDOM_ACCESS);
+
+        // Clean up
+        when(mockClient.putObject(any(PutObjectRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(CompletableFuture.completedFuture(PutObjectResponse.builder().build()));
+        channel.close();
+    }
+
+    @Test
+    @DisplayName("size delegates to temp file channel in random-access mode")
+    void sizeDelegatesToTempFileInRandomAccessMode() throws Exception {
+        int maxInFlight = 2;
+        var option = new S3StreamingMultipartUpload(PART_SIZE, maxInFlight, true);
+        var channel = new S3StreamingMultipartUploadChannel(mockPath, mockClient, option);
+
+        // uploadPart completes immediately
+        when(mockClient.uploadPart(any(UploadPartRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(CompletableFuture.completedFuture(
+                UploadPartResponse.builder().eTag("etag-1").build()));
+
+        // Write a full part
+        ByteBuffer data = ByteBuffer.allocate(PART_SIZE);
+        channel.write(data);
+
+        // Trigger fallback
+        channel.position(0);
+
+        // Size should reflect the temp file size (which is PART_SIZE)
+        assertThat(channel.size()).isEqualTo(PART_SIZE);
+
+        // Clean up
+        when(mockClient.putObject(any(PutObjectRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(CompletableFuture.completedFuture(PutObjectResponse.builder().build()));
+        channel.close();
+    }
+
+    @Test
+    @DisplayName("position in random-access mode delegates to temp file channel")
+    void positionInRandomAccessModeDelegatesToTempFile() throws Exception {
+        int maxInFlight = 2;
+        var option = new S3StreamingMultipartUpload(PART_SIZE, maxInFlight, true);
+        var channel = new S3StreamingMultipartUploadChannel(mockPath, mockClient, option);
+
+        // uploadPart completes immediately
+        when(mockClient.uploadPart(any(UploadPartRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(CompletableFuture.completedFuture(
+                UploadPartResponse.builder().eTag("etag-1").build()));
+
+        // Write a full part
+        ByteBuffer data = ByteBuffer.allocate(PART_SIZE);
+        channel.write(data);
+
+        // Trigger fallback to position 0
+        channel.position(0);
+        assertThat(channel.position()).isEqualTo(0);
+
+        // Seek forward within the temp file
+        channel.position(100);
+        assertThat(channel.position()).isEqualTo(100);
+
+        // Seek backward within the temp file (allowed in RANDOM_ACCESS mode)
+        channel.position(50);
+        assertThat(channel.position()).isEqualTo(50);
+
+        // Clean up
+        when(mockClient.putObject(any(PutObjectRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(CompletableFuture.completedFuture(PutObjectResponse.builder().build()));
+        channel.close();
+    }
+
+    @Test
+    @DisplayName("close in random-access mode throws IOException on upload failure")
+    void closeInRandomAccessModeThrowsOnUploadFailure() throws Exception {
+        int maxInFlight = 2;
+        var option = new S3StreamingMultipartUpload(PART_SIZE, maxInFlight, true);
+        var channel = new S3StreamingMultipartUploadChannel(mockPath, mockClient, option);
+
+        // uploadPart completes immediately
+        when(mockClient.uploadPart(any(UploadPartRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(CompletableFuture.completedFuture(
+                UploadPartResponse.builder().eTag("etag-1").build()));
+
+        // putObject fails
+        var failedFuture = new CompletableFuture<PutObjectResponse>();
+        failedFuture.completeExceptionally(new RuntimeException("PutObject failed"));
+        when(mockClient.putObject(any(PutObjectRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(failedFuture);
+
+        // Write a full part
+        ByteBuffer data = ByteBuffer.allocate(PART_SIZE);
+        channel.write(data);
+
+        // Trigger fallback
+        channel.position(0);
+
+        // Close should throw IOException due to PutObject failure
+        assertThatThrownBy(() -> channel.close())
+            .isInstanceOf(IOException.class)
+            .hasMessageContaining("Failed to upload temp file");
+    }
+
+    @Test
+    @DisplayName("fallback with no prior uploads creates temp file with only buffer data")
+    void fallbackWithNoUploadsCreatesEmptyTempFile() throws Exception {
+        int maxInFlight = 2;
+        var option = new S3StreamingMultipartUpload(PART_SIZE, maxInFlight, true);
+        var channel = new S3StreamingMultipartUploadChannel(mockPath, mockClient, option);
+
+        // Write some data that doesn't fill the buffer (no upload triggered)
+        byte[] smallData = new byte[100];
+        for (int i = 0; i < 100; i++) {
+            smallData[i] = (byte) (i + 1);
+        }
+        channel.write(ByteBuffer.wrap(smallData));
+
+        // Trigger fallback
+        channel.position(0);
+
+        // Verify mode switched
+        assertThat(channel.getMode()).isEqualTo(S3StreamingMultipartUploadChannel.Mode.RANDOM_ACCESS);
+
+        // Verify temp file contains the buffer data
+        var tempFilePath = channel.getTempFile();
+        byte[] tempFileContent = Files.readAllBytes(tempFilePath);
+        assertThat(tempFileContent.length).isEqualTo(100);
+        for (int i = 0; i < 100; i++) {
+            assertThat(tempFileContent[i]).isEqualTo((byte) (i + 1));
+        }
+
+        // Clean up
+        when(mockClient.putObject(any(PutObjectRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(CompletableFuture.completedFuture(PutObjectResponse.builder().build()));
+        channel.close();
+    }
+
+    @Test
+    @DisplayName("fallback drains in-flight uploads best-effort ignoring failures")
+    void fallbackDrainsInFlightBestEffort() throws Exception {
+        int maxInFlight = 2;
+        var option = new S3StreamingMultipartUpload(PART_SIZE, maxInFlight, true);
+        var channel = new S3StreamingMultipartUploadChannel(mockPath, mockClient, option);
+
+        // First upload fails
+        var failedFuture = new CompletableFuture<UploadPartResponse>();
+        failedFuture.completeExceptionally(new RuntimeException("Upload failed"));
+        when(mockClient.uploadPart(any(UploadPartRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(failedFuture);
+
+        // Write a full part (triggers the failed upload)
+        ByteBuffer data = ByteBuffer.allocate(PART_SIZE);
+        channel.write(data);
+
+        // Give the future time to complete
+        Thread.sleep(50);
+
+        // Trigger fallback - should not throw despite the failed in-flight upload
+        channel.position(0);
+
+        // Verify mode switched to RANDOM_ACCESS
+        assertThat(channel.getMode()).isEqualTo(S3StreamingMultipartUploadChannel.Mode.RANDOM_ACCESS);
+
+        // Clean up
+        when(mockClient.putObject(any(PutObjectRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(CompletableFuture.completedFuture(PutObjectResponse.builder().build()));
+        channel.close();
+    }
+
+    @Test
+    @DisplayName("read throws NonReadableChannelException")
+    void readThrowsNonReadableChannelException() throws Exception {
+        int maxInFlight = 2;
+        var option = new S3StreamingMultipartUpload(PART_SIZE, maxInFlight);
+        var channel = new S3StreamingMultipartUploadChannel(mockPath, mockClient, option);
+
+        assertThatThrownBy(() -> channel.read(ByteBuffer.allocate(10)))
+            .isInstanceOf(java.nio.channels.NonReadableChannelException.class);
+
+        channel.close();
+    }
+
+    @Test
+    @DisplayName("truncate throws UnsupportedOperationException")
+    void truncateThrowsUnsupportedOperationException() throws Exception {
+        int maxInFlight = 2;
+        var option = new S3StreamingMultipartUpload(PART_SIZE, maxInFlight);
+        var channel = new S3StreamingMultipartUploadChannel(mockPath, mockClient, option);
+
+        assertThatThrownBy(() -> channel.truncate(100))
+            .isInstanceOf(UnsupportedOperationException.class);
+
+        channel.close();
+    }
+
+    @Test
+    @DisplayName("write on closed channel throws ClosedChannelException")
+    void writeOnClosedChannelThrowsClosedChannelException() throws Exception {
+        int maxInFlight = 2;
+        var option = new S3StreamingMultipartUpload(PART_SIZE, maxInFlight);
+        var channel = new S3StreamingMultipartUploadChannel(mockPath, mockClient, option);
+
+        channel.close();
+
+        assertThatThrownBy(() -> channel.write(ByteBuffer.allocate(10)))
+            .isInstanceOf(java.nio.channels.ClosedChannelException.class);
+    }
+
+    @Test
+    @DisplayName("position with negative value throws IllegalArgumentException")
+    void positionWithNegativeValueThrows() throws Exception {
+        int maxInFlight = 2;
+        var option = new S3StreamingMultipartUpload(PART_SIZE, maxInFlight);
+        var channel = new S3StreamingMultipartUploadChannel(mockPath, mockClient, option);
+
+        assertThatThrownBy(() -> channel.position(-1))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("negative");
+
+        channel.close();
+    }
+
+    @Test
+    @DisplayName("close without any writes does not initiate multipart session")
+    void closeWithoutWritesDoesNotInitiateSession() throws Exception {
+        int maxInFlight = 2;
+        var option = new S3StreamingMultipartUpload(PART_SIZE, maxInFlight);
+        var channel = new S3StreamingMultipartUploadChannel(mockPath, mockClient, option);
+
+        channel.close();
+
+        // Verify no S3 calls were made
+        verify(mockClient, never()).createMultipartUpload(any(CreateMultipartUploadRequest.class));
+        verify(mockClient, never()).completeMultipartUpload(any(CompleteMultipartUploadRequest.class));
+    }
+
+    @Test
+    @DisplayName("close is idempotent - second close has no effect")
+    void closeIsIdempotent() throws Exception {
+        int maxInFlight = 2;
+        var option = new S3StreamingMultipartUpload(PART_SIZE, maxInFlight);
+        var channel = new S3StreamingMultipartUploadChannel(mockPath, mockClient, option);
+
+        // uploadPart completes immediately
+        when(mockClient.uploadPart(any(UploadPartRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(CompletableFuture.completedFuture(
+                UploadPartResponse.builder().eTag("etag-1").build()));
+        when(mockClient.completeMultipartUpload(any(CompleteMultipartUploadRequest.class)))
+            .thenReturn(CompletableFuture.completedFuture(
+                CompleteMultipartUploadResponse.builder().build()));
+
+        // Write some data
+        ByteBuffer data = ByteBuffer.allocate(100);
+        channel.write(data);
+
+        // First close
+        channel.close();
+        assertThat(channel.isOpen()).isFalse();
+
+        // Second close should not throw
+        channel.close();
+    }
+
+    @Test
+    @DisplayName("write with empty buffer returns 0 in append-only mode")
+    void writeWithEmptyBufferReturnsZero() throws Exception {
+        int maxInFlight = 2;
+        var option = new S3StreamingMultipartUpload(PART_SIZE, maxInFlight);
+        var channel = new S3StreamingMultipartUploadChannel(mockPath, mockClient, option);
+
+        // Write with empty buffer
+        ByteBuffer emptyBuffer = ByteBuffer.allocate(0);
+        int bytesWritten = channel.write(emptyBuffer);
+        assertThat(bytesWritten).isEqualTo(0);
+
+        channel.close();
+    }
+
+    @Test
+    @DisplayName("position getter returns current position")
+    void positionGetterReturnsCurrentPosition() throws Exception {
+        int maxInFlight = 2;
+        var option = new S3StreamingMultipartUpload(PART_SIZE, maxInFlight);
+        var channel = new S3StreamingMultipartUploadChannel(mockPath, mockClient, option);
+
+        assertThat(channel.position()).isEqualTo(0);
+
+        // Set up uploadPart mock for the flush on close
+        when(mockClient.uploadPart(any(UploadPartRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(CompletableFuture.completedFuture(
+                UploadPartResponse.builder().eTag("etag-1").build()));
+
+        // Write some data (less than part size, so no upload triggered during write)
+        ByteBuffer data = ByteBuffer.allocate(100);
+        channel.write(data);
+
+        assertThat(channel.position()).isEqualTo(100);
+
+        // Clean up
+        when(mockClient.completeMultipartUpload(any(CompleteMultipartUploadRequest.class)))
+            .thenReturn(CompletableFuture.completedFuture(
+                CompleteMultipartUploadResponse.builder().build()));
+        channel.close();
+    }
+
+    // ---- Error Handling and Cleanup Tests (Task 6) ----
+
+    @Test
+    @DisplayName("upload failure triggers abort with upload ID and part count logging")
+    void uploadFailureTriggersAbort() throws Exception {
+        int maxInFlight = 2;
+        var option = new S3StreamingMultipartUpload(PART_SIZE, maxInFlight);
+        var channel = new S3StreamingMultipartUploadChannel(mockPath, mockClient, option);
+
+        // First upload succeeds, second fails
+        var successFuture = CompletableFuture.completedFuture(
+            UploadPartResponse.builder().eTag("etag-1").build());
+        var failedFuture = new CompletableFuture<UploadPartResponse>();
+        failedFuture.completeExceptionally(new RuntimeException("S3 error"));
+
+        when(mockClient.uploadPart(any(UploadPartRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(successFuture)
+            .thenReturn(failedFuture);
+
+        // Trigger two uploads
+        ByteBuffer data1 = ByteBuffer.allocate(PART_SIZE);
+        channel.write(data1);
+        ByteBuffer data2 = ByteBuffer.allocate(PART_SIZE);
+        channel.write(data2);
+
+        // close() should detect the failure and call abort
+        assertThatThrownBy(() -> channel.close())
+            .isInstanceOf(IOException.class);
+
+        // Verify abort was called
+        verify(mockClient).abortMultipartUpload(any(AbortMultipartUploadRequest.class));
+    }
+
+    @Test
+    @DisplayName("CompleteMultipartUpload failure triggers abort then throws IOException")
+    void completeFailureTriggersAbortThenThrows() throws Exception {
+        int maxInFlight = 2;
+        var option = new S3StreamingMultipartUpload(PART_SIZE, maxInFlight);
+        var channel = new S3StreamingMultipartUploadChannel(mockPath, mockClient, option);
+
+        // uploadPart succeeds
+        when(mockClient.uploadPart(any(UploadPartRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(CompletableFuture.completedFuture(
+                UploadPartResponse.builder().eTag("etag-1").build()));
+
+        // completeMultipartUpload fails
+        var failedComplete = new CompletableFuture<CompleteMultipartUploadResponse>();
+        failedComplete.completeExceptionally(new RuntimeException("Complete failed"));
+        when(mockClient.completeMultipartUpload(any(CompleteMultipartUploadRequest.class)))
+            .thenReturn(failedComplete);
+
+        // Write some data
+        ByteBuffer data = ByteBuffer.allocate(100);
+        channel.write(data);
+
+        // close() should throw IOException and call abort
+        assertThatThrownBy(() -> channel.close())
+            .isInstanceOf(IOException.class)
+            .hasMessageContaining("Failed to complete multipart upload");
+
+        // Verify abort was called after complete failure
+        verify(mockClient).abortMultipartUpload(any(AbortMultipartUploadRequest.class));
+    }
+
+    @Test
+    @DisplayName("shutdown hook is registered on first write")
+    void shutdownHookRegisteredOnFirstWrite() throws Exception {
+        int maxInFlight = 2;
+        var option = new S3StreamingMultipartUpload(PART_SIZE, maxInFlight);
+        var channel = new S3StreamingMultipartUploadChannel(mockPath, mockClient, option);
+
+        // Before any write, no shutdown hook
+        assertThat(channel.getShutdownHook()).isNull();
+
+        // Write triggers multipart upload initiation which registers the hook
+        ByteBuffer data = ByteBuffer.allocate(10);
+        channel.write(data);
+
+        // Shutdown hook should now be registered
+        assertThat(channel.getShutdownHook()).isNotNull();
+
+        // Clean up
+        when(mockClient.uploadPart(any(UploadPartRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(CompletableFuture.completedFuture(
+                UploadPartResponse.builder().eTag("etag-1").build()));
+        when(mockClient.completeMultipartUpload(any(CompleteMultipartUploadRequest.class)))
+            .thenReturn(CompletableFuture.completedFuture(
+                CompleteMultipartUploadResponse.builder().build()));
+        channel.close();
+    }
+
+    @Test
+    @DisplayName("shutdown hook is deregistered on successful close")
+    void shutdownHookDeregisteredOnSuccessfulClose() throws Exception {
+        int maxInFlight = 2;
+        var option = new S3StreamingMultipartUpload(PART_SIZE, maxInFlight);
+        var channel = new S3StreamingMultipartUploadChannel(mockPath, mockClient, option);
+
+        // uploadPart succeeds
+        when(mockClient.uploadPart(any(UploadPartRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(CompletableFuture.completedFuture(
+                UploadPartResponse.builder().eTag("etag-1").build()));
+        when(mockClient.completeMultipartUpload(any(CompleteMultipartUploadRequest.class)))
+            .thenReturn(CompletableFuture.completedFuture(
+                CompleteMultipartUploadResponse.builder().build()));
+
+        // Write data to trigger session initiation
+        ByteBuffer data = ByteBuffer.allocate(10);
+        channel.write(data);
+
+        // Verify hook is registered
+        assertThat(channel.getShutdownHook()).isNotNull();
+
+        // Close successfully
+        channel.close();
+
+        // Verify hook is deregistered
+        assertThat(channel.getShutdownHook()).isNull();
+    }
+
+    @Test
+    @DisplayName("timeout retry: upload retries once on timeout then succeeds")
+    void timeoutRetrySucceedsOnSecondAttempt() throws Exception {
+        int maxInFlight = 2;
+        var option = new S3StreamingMultipartUpload(PART_SIZE, maxInFlight);
+        var channel = new S3StreamingMultipartUploadChannel(mockPath, mockClient, option);
+
+        // First call times out, second call succeeds
+        var timeoutFuture = new CompletableFuture<UploadPartResponse>();
+        timeoutFuture.completeExceptionally(new java.util.concurrent.TimeoutException("Request timed out"));
+
+        var successFuture = CompletableFuture.completedFuture(
+            UploadPartResponse.builder().eTag("etag-1").build());
+
+        when(mockClient.uploadPart(any(UploadPartRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(timeoutFuture)
+            .thenReturn(successFuture);
+
+        when(mockClient.completeMultipartUpload(any(CompleteMultipartUploadRequest.class)))
+            .thenReturn(CompletableFuture.completedFuture(
+                CompleteMultipartUploadResponse.builder().build()));
+
+        // Write a full part to trigger upload
+        ByteBuffer data = ByteBuffer.allocate(PART_SIZE);
+        channel.write(data);
+
+        // Close should succeed because the retry worked
+        channel.close();
+
+        // Verify uploadPart was called twice (original + retry)
+        verify(mockClient, org.mockito.Mockito.times(2))
+            .uploadPart(any(UploadPartRequest.class), any(AsyncRequestBody.class));
+    }
+
+    @Test
+    @DisplayName("timeout retry: upload fails after retry also times out")
+    void timeoutRetryFailsAfterSecondTimeout() throws Exception {
+        int maxInFlight = 2;
+        var option = new S3StreamingMultipartUpload(PART_SIZE, maxInFlight);
+        var channel = new S3StreamingMultipartUploadChannel(mockPath, mockClient, option);
+
+        // Both calls time out
+        var timeoutFuture1 = new CompletableFuture<UploadPartResponse>();
+        timeoutFuture1.completeExceptionally(new java.util.concurrent.TimeoutException("Request timed out"));
+
+        var timeoutFuture2 = new CompletableFuture<UploadPartResponse>();
+        timeoutFuture2.completeExceptionally(new java.util.concurrent.TimeoutException("Retry also timed out"));
+
+        when(mockClient.uploadPart(any(UploadPartRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(timeoutFuture1)
+            .thenReturn(timeoutFuture2);
+
+        // Write a full part to trigger upload
+        ByteBuffer data = ByteBuffer.allocate(PART_SIZE);
+        channel.write(data);
+
+        // Give futures time to complete
+        Thread.sleep(50);
+
+        // close() should detect the failure and throw
+        assertThatThrownBy(() -> channel.close())
+            .isInstanceOf(IOException.class);
+
+        // Verify abort was called
+        verify(mockClient).abortMultipartUpload(any(AbortMultipartUploadRequest.class));
+    }
+
+    @Test
+    @DisplayName("non-timeout failure does not trigger retry")
+    void nonTimeoutFailureDoesNotRetry() throws Exception {
+        int maxInFlight = 2;
+        var option = new S3StreamingMultipartUpload(PART_SIZE, maxInFlight);
+        var channel = new S3StreamingMultipartUploadChannel(mockPath, mockClient, option);
+
+        // Upload fails with a non-timeout error
+        var failedFuture = new CompletableFuture<UploadPartResponse>();
+        failedFuture.completeExceptionally(new RuntimeException("Access denied"));
+
+        when(mockClient.uploadPart(any(UploadPartRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(failedFuture);
+
+        // Write a full part to trigger upload
+        ByteBuffer data = ByteBuffer.allocate(PART_SIZE);
+        channel.write(data);
+
+        // Give future time to complete
+        Thread.sleep(50);
+
+        // close() should detect the failure
+        assertThatThrownBy(() -> channel.close())
+            .isInstanceOf(IOException.class);
+
+        // Verify uploadPart was called only once (no retry for non-timeout)
+        verify(mockClient, org.mockito.Mockito.times(1))
+            .uploadPart(any(UploadPartRequest.class), any(AsyncRequestBody.class));
+    }
+
+    // ---- Part Limit Enforcement Tests (Task 7) ----
+
+    @Test
+    @DisplayName("part limit exceeded throws IllegalStateException at 10,001st part")
+    void partLimitExceeded_throwsIllegalStateException() throws Exception {
+        int maxInFlight = 2;
+        var option = new S3StreamingMultipartUpload(PART_SIZE, maxInFlight);
+        var channel = new S3StreamingMultipartUploadChannel(mockPath, mockClient, option);
+
+        // uploadPart completes immediately
+        when(mockClient.uploadPart(any(UploadPartRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(CompletableFuture.completedFuture(
+                UploadPartResponse.builder().eTag("etag-1").build()));
+
+        // Write first part to initiate the session
+        channel.write(ByteBuffer.allocate(PART_SIZE));
+
+        // Use reflection to set nextPartNumber to MAX_PARTS + 1 (simulating 10,000 parts already uploaded)
+        var field = S3StreamingMultipartUploadChannel.class.getDeclaredField("nextPartNumber");
+        field.setAccessible(true);
+        field.setInt(channel, S3StreamingMultipartUpload.MAX_PARTS + 1);
+
+        // Next write that fills the buffer should throw IllegalStateException
+        assertThatThrownBy(() -> channel.write(ByteBuffer.allocate(PART_SIZE)))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("10000")
+            .hasMessageContaining(String.valueOf(PART_SIZE));
+    }
+
+    @Test
+    @DisplayName("part limit exceeded triggers abort of multipart upload")
+    void partLimitExceeded_triggersAbort() throws Exception {
+        int maxInFlight = 2;
+        var option = new S3StreamingMultipartUpload(PART_SIZE, maxInFlight);
+        var channel = new S3StreamingMultipartUploadChannel(mockPath, mockClient, option);
+
+        // uploadPart completes immediately
+        when(mockClient.uploadPart(any(UploadPartRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(CompletableFuture.completedFuture(
+                UploadPartResponse.builder().eTag("etag-1").build()));
+
+        // Write first part to initiate the session
+        channel.write(ByteBuffer.allocate(PART_SIZE));
+
+        // Use reflection to set nextPartNumber to MAX_PARTS + 1
+        var field = S3StreamingMultipartUploadChannel.class.getDeclaredField("nextPartNumber");
+        field.setAccessible(true);
+        field.setInt(channel, S3StreamingMultipartUpload.MAX_PARTS + 1);
+
+        // Trigger the part limit check
+        try {
+            channel.write(ByteBuffer.allocate(PART_SIZE));
+        } catch (IllegalStateException e) {
+            // Expected
+        }
+
+        // Verify abort was called
+        verify(mockClient).abortMultipartUpload(any(AbortMultipartUploadRequest.class));
+    }
+
+    @Test
+    @DisplayName("part limit error message contains part size and total bytes written")
+    void partLimitExceeded_errorMessageContainsDetails() throws Exception {
+        int maxInFlight = 2;
+        var option = new S3StreamingMultipartUpload(PART_SIZE, maxInFlight);
+        var channel = new S3StreamingMultipartUploadChannel(mockPath, mockClient, option);
+
+        // uploadPart completes immediately
+        when(mockClient.uploadPart(any(UploadPartRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(CompletableFuture.completedFuture(
+                UploadPartResponse.builder().eTag("etag-1").build()));
+
+        // Write first part to initiate the session
+        channel.write(ByteBuffer.allocate(PART_SIZE));
+
+        // Use reflection to set nextPartNumber to MAX_PARTS + 1
+        var field = S3StreamingMultipartUploadChannel.class.getDeclaredField("nextPartNumber");
+        field.setAccessible(true);
+        field.setInt(channel, S3StreamingMultipartUpload.MAX_PARTS + 1);
+
+        // Next write that fills the buffer should throw with descriptive message
+        assertThatThrownBy(() -> channel.write(ByteBuffer.allocate(PART_SIZE)))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining(String.valueOf(S3StreamingMultipartUpload.MAX_PARTS))
+            .hasMessageContaining(String.valueOf(PART_SIZE))
+            .hasMessageContaining("total bytes written")
+            .hasMessageContaining("Consider increasing the part size");
+    }
+
+    @Test
+    @DisplayName("abort failure does not throw, just logs warning")
+    void abortFailureDoesNotThrow() throws Exception {
+        int maxInFlight = 2;
+        var option = new S3StreamingMultipartUpload(PART_SIZE, maxInFlight);
+        var channel = new S3StreamingMultipartUploadChannel(mockPath, mockClient, option);
+
+        // uploadPart fails
+        var failedFuture = new CompletableFuture<UploadPartResponse>();
+        failedFuture.completeExceptionally(new RuntimeException("Upload error"));
+        when(mockClient.uploadPart(any(UploadPartRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(failedFuture);
+
+        // abortMultipartUpload also fails
+        var abortFailedFuture = new CompletableFuture<AbortMultipartUploadResponse>();
+        abortFailedFuture.completeExceptionally(new RuntimeException("Abort also failed"));
+        when(mockClient.abortMultipartUpload(any(AbortMultipartUploadRequest.class)))
+            .thenReturn(abortFailedFuture);
+
+        // Write a full part to trigger the failed upload
+        ByteBuffer data = ByteBuffer.allocate(PART_SIZE);
+        channel.write(data);
+
+        // Give future time to complete
+        Thread.sleep(50);
+
+        // close() should throw IOException for the upload failure,
+        // but the abort failure should not cause an additional exception
+        assertThatThrownBy(() -> channel.close())
+            .isInstanceOf(IOException.class)
+            .hasMessageContaining("in-flight part upload failed");
+
+        // Verify abort was attempted
+        verify(mockClient).abortMultipartUpload(any(AbortMultipartUploadRequest.class));
+
+        // Channel should be closed (no additional exception from abort failure)
+        assertThat(channel.isOpen()).isFalse();
+    }
+
+    // ---- Fallback Disabled (Strict Append-Only Mode) Tests ----
+
+    @Test
+    @DisplayName("fallback disabled: seek throws UnsupportedOperationException")
+    void fallbackDisabled_seekThrowsUnsupportedOperationException() throws Exception {
+        var option = new S3StreamingMultipartUpload(PART_SIZE, 2, false);
+        var channel = new S3StreamingMultipartUploadChannel(mockPath, mockClient, option);
+
+        when(mockClient.uploadPart(any(UploadPartRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(CompletableFuture.completedFuture(
+                UploadPartResponse.builder().eTag("etag-1").build()));
+        when(mockClient.completeMultipartUpload(any(CompleteMultipartUploadRequest.class)))
+            .thenReturn(CompletableFuture.completedFuture(
+                CompleteMultipartUploadResponse.builder().build()));
+
+        // Write some data
+        ByteBuffer data = ByteBuffer.allocate(100);
+        channel.write(data);
+
+        // Any position change should throw
+        assertThatThrownBy(() -> channel.position(0))
+            .isInstanceOf(UnsupportedOperationException.class)
+            .hasMessageContaining("strict append-only mode")
+            .hasMessageContaining("fallback disabled");
+
+        // Forward seek should also throw
+        assertThatThrownBy(() -> channel.position(200))
+            .isInstanceOf(UnsupportedOperationException.class)
+            .hasMessageContaining("strict append-only mode");
+
+        // Channel should still be in APPEND_ONLY mode (no fallback occurred)
+        assertThat(channel.getMode()).isEqualTo(S3StreamingMultipartUploadChannel.Mode.APPEND_ONLY);
+
+        channel.close();
+    }
+
+    @Test
+    @DisplayName("fallback disabled: position(currentPosition) is still a no-op")
+    void fallbackDisabled_positionAtCurrentIsNoOp() throws Exception {
+        var option = new S3StreamingMultipartUpload(PART_SIZE, 2, false);
+        var channel = new S3StreamingMultipartUploadChannel(mockPath, mockClient, option);
+
+        when(mockClient.uploadPart(any(UploadPartRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(CompletableFuture.completedFuture(
+                UploadPartResponse.builder().eTag("etag-1").build()));
+
+        ByteBuffer data = ByteBuffer.allocate(100);
+        channel.write(data);
+
+        // Setting position to current value should not throw
+        channel.position(100);
+
+        assertThat(channel.getMode()).isEqualTo(S3StreamingMultipartUploadChannel.Mode.APPEND_ONLY);
+        assertThat(channel.position()).isEqualTo(100);
+
+        when(mockClient.completeMultipartUpload(any(CompleteMultipartUploadRequest.class)))
+            .thenReturn(CompletableFuture.completedFuture(
+                CompleteMultipartUploadResponse.builder().build()));
+        channel.close();
+    }
+
+    @Test
+    @DisplayName("fallback disabled: part data is not retained in memory after upload")
+    void fallbackDisabled_partDataNotRetained() throws Exception {
+        var option = new S3StreamingMultipartUpload(PART_SIZE, 2, false);
+        var channel = new S3StreamingMultipartUploadChannel(mockPath, mockClient, option);
+
+        when(mockClient.uploadPart(any(UploadPartRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(CompletableFuture.completedFuture(
+                UploadPartResponse.builder().eTag("etag-1").build()));
+        when(mockClient.completeMultipartUpload(any(CompleteMultipartUploadRequest.class)))
+            .thenReturn(CompletableFuture.completedFuture(
+                CompleteMultipartUploadResponse.builder().build()));
+
+        // Write multiple full parts
+        for (int i = 0; i < 3; i++) {
+            ByteBuffer data = ByteBuffer.allocate(PART_SIZE);
+            channel.write(data);
+        }
+
+        // Use reflection to check partDataHistory is empty
+        var field = S3StreamingMultipartUploadChannel.class.getDeclaredField("partDataHistory");
+        field.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        List<byte[]> history = (List<byte[]>) field.get(channel);
+        assertThat(history).isEmpty();
+
+        channel.close();
+    }
+
+    @Test
+    @DisplayName("fallback disabled: normal append-only write and close works correctly")
+    void fallbackDisabled_normalWriteAndCloseWorks() throws Exception {
+        var option = new S3StreamingMultipartUpload(PART_SIZE, 2, false);
+        var channel = new S3StreamingMultipartUploadChannel(mockPath, mockClient, option);
+
+        when(mockClient.uploadPart(any(UploadPartRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(CompletableFuture.completedFuture(
+                UploadPartResponse.builder().eTag("etag-1").build()));
+        when(mockClient.completeMultipartUpload(any(CompleteMultipartUploadRequest.class)))
+            .thenReturn(CompletableFuture.completedFuture(
+                CompleteMultipartUploadResponse.builder().build()));
+
+        // Write 2.5 parts worth of data
+        for (int i = 0; i < 2; i++) {
+            ByteBuffer data = ByteBuffer.allocate(PART_SIZE);
+            channel.write(data);
+        }
+        ByteBuffer remainder = ByteBuffer.allocate(PART_SIZE / 2);
+        channel.write(remainder);
+
+        channel.close();
+
+        // Verify complete was called (upload succeeded)
+        verify(mockClient).completeMultipartUpload(any(CompleteMultipartUploadRequest.class));
+        assertThat(channel.isOpen()).isFalse();
+    }
+
+    @Test
+    @DisplayName("fallback enabled (default): part data is retained for fallback")
+    void fallbackEnabled_partDataRetained() throws Exception {
+        var option = new S3StreamingMultipartUpload(PART_SIZE, 2, true);
+        var channel = new S3StreamingMultipartUploadChannel(mockPath, mockClient, option);
+
+        when(mockClient.uploadPart(any(UploadPartRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(CompletableFuture.completedFuture(
+                UploadPartResponse.builder().eTag("etag-1").build()));
+        when(mockClient.completeMultipartUpload(any(CompleteMultipartUploadRequest.class)))
+            .thenReturn(CompletableFuture.completedFuture(
+                CompleteMultipartUploadResponse.builder().build()));
+
+        // Write multiple full parts
+        for (int i = 0; i < 3; i++) {
+            ByteBuffer data = ByteBuffer.allocate(PART_SIZE);
+            channel.write(data);
+        }
+
+        // Use reflection to check partDataHistory has entries
+        var field = S3StreamingMultipartUploadChannel.class.getDeclaredField("partDataHistory");
+        field.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        List<byte[]> history = (List<byte[]>) field.get(channel);
+        assertThat(history).hasSize(3);
+
+        channel.close();
+    }
+}

--- a/src/test/java/software/amazon/nio/spi/s3/S3StreamingMultipartUploadPropertyTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3StreamingMultipartUploadPropertyTest.java
@@ -1,0 +1,362 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.nio.spi.s3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.constraints.IntRange;
+import net.jqwik.api.constraints.LongRange;
+import net.jqwik.api.constraints.Size;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.AbortMultipartUploadResponse;
+import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadResponse;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadResponse;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.services.s3.model.UploadPartRequest;
+import software.amazon.awssdk.services.s3.model.UploadPartResponse;
+
+/**
+ * Property-based tests for the streaming multipart upload feature.
+ *
+ * <p>Uses jqwik to verify correctness properties hold across many randomly generated inputs.
+ */
+class S3StreamingMultipartUploadPropertyTest {
+
+    private static final int MIN_PART_SIZE = 5 * 1024 * 1024; // 5 MiB
+
+    private S3AsyncClient createMockClient() {
+        S3AsyncClient mockClient = mock(S3AsyncClient.class);
+        when(mockClient.createMultipartUpload(any(CreateMultipartUploadRequest.class)))
+            .thenReturn(CompletableFuture.completedFuture(
+                CreateMultipartUploadResponse.builder().uploadId("test-upload-id").build()));
+        when(mockClient.abortMultipartUpload(any(AbortMultipartUploadRequest.class)))
+            .thenReturn(CompletableFuture.completedFuture(
+                AbortMultipartUploadResponse.builder().build()));
+        return mockClient;
+    }
+
+    private S3Path createMockPath() {
+        S3Path mockPath = mock(S3Path.class);
+        when(mockPath.bucketName()).thenReturn("test-bucket");
+        when(mockPath.getKey()).thenReturn("test-key");
+        when(mockPath.toUri()).thenReturn(java.net.URI.create("s3://test-bucket/test-key"));
+        return mockPath;
+    }
+
+    // Feature: streaming-multipart-upload, Part size validation accepts only valid range
+    @Property(tries = 100)
+    void partSizeValidation(@ForAll @LongRange(min = -100, max = 6L * 1024 * 1024 * 1024) long partSize) {
+        boolean inRange = partSize >= 5L * 1024 * 1024 && partSize <= 5L * 1024 * 1024 * 1024;
+        if (inRange) {
+            assertDoesNotThrow(() -> S3OpenOption.streamingMultipartUpload(partSize));
+        } else {
+            assertThrows(IllegalArgumentException.class, () -> S3OpenOption.streamingMultipartUpload(partSize));
+        }
+    }
+
+    // Feature: streaming-multipart-upload, Property: Buffering threshold triggers upload at exactly part size
+    @Property(tries = 100)
+    void bufferingThreshold(@ForAll @Size(min = 1, max = 10) List<@IntRange(min = 1, max = MIN_PART_SIZE) Integer> writeSizes) throws IOException {
+        S3AsyncClient mockClient = createMockClient();
+        S3Path mockPath = createMockPath();
+
+        AtomicInteger uploadPartCount = new AtomicInteger(0);
+        when(mockClient.uploadPart(any(UploadPartRequest.class), any(AsyncRequestBody.class)))
+            .thenAnswer(invocation -> {
+                uploadPartCount.incrementAndGet();
+                return CompletableFuture.completedFuture(
+                    UploadPartResponse.builder().eTag("etag-" + uploadPartCount.get()).build());
+            });
+        when(mockClient.completeMultipartUpload(any(CompleteMultipartUploadRequest.class)))
+            .thenReturn(CompletableFuture.completedFuture(
+                CompleteMultipartUploadResponse.builder().build()));
+
+        var option = new S3StreamingMultipartUpload(MIN_PART_SIZE, 4);
+        var channel = new S3StreamingMultipartUploadChannel(mockPath, mockClient, option);
+
+        long totalBytesWritten = 0;
+        for (int size : writeSizes) {
+            ByteBuffer buf = ByteBuffer.allocate(size);
+            channel.write(buf);
+            totalBytesWritten += size;
+        }
+
+        // The number of uploads triggered should be exactly totalBytesWritten / partSize
+        int expectedUploads = (int) (totalBytesWritten / MIN_PART_SIZE);
+        assertThat(uploadPartCount.get()).isEqualTo(expectedUploads);
+
+        channel.close();
+    }
+
+    // Feature: streaming-multipart-upload, Property: Sequential part ordering
+    @Property(tries = 100)
+    void sequentialPartOrdering(@ForAll @IntRange(min = 2, max = 8) int numParts) throws IOException {
+        S3AsyncClient mockClient = createMockClient();
+        S3Path mockPath = createMockPath();
+
+        List<Integer> capturedPartNumbers = new ArrayList<>();
+        when(mockClient.uploadPart(any(UploadPartRequest.class), any(AsyncRequestBody.class)))
+            .thenAnswer(invocation -> {
+                UploadPartRequest req = invocation.getArgument(0);
+                capturedPartNumbers.add(req.partNumber());
+                return CompletableFuture.completedFuture(
+                    UploadPartResponse.builder().eTag("etag-" + req.partNumber()).build());
+            });
+        when(mockClient.completeMultipartUpload(any(CompleteMultipartUploadRequest.class)))
+            .thenReturn(CompletableFuture.completedFuture(
+                CompleteMultipartUploadResponse.builder().build()));
+
+        var option = new S3StreamingMultipartUpload(MIN_PART_SIZE, 4);
+        var channel = new S3StreamingMultipartUploadChannel(mockPath, mockClient, option);
+
+        // Write enough data to produce numParts full parts
+        for (int i = 0; i < numParts; i++) {
+            ByteBuffer buf = ByteBuffer.allocate(MIN_PART_SIZE);
+            channel.write(buf);
+        }
+
+        channel.close();
+
+        // Verify part numbers are sequential 1..N
+        assertThat(capturedPartNumbers).hasSize(numParts);
+        for (int i = 0; i < numParts; i++) {
+            assertThat(capturedPartNumbers.get(i)).isEqualTo(i + 1);
+        }
+    }
+
+    // Feature: streaming-multipart-upload, Property: Close flushes remaining data
+    @Property(tries = 100)
+    void closeFlushesRemaining(@ForAll @IntRange(min = 1, max = MIN_PART_SIZE - 1) int remainder) throws IOException {
+        S3AsyncClient mockClient = createMockClient();
+        S3Path mockPath = createMockPath();
+
+        List<Long> uploadedContentLengths = new ArrayList<>();
+        when(mockClient.uploadPart(any(UploadPartRequest.class), any(AsyncRequestBody.class)))
+            .thenAnswer(invocation -> {
+                UploadPartRequest req = invocation.getArgument(0);
+                uploadedContentLengths.add(req.contentLength());
+                return CompletableFuture.completedFuture(
+                    UploadPartResponse.builder().eTag("etag-" + uploadedContentLengths.size()).build());
+            });
+        when(mockClient.completeMultipartUpload(any(CompleteMultipartUploadRequest.class)))
+            .thenReturn(CompletableFuture.completedFuture(
+                CompleteMultipartUploadResponse.builder().build()));
+
+        var option = new S3StreamingMultipartUpload(MIN_PART_SIZE, 4);
+        var channel = new S3StreamingMultipartUploadChannel(mockPath, mockClient, option);
+
+        // Write one full part + remainder
+        ByteBuffer fullPart = ByteBuffer.allocate(MIN_PART_SIZE);
+        channel.write(fullPart);
+
+        ByteBuffer remainderBuf = ByteBuffer.allocate(remainder);
+        channel.write(remainderBuf);
+
+        channel.close();
+
+        // Should have 2 uploads: one full part and one final part with remainder
+        assertThat(uploadedContentLengths).hasSize(2);
+        assertThat(uploadedContentLengths.get(0)).isEqualTo(MIN_PART_SIZE);
+        assertThat(uploadedContentLengths.get(1)).isEqualTo((long) remainder);
+    }
+
+    // Feature: streaming-multipart-upload, Property: Fallback preserves all written data
+    @Property(tries = 100)
+    void fallbackDataPreservation(@ForAll @Size(min = 1, max = 5) List<@IntRange(min = 1, max = 1024) Integer> writeSizes) throws IOException {
+        S3AsyncClient mockClient = createMockClient();
+        S3Path mockPath = createMockPath();
+
+        when(mockClient.uploadPart(any(UploadPartRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(CompletableFuture.completedFuture(
+                UploadPartResponse.builder().eTag("etag-1").build()));
+        when(mockClient.putObject(any(PutObjectRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(CompletableFuture.completedFuture(PutObjectResponse.builder().build()));
+
+        // Use a small part size so we can trigger uploads with small writes
+        int smallPartSize = MIN_PART_SIZE;
+        var option = new S3StreamingMultipartUpload(smallPartSize, 4, true);
+        var channel = new S3StreamingMultipartUploadChannel(mockPath, mockClient, option);
+
+        // Write data and track what we wrote
+        byte[] allWrittenData = new byte[writeSizes.stream().mapToInt(Integer::intValue).sum()];
+        int offset = 0;
+        for (int size : writeSizes) {
+            byte[] data = new byte[size];
+            for (int i = 0; i < size; i++) {
+                data[i] = (byte) ((offset + i) % 127);
+            }
+            channel.write(ByteBuffer.wrap(data));
+            System.arraycopy(data, 0, allWrittenData, offset, size);
+            offset += size;
+        }
+
+        // Trigger fallback via backward seek
+        channel.position(0);
+
+        // Verify temp file contains all written data
+        var tempFilePath = channel.getTempFile();
+        assertThat(tempFilePath).isNotNull();
+
+        byte[] tempFileContent = Files.readAllBytes(tempFilePath);
+        assertThat(tempFileContent).isEqualTo(allWrittenData);
+
+        channel.close();
+    }
+
+    // Feature: streaming-multipart-upload, Property: Close idempotence
+    @Property(tries = 100)
+    void closeIdempotence(@ForAll @IntRange(min = 2, max = 5) int closeCalls) throws IOException {
+        S3AsyncClient mockClient = createMockClient();
+        S3Path mockPath = createMockPath();
+
+        when(mockClient.uploadPart(any(UploadPartRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(CompletableFuture.completedFuture(
+                UploadPartResponse.builder().eTag("etag-1").build()));
+        when(mockClient.completeMultipartUpload(any(CompleteMultipartUploadRequest.class)))
+            .thenReturn(CompletableFuture.completedFuture(
+                CompleteMultipartUploadResponse.builder().build()));
+
+        var option = new S3StreamingMultipartUpload(MIN_PART_SIZE, 4);
+        var channel = new S3StreamingMultipartUploadChannel(mockPath, mockClient, option);
+
+        // Write enough to trigger at least one upload
+        ByteBuffer data = ByteBuffer.allocate(MIN_PART_SIZE);
+        channel.write(data);
+
+        // Close multiple times
+        for (int i = 0; i < closeCalls; i++) {
+            channel.close();
+        }
+
+        // Verify completeMultipartUpload was called exactly once
+        verify(mockClient, times(1)).completeMultipartUpload(any(CompleteMultipartUploadRequest.class));
+    }
+
+    // Feature: streaming-multipart-upload, Property 7: Position equals total bytes written
+    // **Validates: Requirements 10.1, 10.2**
+    @Property(tries = 100)
+    void positionTracking(@ForAll @Size(min = 1, max = 10) List<@IntRange(min = 1, max = 10000) Integer> writeSizes) throws IOException {
+        S3AsyncClient mockClient = createMockClient();
+        S3Path mockPath = createMockPath();
+
+        when(mockClient.uploadPart(any(UploadPartRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(CompletableFuture.completedFuture(
+                UploadPartResponse.builder().eTag("etag-1").build()));
+
+        var option = new S3StreamingMultipartUpload(MIN_PART_SIZE, 4);
+        var channel = new S3StreamingMultipartUploadChannel(mockPath, mockClient, option);
+
+        long expectedPosition = 0;
+        for (int size : writeSizes) {
+            ByteBuffer buf = ByteBuffer.allocate(size);
+            channel.write(buf);
+            expectedPosition += size;
+            assertThat(channel.position()).isEqualTo(expectedPosition);
+        }
+
+        // Also verify size equals position in append-only mode
+        assertThat(channel.size()).isEqualTo(expectedPosition);
+
+        // Clean up
+        when(mockClient.completeMultipartUpload(any(CompleteMultipartUploadRequest.class)))
+            .thenReturn(CompletableFuture.completedFuture(
+                CompleteMultipartUploadResponse.builder().build()));
+        channel.close();
+    }
+
+    // Feature: streaming-multipart-upload, Property 8: Part limit enforcement
+    // **Validates: Requirements 11.1, 11.3, 11.4**
+    @Property(tries = 100)
+    void partLimitEnforcement(@ForAll @IntRange(min = 10001, max = 10010) int partNumber) throws Exception {
+        S3AsyncClient mockClient = createMockClient();
+        S3Path mockPath = createMockPath();
+
+        when(mockClient.uploadPart(any(UploadPartRequest.class), any(AsyncRequestBody.class)))
+            .thenReturn(CompletableFuture.completedFuture(
+                UploadPartResponse.builder().eTag("etag-1").build()));
+
+        var option = new S3StreamingMultipartUpload(MIN_PART_SIZE, 4);
+        var channel = new S3StreamingMultipartUploadChannel(mockPath, mockClient, option);
+
+        // Write one buffer to initiate the upload session
+        ByteBuffer initBuf = ByteBuffer.allocate(1);
+        channel.write(initBuf);
+
+        // Use reflection to set nextPartNumber to simulate being at the limit
+        Field nextPartNumberField = S3StreamingMultipartUploadChannel.class.getDeclaredField("nextPartNumber");
+        nextPartNumberField.setAccessible(true);
+        nextPartNumberField.setInt(channel, partNumber);
+
+        // Writing a full buffer should trigger uploadCurrentBuffer which checks the limit
+        ByteBuffer fullBuf = ByteBuffer.allocate(MIN_PART_SIZE);
+        assertThatThrownBy(() -> channel.write(fullBuf))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("part limit");
+    }
+
+    // Feature: streaming-multipart-upload, Property 9: Memory bound invariant
+    // **Validates: Requirements 6.4**
+    @Property(tries = 100)
+    void memoryBound(@ForAll @IntRange(min = 1, max = 4) int maxInFlight) throws IOException {
+        S3AsyncClient mockClient = createMockClient();
+        S3Path mockPath = createMockPath();
+
+        // Track the number of concurrently held permits (in-flight uploads)
+        AtomicInteger concurrentUploads = new AtomicInteger(0);
+        AtomicInteger maxConcurrentUploads = new AtomicInteger(0);
+
+        when(mockClient.uploadPart(any(UploadPartRequest.class), any(AsyncRequestBody.class)))
+            .thenAnswer(invocation -> {
+                int current = concurrentUploads.incrementAndGet();
+                maxConcurrentUploads.updateAndGet(max -> Math.max(max, current));
+                // Complete immediately to release the permit
+                concurrentUploads.decrementAndGet();
+                return CompletableFuture.completedFuture(
+                    UploadPartResponse.builder().eTag("etag-1").build());
+            });
+        when(mockClient.completeMultipartUpload(any(CompleteMultipartUploadRequest.class)))
+            .thenReturn(CompletableFuture.completedFuture(
+                CompleteMultipartUploadResponse.builder().build()));
+
+        var option = new S3StreamingMultipartUpload(MIN_PART_SIZE, maxInFlight);
+        var channel = new S3StreamingMultipartUploadChannel(mockPath, mockClient, option);
+
+        // Write enough data to trigger multiple uploads
+        for (int i = 0; i < maxInFlight + 3; i++) {
+            ByteBuffer buf = ByteBuffer.allocate(MIN_PART_SIZE);
+            channel.write(buf);
+        }
+
+        channel.close();
+
+        // The max concurrent uploads should never exceed maxInFlight
+        // (since the semaphore limits permits to maxInFlight)
+        assertThat(maxConcurrentUploads.get()).isLessThanOrEqualTo(maxInFlight);
+    }
+}

--- a/src/test/java/software/amazon/nio/spi/s3/S3StreamingMultipartUploadTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3StreamingMultipartUploadTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.nio.spi.s3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.file.OpenOption;
+import org.junit.jupiter.api.Test;
+
+class S3StreamingMultipartUploadTest {
+
+    @Test
+    void streamingMultipartUpload_defaultFactory_returnsInstanceWithDefaults() {
+        S3OpenOption option = S3OpenOption.streamingMultipartUpload();
+
+        assertThat(option)
+            .isInstanceOf(S3StreamingMultipartUpload.class)
+            .isInstanceOf(OpenOption.class);
+
+        S3StreamingMultipartUpload streaming = (S3StreamingMultipartUpload) option;
+        assertThat(streaming.getPartSize()).isEqualTo(8 * 1024 * 1024L);
+        assertThat(streaming.getMaxInFlight()).isEqualTo(4);
+    }
+
+    @Test
+    void streamingMultipartUpload_customPartSize_returnsInstanceWithCustomSize() {
+        long customPartSize = 16 * 1024 * 1024L; // 16 MiB
+        S3OpenOption option = S3OpenOption.streamingMultipartUpload(customPartSize);
+
+        assertThat(option).isInstanceOf(S3StreamingMultipartUpload.class);
+
+        S3StreamingMultipartUpload streaming = (S3StreamingMultipartUpload) option;
+        assertThat(streaming.getPartSize()).isEqualTo(customPartSize);
+        assertThat(streaming.getMaxInFlight()).isEqualTo(4);
+    }
+
+    @Test
+    void streamingMultipartUpload_minimumPartSize_accepted() {
+        long minPartSize = 5 * 1024 * 1024L; // 5 MiB
+        S3OpenOption option = S3OpenOption.streamingMultipartUpload(minPartSize);
+
+        S3StreamingMultipartUpload streaming = (S3StreamingMultipartUpload) option;
+        assertThat(streaming.getPartSize()).isEqualTo(minPartSize);
+    }
+
+    @Test
+    void streamingMultipartUpload_maximumPartSize_accepted() {
+        long maxPartSize = 5L * 1024 * 1024 * 1024; // 5 GiB
+        S3OpenOption option = S3OpenOption.streamingMultipartUpload(maxPartSize);
+
+        S3StreamingMultipartUpload streaming = (S3StreamingMultipartUpload) option;
+        assertThat(streaming.getPartSize()).isEqualTo(maxPartSize);
+    }
+
+    @Test
+    void streamingMultipartUpload_partSizeBelowMinimum_throwsIllegalArgumentException() {
+        long tooSmall = 5 * 1024 * 1024L - 1; // 5 MiB - 1 byte
+
+        assertThatThrownBy(() -> S3OpenOption.streamingMultipartUpload(tooSmall))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Part size must be at least 5 MiB")
+            .hasMessageContaining(String.valueOf(tooSmall));
+    }
+
+    @Test
+    void streamingMultipartUpload_partSizeAboveMaximum_throwsIllegalArgumentException() {
+        long tooLarge = 5L * 1024 * 1024 * 1024 + 1; // 5 GiB + 1 byte
+
+        assertThatThrownBy(() -> S3OpenOption.streamingMultipartUpload(tooLarge))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Part size must not exceed 5 GiB")
+            .hasMessageContaining(String.valueOf(tooLarge));
+    }
+
+    @Test
+    void streamingMultipartUpload_zeroPartSize_throwsIllegalArgumentException() {
+        assertThatThrownBy(() -> S3OpenOption.streamingMultipartUpload(0))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Part size must be at least 5 MiB");
+    }
+
+    @Test
+    void streamingMultipartUpload_negativePartSize_throwsIllegalArgumentException() {
+        assertThatThrownBy(() -> S3OpenOption.streamingMultipartUpload(-1))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Part size must be at least 5 MiB");
+    }
+
+    @Test
+    void copy_returnsNewInstanceWithSameConfiguration() {
+        S3StreamingMultipartUpload original = new S3StreamingMultipartUpload(
+            16 * 1024 * 1024L, 8);
+
+        S3OpenOption copied = original.copy();
+
+        assertThat(copied)
+            .isInstanceOf(S3StreamingMultipartUpload.class)
+            .isNotSameAs(original);
+
+        S3StreamingMultipartUpload copiedStreaming = (S3StreamingMultipartUpload) copied;
+        assertThat(copiedStreaming.getPartSize()).isEqualTo(original.getPartSize());
+        assertThat(copiedStreaming.getMaxInFlight()).isEqualTo(original.getMaxInFlight());
+    }
+
+    @Test
+    void copy_defaultInstance_returnsNewInstanceWithDefaults() {
+        S3OpenOption original = S3OpenOption.streamingMultipartUpload();
+
+        S3OpenOption copied = ((S3StreamingMultipartUpload) original).copy();
+
+        assertThat(copied).isNotSameAs(original);
+
+        S3StreamingMultipartUpload copiedStreaming = (S3StreamingMultipartUpload) copied;
+        assertThat(copiedStreaming.getPartSize()).isEqualTo(S3StreamingMultipartUpload.DEFAULT_PART_SIZE);
+        assertThat(copiedStreaming.getMaxInFlight()).isEqualTo(S3StreamingMultipartUpload.DEFAULT_MAX_IN_FLIGHT);
+    }
+
+    @Test
+    void constants_haveCorrectValues() {
+        assertThat(S3StreamingMultipartUpload.MIN_PART_SIZE).isEqualTo(5 * 1024 * 1024L);
+        assertThat(S3StreamingMultipartUpload.MAX_PART_SIZE).isEqualTo(5L * 1024 * 1024 * 1024);
+        assertThat(S3StreamingMultipartUpload.DEFAULT_PART_SIZE).isEqualTo(8 * 1024 * 1024L);
+        assertThat(S3StreamingMultipartUpload.MAX_PARTS).isEqualTo(10_000);
+        assertThat(S3StreamingMultipartUpload.DEFAULT_MAX_IN_FLIGHT).isEqualTo(4);
+    }
+}

--- a/src/test/java/software/amazon/nio/spi/s3/config/S3NioSpiConfigurationPropertyTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/config/S3NioSpiConfigurationPropertyTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.nio.spi.s3.config;
+
+import static com.github.stefanbirkner.systemlambda.SystemLambda.restoreSystemProperties;
+import static com.github.stefanbirkner.systemlambda.SystemLambda.withEnvironmentVariable;
+import static org.assertj.core.api.BDDAssertions.then;
+import static software.amazon.nio.spi.s3.config.S3NioSpiConfiguration.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.constraints.LongRange;
+
+/**
+ * Property-based tests for S3NioSpiConfiguration streaming multipart upload configuration.
+ *
+ * Feature: streaming-multipart-upload, Property 10: Configuration-driven streaming option inclusion
+ * **Validates: Requirements 14.1, 14.2, 14.3, 14.4, 14.5, 14.6, 14.7, 14.8, 14.10**
+ */
+public class S3NioSpiConfigurationPropertyTest {
+
+    // Feature: streaming-multipart-upload, Property 10: Configuration-driven streaming option inclusion
+    // **Validates: Requirements 14.1, 14.2, 14.3, 14.4, 14.5, 14.6, 14.7, 14.8, 14.10**
+    @Property(tries = 100)
+    void getOpenOptionsIncludesStreamingIffResolvedValueIsTrue(
+            @ForAll boolean programmaticEnabled,
+            @ForAll @LongRange(min = 5 * 1024 * 1024, max = 5L * 1024 * 1024 * 1024) long programmaticPartSize) {
+
+        // Use programmatic override (highest precedence) to test the resolved value behavior
+        Map<String, String> overrides = new HashMap<>();
+        overrides.put(S3_SPI_WRITE_STREAMING_MULTIPART_UPLOAD_PROPERTY, String.valueOf(programmaticEnabled));
+        overrides.put(S3_SPI_WRITE_MULTIPART_PART_SIZE_PROPERTY, String.valueOf(programmaticPartSize));
+
+        var config = new S3NioSpiConfiguration(overrides);
+
+        var options = config.getOpenOptions();
+        boolean hasStreamingOption = options.stream()
+            .anyMatch(o -> o.getClass().getName().contains("S3StreamingMultipartUpload"));
+
+        // getOpenOptions() includes S3StreamingMultipartUpload iff resolved value is true
+        then(hasStreamingOption).isEqualTo(programmaticEnabled);
+    }
+
+    // Feature: streaming-multipart-upload, Property 10: Configuration-driven streaming option inclusion
+    // Tests override precedence: system property > env var > default
+    // **Validates: Requirements 14.3, 14.4, 14.10**
+    @Property(tries = 100)
+    void systemPropertyOverridesEnvVar(@ForAll boolean sysPropValue) throws Exception {
+        // Env var says the opposite of system property
+        String envVarValue = String.valueOf(!sysPropValue);
+
+        withEnvironmentVariable("S3_SPI_WRITE_STREAMING_MULTIPART_UPLOAD", envVarValue)
+            .execute(() -> {
+                restoreSystemProperties(() -> {
+                    System.setProperty(S3_SPI_WRITE_STREAMING_MULTIPART_UPLOAD_PROPERTY,
+                        String.valueOf(sysPropValue));
+
+                    var config = new S3NioSpiConfiguration();
+                    // System property takes precedence over env var
+                    then(config.isStreamingMultipartUploadEnabled()).isEqualTo(sysPropValue);
+
+                    var options = config.getOpenOptions();
+                    boolean hasStreamingOption = options.stream()
+                        .anyMatch(o -> o.getClass().getName().contains("S3StreamingMultipartUpload"));
+                    then(hasStreamingOption).isEqualTo(sysPropValue);
+                });
+            });
+    }
+
+    // Feature: streaming-multipart-upload, Property 10: Configuration-driven streaming option inclusion
+    // Tests that programmatic override > system property > env var
+    // **Validates: Requirements 14.10**
+    @Property(tries = 100)
+    void programmaticOverridesTakeHighestPrecedence(@ForAll boolean programmaticValue) throws Exception {
+        // Set env var and system property to the opposite
+        String oppositeValue = String.valueOf(!programmaticValue);
+
+        withEnvironmentVariable("S3_SPI_WRITE_STREAMING_MULTIPART_UPLOAD", oppositeValue)
+            .execute(() -> {
+                restoreSystemProperties(() -> {
+                    System.setProperty(S3_SPI_WRITE_STREAMING_MULTIPART_UPLOAD_PROPERTY, oppositeValue);
+
+                    Map<String, String> overrides = new HashMap<>();
+                    overrides.put(S3_SPI_WRITE_STREAMING_MULTIPART_UPLOAD_PROPERTY,
+                        String.valueOf(programmaticValue));
+
+                    var config = new S3NioSpiConfiguration(overrides);
+                    // Programmatic override takes highest precedence
+                    then(config.isStreamingMultipartUploadEnabled()).isEqualTo(programmaticValue);
+
+                    var options = config.getOpenOptions();
+                    boolean hasStreamingOption = options.stream()
+                        .anyMatch(o -> o.getClass().getName().contains("S3StreamingMultipartUpload"));
+                    then(hasStreamingOption).isEqualTo(programmaticValue);
+                });
+            });
+    }
+}

--- a/src/test/java/software/amazon/nio/spi/s3/config/S3NioSpiConfigurationTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/config/S3NioSpiConfigurationTest.java
@@ -401,4 +401,94 @@ public class S3NioSpiConfigurationTest {
             .hasMessageStartingWith("Duplicate key software.amazon.nio.spi.s3.S3PreventConcurrentOverwrite");
     }
 
+    @Test
+    public void streamingMultipartUploadDefaultValues() {
+        then(config.isStreamingMultipartUploadEnabled()).isFalse();
+        then(config.getMultipartPartSize()).isEqualTo(S3_SPI_WRITE_MULTIPART_PART_SIZE_DEFAULT);
+        then(config.getMultipartPartSize()).isEqualTo(8L * 1024 * 1024);
+    }
+
+    @Test
+    public void streamingMultipartUploadEnvVarOverride() throws Exception {
+        withEnvironmentVariable("S3_SPI_WRITE_STREAMING_MULTIPART_UPLOAD", "true")
+            .and("S3_SPI_WRITE_MULTIPART_PART_SIZE", "16777216")
+            .execute(() -> {
+                var c = new S3NioSpiConfiguration();
+                then(c.isStreamingMultipartUploadEnabled()).isTrue();
+                then(c.getMultipartPartSize()).isEqualTo(16777216L);
+            });
+    }
+
+    @Test
+    public void streamingMultipartUploadSystemPropertyOverride() throws Exception {
+        withEnvironmentVariable("S3_SPI_WRITE_STREAMING_MULTIPART_UPLOAD", "false")
+            .execute(() -> {
+                restoreSystemProperties(() -> {
+                    System.setProperty(S3_SPI_WRITE_STREAMING_MULTIPART_UPLOAD_PROPERTY, "true");
+                    System.setProperty(S3_SPI_WRITE_MULTIPART_PART_SIZE_PROPERTY, "10485760");
+                    var c = new S3NioSpiConfiguration();
+                    then(c.isStreamingMultipartUploadEnabled()).isTrue();
+                    then(c.getMultipartPartSize()).isEqualTo(10485760L);
+                });
+            });
+    }
+
+    @Test
+    public void streamingMultipartUploadProgrammaticOverride() {
+        Map<String, String> overridesMap = new HashMap<>();
+        overridesMap.put(S3_SPI_WRITE_STREAMING_MULTIPART_UPLOAD_PROPERTY, "true");
+        overridesMap.put(S3_SPI_WRITE_MULTIPART_PART_SIZE_PROPERTY, "20971520");
+        var c = new S3NioSpiConfiguration(overridesMap);
+        then(c.isStreamingMultipartUploadEnabled()).isTrue();
+        then(c.getMultipartPartSize()).isEqualTo(20971520L);
+    }
+
+    @Test
+    public void getOpenOptionsIncludesStreamingWhenEnabled() {
+        config.withStreamingMultipartUpload(true);
+        var options = config.getOpenOptions();
+        then(options).anyMatch(o -> o.getClass().getName().contains("S3StreamingMultipartUpload"));
+    }
+
+    @Test
+    public void getOpenOptionsExcludesStreamingWhenDisabled() {
+        config.withStreamingMultipartUpload(false);
+        var options = config.getOpenOptions();
+        then(options).noneMatch(o -> o.getClass().getName().contains("S3StreamingMultipartUpload"));
+    }
+
+    @Test
+    public void invalidPartSizeLogsWarningAndUsesDefault() {
+        config.put(S3_SPI_WRITE_MULTIPART_PART_SIZE_PROPERTY, "not-a-number");
+        then(config.getMultipartPartSize()).isEqualTo(S3_SPI_WRITE_MULTIPART_PART_SIZE_DEFAULT);
+    }
+
+    @Test
+    public void withStreamingMultipartUploadFluentSetter() {
+        then(config.withStreamingMultipartUpload(true)).isSameAs(config);
+        then(config.isStreamingMultipartUploadEnabled()).isTrue();
+        then(config.withStreamingMultipartUpload(false)).isSameAs(config);
+        then(config.isStreamingMultipartUploadEnabled()).isFalse();
+    }
+
+    @Test
+    public void withMultipartPartSizeFluentSetter() {
+        long validSize = 10 * 1024 * 1024L; // 10 MiB
+        then(config.withMultipartPartSize(validSize)).isSameAs(config);
+        then(config.getMultipartPartSize()).isEqualTo(validSize);
+    }
+
+    @Test
+    public void withMultipartPartSizeValidation() {
+        long tooSmall = 4 * 1024 * 1024L; // 4 MiB (below 5 MiB minimum)
+        assertThatCode(() -> config.withMultipartPartSize(tooSmall))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("partSize must be at least 5 MiB");
+
+        long tooLarge = 6L * 1024 * 1024 * 1024; // 6 GiB (above 5 GiB maximum)
+        assertThatCode(() -> config.withMultipartPartSize(tooLarge))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("partSize must not exceed 5 GiB");
+    }
+
 }


### PR DESCRIPTION

- Add S3StreamingMultipartUpload open option to enable streaming uploads
- Implement S3StreamingMultipartUploadChannel for incremental part uploads
- Add PartBuffer utility for managing part accumulation and flushing
- Implement append-only mode for sequential writes with async part uploads
- Implement random-access fallback mode for backward seeks
- Add comprehensive integration and unit tests for streaming upload scenarios
- Add property-based tests for multipart upload edge cases
- Update S3SeekableByteChannel to support streaming multipart upload option
- Update S3FileChannel and AsyncS3FileChannel to integrate streaming support
- Add S3NioSpiConfiguration properties for streaming upload defaults
- Add StreamingMultipartUploadDemo example showing usage patterns
- Update .gitignore to exclude jqwik property-based testing database
- Update project documentation and Kiro specifications for feature
- Reduces memory/disk pressure for large file uploads by streaming parts to S3 incrementally
- Provides fallback to existing temp-file approach when random access is detected


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
