### PR TITLE
Release version 2.5.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,9 @@ target
 # MacOS
 .DS_Store
 
-# directory used for API break checks
-/.palantir/
+# API break checks (revapi): ignore transient files but track accepted breaks
+/.palantir/*
+!/.palantir/revapi.yml
 
 # sdkman files
 .sdkmanrc

--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -1,0 +1,8 @@
+acceptedBreaks:
+  "2.4.0":
+    software.amazon.nio.s3:aws-java-nio-spi-for-s3:
+    - code: "java.field.constantValueChanged"
+      old: "field software.amazon.nio.spi.s3.config.S3NioSpiConfiguration.AWS_ACCESS_KEY_PROPERTY"
+      new: "field software.amazon.nio.spi.s3.config.S3NioSpiConfiguration.AWS_ACCESS_KEY_PROPERTY"
+      justification: "Corrected constant to match AWS SDK system property aws.accessKeyId\
+        \ (#746); released in 2.5.0"

--- a/README.md
+++ b/README.md
@@ -69,13 +69,13 @@ For example:
 <dependency>
     <groupId>software.amazon.nio.s3</groupId>
     <artifactId>aws-java-nio-spi-for-s3</artifactId>
-    <version>2.4.0</version>
+    <version>2.5.0</version>
 </dependency>
 ```
 
 `build.gradle(.kts)`
 ```groovy
-    implementation("software.amazon.nio.s3:aws-java-nio-spi-for-s3:2.4.0")
+    implementation("software.amazon.nio.s3:aws-java-nio-spi-for-s3:2.5.0")
 ```
 
 > [!TIP]
@@ -83,7 +83,7 @@ For example:
 > you can use `runtimeOnly` instead of `implementation`. This allows the S3 provider to be discovered 
 > automatically via Java's ServiceLoader mechanism:
 > ```groovy
-> runtimeOnly("software.amazon.nio.s3:aws-java-nio-spi-for-s3:2.4.0")
+> runtimeOnly("software.amazon.nio.s3:aws-java-nio-spi-for-s3:2.5.0")
 > ```
 > This approach is cleaner as it keeps the S3 provider as a pure runtime dependency that's loaded dynamically.
 >
@@ -102,7 +102,7 @@ and wide range of supported platforms.
 > If **size** is an **issue**, you can **exclude** the `crt` dependency from the library and import the [specific `crt` library](https://github.com/awslabs/aws-crt-java?tab=readme-ov-file#platform-specific-jars)
 > for your platform. For example:
 > ```
-> implementation("software.amazon.nio.s3:aws-java-nio-spi-for-s3:2.4.0") {
+> implementation("software.amazon.nio.s3:aws-java-nio-spi-for-s3:2.5.0") {
 >	exclude group: 'software.amazon.awssdk.crt', module: 'aws-crt'
 > }
 > implementation 'software.amazon.awssdk.crt:aws-crt:0.31.1:linux-x86_64'

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ group = 'software.amazon.nio.s3'
 base {
     archivesName = 'nio-spi-for-s3'
 }
-version = '2.4.0'
+version = '2.5.0'
 
 java {
     withSourcesJar()


### PR DESCRIPTION
## Summary
Release 2.5.0 of aws-java-nio-spi-for-s3 (already published to Maven Central).

Minor version bump (rather than patch) because revapi reports a semantic API break: the public constant `S3NioSpiConfiguration.AWS_ACCESS_KEY_PROPERTY` value was corrected from `aws.accessKey` to `aws.accessKeyId` in #746 to match the AWS SDK system property name.

## Changes
- Bump version `2.4.0` -> `2.5.0` in `build.gradle`
- Update version references in `README.md`
- Accept the revapi break for `AWS_ACCESS_KEY_PROPERTY` and track it in `.palantir/revapi.yml` (un-ignored so the acceptance persists for CI)

## Testing
- `./gradlew build` passes (unit tests + revapi)
- `./gradlew build signMavenPublication publishMavenPublicationToMavenRepository` produced signed artifacts in `build/staging-deploy`
- Deployed to Maven Central via `jreleaserDeploy`

## Notes
- The `v2.5.0` tag will be created on `main` after this PR is merged.