### PR TITLE
fix(S3ReadAheadByteChannel): fill destination buffer across fragments

### DIFF
--- a/src/main/java/software/amazon/nio/spi/s3/S3ReadAheadByteChannel.java
+++ b/src/main/java/software/amazon/nio/spi/s3/S3ReadAheadByteChannel.java
@@ -103,53 +103,24 @@ class S3ReadAheadByteChannel implements ReadableByteChannel {
             return -1;
         }
 
-        //figure out the index of the fragment the bytes would start in
-        var fragmentIndex = fragmentIndexForByteNumber(channelPosition);
-        logger.debug("fragment index: {}", fragmentIndex);
-
-        var fragmentOffset = (int) (channelPosition - (fragmentIndex.longValue() * maxFragmentSize));
-        logger.debug("fragment {} offset: {}", fragmentIndex, fragmentOffset);
-
         try {
-            final var fragment = Objects.requireNonNull(readAheadBuffersCache.get(fragmentIndex, this::computeFragmentFuture))
-                .get(timeout, timeUnit)
-                .asReadOnlyBuffer();
+            var totalBytesRead = 0;
 
-            fragment.position(fragmentOffset);
-            logger.debug("fragment remaining: {}", fragment.remaining());
-            logger.debug("dst remaining: {}", dst.remaining());
-
-            //put the bytes from fragment from the offset upto the min of fragment remaining or dst remaining
-            var limit = Math.min(fragment.remaining(), dst.remaining());
-            logger.debug("byte limit: {}", limit);
-
-            var copiedBytes = new byte[limit];
-            fragment.get(copiedBytes, 0, limit);
-            dst.put(copiedBytes);
-
-            if (fragment.position() >= fragment.limit() / 2) {
-
-                // clear any fragments in cache that are lower index than this one
-                clearPriorFragments(fragmentIndex);
-
-                // until available cache slots are filled or number of fragments in file
-                var maxFragmentsToLoad = Math.min(maxNumberFragments - 1, numFragmentsInObject - fragmentIndex - 1);
-
-                for (var i = 0; i < maxFragmentsToLoad; i++) {
-                    final var idxToLoad = i + fragmentIndex + 1;
-
-                    //  add the index if it's not already there
-                    if (readAheadBuffersCache.asMap().containsKey(idxToLoad)) {
-                        continue;
-                    }
-
-                    logger.debug("initiate pre-loading fragment with index '{}' from '{}'", idxToLoad, path.toUri());
-                    readAheadBuffersCache.put(idxToLoad, computeFragmentFuture(idxToLoad));
-                }
+            // Fill the destination buffer even when the requested range spans more than one
+            // read-ahead fragment. A single fragment can only serve bytes up to its own boundary,
+            // so without this loop read() would return a short read at every fragment boundary.
+            // Although short reads are permitted by the ReadableByteChannel contract, some callers
+            // (e.g. htsjdk's IndexedFastaSequenceFile) issue a single read() and assume the buffer
+            // is filled the way a local FileChannel would. A short read shifts their parsing and
+            // can, for example, leak a line-terminator byte into the returned data.
+            while (dst.hasRemaining() && channelPosition < size) {
+                var bytesRead = readSingleFragment(dst, channelPosition);
+                channelPosition += bytesRead;
+                totalBytesRead += bytesRead;
             }
 
-            delegator.position(channelPosition + copiedBytes.length);
-            return copiedBytes.length;
+            delegator.position(channelPosition);
+            return totalBytesRead;
 
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
@@ -165,6 +136,67 @@ class S3ReadAheadByteChannel implements ReadableByteChannel {
             throw TimeOutUtils.logAndGenerateExceptionOnTimeOut(logger, "read",
                 TimeOutUtils.TIMEOUT_TIME_LENGTH_5, TimeUnit.MINUTES);
         }
+    }
+
+    /**
+     * Copies bytes from the single read-ahead fragment that contains {@code channelPosition} into
+     * {@code dst}, up to the minimum of the bytes remaining in that fragment and the space remaining
+     * in {@code dst}. Also triggers read-ahead pre-loading of subsequent fragments once more than
+     * half of the current fragment has been consumed.
+     *
+     * @param dst             the destination buffer to copy bytes into.
+     * @param channelPosition the absolute position in the object to start reading from.
+     * @return the number of bytes copied. Always {@code >= 1} when {@code channelPosition < size}
+     *     and {@code dst} has remaining capacity, guaranteeing the calling loop makes progress.
+     */
+    private int readSingleFragment(ByteBuffer dst, long channelPosition)
+            throws InterruptedException, ExecutionException, TimeoutException {
+
+        //figure out the index of the fragment the bytes would start in
+        var fragmentIndex = fragmentIndexForByteNumber(channelPosition);
+        logger.debug("fragment index: {}", fragmentIndex);
+
+        var fragmentOffset = (int) (channelPosition - (fragmentIndex.longValue() * maxFragmentSize));
+        logger.debug("fragment {} offset: {}", fragmentIndex, fragmentOffset);
+
+        final var fragment = Objects.requireNonNull(readAheadBuffersCache.get(fragmentIndex, this::computeFragmentFuture))
+            .get(timeout, timeUnit)
+            .asReadOnlyBuffer();
+
+        fragment.position(fragmentOffset);
+        logger.debug("fragment remaining: {}", fragment.remaining());
+        logger.debug("dst remaining: {}", dst.remaining());
+
+        //put the bytes from fragment from the offset upto the min of fragment remaining or dst remaining
+        var limit = Math.min(fragment.remaining(), dst.remaining());
+        logger.debug("byte limit: {}", limit);
+
+        var copiedBytes = new byte[limit];
+        fragment.get(copiedBytes, 0, limit);
+        dst.put(copiedBytes);
+
+        if (fragment.position() >= fragment.limit() / 2) {
+
+            // clear any fragments in cache that are lower index than this one
+            clearPriorFragments(fragmentIndex);
+
+            // until available cache slots are filled or number of fragments in file
+            var maxFragmentsToLoad = Math.min(maxNumberFragments - 1, numFragmentsInObject - fragmentIndex - 1);
+
+            for (var i = 0; i < maxFragmentsToLoad; i++) {
+                final var idxToLoad = i + fragmentIndex + 1;
+
+                //  add the index if it's not already there
+                if (readAheadBuffersCache.asMap().containsKey(idxToLoad)) {
+                    continue;
+                }
+
+                logger.debug("initiate pre-loading fragment with index '{}' from '{}'", idxToLoad, path.toUri());
+                readAheadBuffersCache.put(idxToLoad, computeFragmentFuture(idxToLoad));
+            }
+        }
+
+        return copiedBytes.length;
     }
 
     @Override

--- a/src/test/java/software/amazon/nio/spi/s3/S3ReadAheadByteChannelFragmentBoundaryTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3ReadAheadByteChannelFragmentBoundaryTest.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.nio.spi.s3;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.lenient;
+import static software.amazon.nio.spi.s3.S3Matchers.anyConsumer;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.internal.async.ByteArrayAsyncResponseTransformer;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+
+/**
+ * Regression tests for <a href="https://github.com/awslabs/aws-java-nio-spi-for-s3/issues/761">#761</a>.
+ *
+ * <p>Reads that span more than one read-ahead fragment must fill the destination buffer instead of
+ * returning a short read at the fragment boundary. Callers such as htsjdk's
+ * {@code IndexedFastaSequenceFile} issue a single {@code channel.read(buffer)} and assume the buffer
+ * is filled the way a local {@code FileChannel} would be; a short read shifts their parsing and can
+ * leak a line-terminator byte (10, {@code '\n'}) into the returned bases.
+ */
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("unchecked")
+public class S3ReadAheadByteChannelFragmentBoundaryTest {
+
+    final S3FileSystemProvider provider = new S3FileSystemProvider();
+
+    S3Path path;
+
+    @Mock
+    S3SeekableByteChannel delegator;
+
+    @Mock
+    S3AsyncClient client;
+
+    byte[] backing;
+    final long[] positionHolder = {0L};
+
+    private void initChannel(byte[] data, int fragmentSize, int maxFragments) throws IOException {
+        this.backing = data;
+        path = S3Path.getPath((S3FileSystem) provider.getFileSystem(URI.create("s3://my-bucket")), "/object");
+
+        lenient().when(delegator.size()).thenReturn((long) backing.length);
+        lenient().when(delegator.position()).thenAnswer(i -> positionHolder[0]);
+        lenient().when(delegator.position(anyLong())).thenAnswer(i -> {
+            positionHolder[0] = i.getArgument(0);
+            return delegator;
+        });
+
+        // Return exactly the requested byte range, honouring the Range header like real S3.
+        lenient().when(client.getObject(anyConsumer(), any(ByteArrayAsyncResponseTransformer.class)))
+            .thenAnswer(invocation -> {
+                Consumer<GetObjectRequest.Builder> consumer = invocation.getArgument(0);
+                var builder = GetObjectRequest.builder();
+                consumer.accept(builder);
+                var spec = builder.build().range().substring("bytes=".length());
+                var parts = spec.split("-");
+                int from = Integer.parseInt(parts[0]);
+                int to = Integer.parseInt(parts[1]);
+                int len = to - from + 1;
+                var slice = new byte[len];
+                System.arraycopy(backing, from, slice, 0, len);
+                return CompletableFuture.completedFuture(
+                    ResponseBytes.fromByteArray(GetObjectResponse.builder().build(), slice));
+            });
+
+        // Use the construction path with explicit fragment sizing.
+        this.readAheadByteChannel =
+            new S3ReadAheadByteChannel(path, fragmentSize, maxFragments, client, delegator, null, null);
+    }
+
+    S3ReadAheadByteChannel readAheadByteChannel;
+
+    @BeforeEach
+    public void resetPosition() {
+        positionHolder[0] = 0L;
+    }
+
+    @Test
+    public void singleReadFillsBufferAcrossFragmentBoundary() throws IOException {
+        var data = new byte[100];
+        for (int i = 0; i < data.length; i++) {
+            data[i] = (byte) ('A' + (i % 26));
+        }
+        initChannel(data, 10, 50); // 10-byte fragments
+
+        positionHolder[0] = 5L;            // start inside fragment 0 (bytes 0..9)
+        var dst = ByteBuffer.allocate(20); // spans fragments 0, 1 and into 2
+
+        int n = readAheadByteChannel.read(dst);
+
+        assertEquals(20, n, "read() must fill the buffer across fragment boundaries");
+        var expected = new byte[20];
+        System.arraycopy(data, 5, expected, 0, 20);
+        assertArrayEquals(expected, dst.array());
+    }
+
+    @Test
+    public void readStopsAtEndOfObjectNotJustFragment() throws IOException {
+        var data = new byte[25];
+        for (int i = 0; i < data.length; i++) {
+            data[i] = (byte) i;
+        }
+        initChannel(data, 10, 50); // fragments: [0..9][10..19][20..24]
+
+        positionHolder[0] = 8L;
+        var dst = ByteBuffer.allocate(1000); // ask for far more than remains
+
+        int n = readAheadByteChannel.read(dst);
+
+        // Should return all remaining bytes (8..24 = 17 bytes), spanning all three fragments.
+        assertEquals(17, n);
+        var expected = new byte[17];
+        System.arraycopy(data, 8, expected, 0, 17);
+        var got = new byte[17];
+        dst.flip();
+        dst.get(got);
+        assertArrayEquals(expected, got);
+
+        // A subsequent read at EOF returns -1.
+        positionHolder[0] = 25L;
+        assertEquals(-1, readAheadByteChannel.read(ByteBuffer.allocate(8)));
+    }
+
+    /**
+     * Faithful port of htsjdk's {@code IndexedFastaSequenceFile} access pattern: it seeks to an
+     * absolute position, issues a single {@code read(buffer)}, then walks the buffer skipping
+     * line terminators at fixed intervals. This reproduces the original bug: before the fix, a
+     * read straddling a fragment boundary returned short, the walker misaligned, and a {@code '\n'}
+     * leaked into the bases. The reference sequence is verified byte-for-byte.
+     */
+    @Test
+    public void htsjdkStyleNewlineWalkerAcrossFragmentBoundary() throws IOException {
+        final int basesPerLine = 6;
+        final int bytesPerLine = basesPerLine + 1; // + '\n'
+        final int numLines = 40;
+
+        // Build a FASTA-body-like buffer: lines of bases terminated by '\n'.
+        var body = new StringBuilder();
+        final byte[] alphabet = "ACGT".getBytes();
+        int baseCounter = 0;
+        for (int line = 0; line < numLines; line++) {
+            for (int b = 0; b < basesPerLine; b++) {
+                body.append((char) alphabet[baseCounter % alphabet.length]);
+                baseCounter++;
+            }
+            body.append('\n');
+        }
+        var data = body.toString().getBytes();
+
+        // Choose a fragment size that is NOT a multiple of bytesPerLine so reads straddle
+        // boundaries at varied offsets relative to the line structure.
+        initChannel(data, 13, 50);
+
+        final int totalBases = numLines * basesPerLine;
+
+        // The expected contiguous base sequence (no terminators).
+        var expectedBases = new byte[totalBases];
+        for (int i = 0; i < totalBases; i++) {
+            expectedBases[i] = alphabet[i % alphabet.length];
+        }
+
+        // Query many sub-ranges, including ones that start/stop at varied positions, to force reads
+        // that straddle fragment boundaries.
+        for (int start = 0; start < totalBases; start += 1) {
+            int stop = Math.min(totalBases, start + 17);
+            var got = readBasesHtsjdkStyle(start, stop, basesPerLine, bytesPerLine);
+            var expected = new byte[stop - start];
+            System.arraycopy(expectedBases, start, expected, 0, stop - start);
+            assertArrayEquals(expected, got, "base mismatch for [" + start + "," + stop + ")");
+        }
+    }
+
+    /**
+     * Minimal re-implementation of htsjdk's subsequence read loop against our channel.
+     *
+     * @param start 0-based inclusive start base index
+     * @param stop  0-based exclusive stop base index
+     */
+    private byte[] readBasesHtsjdkStyle(int start, int stop, int basesPerLine, int bytesPerLine)
+            throws IOException {
+        final int terminatorLength = bytesPerLine - basesPerLine;
+        final int length = stop - start;
+        final byte[] target = new byte[length];
+        final ByteBuffer targetBuffer = ByteBuffer.wrap(target);
+
+        long startOffset = ((long) (start) / basesPerLine) * bytesPerLine + (start) % basesPerLine;
+        final ByteBuffer channelBuffer = ByteBuffer.allocate(Math.max(bytesPerLine * 2, 16));
+
+        while (targetBuffer.position() < length) {
+            startOffset += Math.max((int) (startOffset % bytesPerLine - basesPerLine + 1), 0);
+
+            startOffset += readFromPosition(channelBuffer, startOffset);
+            channelBuffer.flip();
+
+            final int positionInContig = start + targetBuffer.position();
+            final int nextBaseSpan =
+                Math.min(basesPerLine - positionInContig % basesPerLine, length - targetBuffer.position());
+            int bytesToTransfer = Math.min(nextBaseSpan, channelBuffer.capacity());
+            channelBuffer.limit(channelBuffer.position() + bytesToTransfer);
+
+            while (channelBuffer.hasRemaining()) {
+                targetBuffer.put(channelBuffer);
+                bytesToTransfer = Math.min(basesPerLine, length - targetBuffer.position());
+                channelBuffer.limit(Math.min(
+                    channelBuffer.position() + bytesToTransfer + terminatorLength, channelBuffer.capacity()));
+                channelBuffer.position(Math.min(channelBuffer.position() + terminatorLength, channelBuffer.capacity()));
+            }
+            channelBuffer.flip();
+        }
+        return target;
+    }
+
+    /** Mirrors htsjdk's non-FileChannel readFromPosition: save position, seek, read, restore. */
+    private int readFromPosition(ByteBuffer buffer, long position) throws IOException {
+        long oldPos = positionHolder[0];
+        try {
+            positionHolder[0] = position;
+            return readAheadByteChannel.read(buffer);
+        } finally {
+            positionHolder[0] = oldPos;
+        }
+    }
+}

--- a/src/test/java/software/amazon/nio/spi/s3/S3ReadAheadByteChannelTest.java
+++ b/src/test/java/software/amazon/nio/spi/s3/S3ReadAheadByteChannelTest.java
@@ -75,11 +75,16 @@ public class S3ReadAheadByteChannelTest {
         when(delegator.position()).thenReturn(0L);
         var dst = ByteBuffer.allocate(30);
         final var numBytesRead = readAheadByteChannel.read(dst);
-        assertEquals(26, numBytesRead);
+        // The destination buffer (capacity 30) spans the 26-byte fragment 0 and the start of
+        // fragment 1, so read() now fills the whole buffer rather than stopping at the boundary.
+        assertEquals(30, numBytesRead);
         // this should have triggered loading of the next fragment to the cache
         assertEquals(2, readAheadByteChannel.numberOfCachedFragments());
         assertEquals('a', dst.get(0));
         assertEquals('z', dst.get(25));
+        // bytes 26-29 are served from the next fragment
+        assertEquals('A', dst.get(26));
+        assertEquals('D', dst.get(29));
     }
 
     @Test
@@ -96,11 +101,16 @@ public class S3ReadAheadByteChannelTest {
         when(delegator.position()).thenReturn(1L);
         var dst = ByteBuffer.allocate(30);
         final var numBytesRead = readAheadByteChannel.read(dst);
-        assertEquals(25, numBytesRead);
+        // Starting at position 1, fragment 0 supplies 25 bytes (b..z); the buffer has room for 5
+        // more, which are filled from the next fragment instead of returning a short read.
+        assertEquals(30, numBytesRead);
         //should have triggered loading of the next fragment to the cache
         assertEquals(2, readAheadByteChannel.numberOfCachedFragments());
         assertEquals('b', dst.get(0));
         assertEquals('z', dst.get(24));
+        // bytes 25-29 are served from the next fragment
+        assertEquals('A', dst.get(25));
+        assertEquals('E', dst.get(29));
     }
 
     @Test


### PR DESCRIPTION
*Issue #, if available:*
#761 

*Description of changes:*

- Extract single-fragment read logic into dedicated readSingleFragment() method
- Implement loop in read() to fill destination buffer even when spanning multiple fragments
- Add comprehensive JavaDoc explaining the fragment boundary handling and short read prevention
- Add new S3ReadAheadByteChannelFragmentBoundaryTest to verify buffer filling across boundaries
- Update existing S3ReadAheadByteChannelTest with additional edge case coverage
- Fixes issue where short reads at fragment boundaries could corrupt parsing in callers expecting full buffer fills (e.g., htsjdk's IndexedFastaSequenceFile)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
